### PR TITLE
Fix DB migration script errors found whilst starting from an empty DB

### DIFF
--- a/server/src/main/resources/db/migration/V1_167__add_more_standard_tasks.sql
+++ b/server/src/main/resources/db/migration/V1_167__add_more_standard_tasks.sql
@@ -53,7 +53,7 @@ values ('Residence Attestation','UploadTask',
 insert into task (name, task_type, description, days_to_complete, upload_subfolder_name,
                   upload_type, uploadable_file_types,
                   created_by, created_date)
-values ('Residence Attestation','UploadTask', 'Translation of original document',
+values ('Residence Attestation Translation','UploadTask', 'Translation of original document',
         14, 'Address', 'residenceAttestTrans', null,
         (select id from users where username = 'SystemAdmin'), now());
 

--- a/server/src/main/resources/db/migration/V1_209__add_partners_abbreviations.sql
+++ b/server/src/main/resources/db/migration/V1_209__add_partners_abbreviations.sql
@@ -14,10 +14,10 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-update partner set abbreviation = 'IOM' where 'name' = 'IOM';
-update partner set abbreviation = 'HIAS' where 'name' = 'HIAS';
-update partner set abbreviation = 'UNHCR' where 'name' = 'UNHCR';
-update partner set abbreviation = 'RP' where 'name' = 'Refuge Point';
-update partner set abbreviation = 'Dignity' where 'name' = 'Dignity for Children';
-update partner set abbreviation = 'CRS' where 'name' = 'Catholic Relief Services';
-update partner set abbreviation = 'TBB' where 'name' = 'Talent Beyond Boundaries';
+update partner set abbreviation = 'IOM' where name = 'IOM';
+update partner set abbreviation = 'HIAS' where name = 'HIAS';
+update partner set abbreviation = 'UNHCR' where name = 'UNHCR';
+update partner set abbreviation = 'RP' where name = 'Refuge Point';
+update partner set abbreviation = 'Dignity' where name = 'Dignity for Children';
+update partner set abbreviation = 'CRS' where name = 'Catholic Relief Services';
+update partner set abbreviation = 'TBB' where name = 'Talent Beyond Boundaries';

--- a/server/src/main/resources/db/migration/V1__init.sql
+++ b/server/src/main/resources/db/migration/V1__init.sql
@@ -201,3 +201,7 @@ comment                 text,
 created_by              bigint references users,
 created_date            timestamptz
 );
+
+-- Create the default system admin user which is required by later migration scripts
+-- Both the id (1) and username (SystemAdmin) are referenced
+insert into users (id, username, first_name, last_name, email, role, status) values (1, 'SystemAdmin', 'System', 'Admin', 'systemadmin@example.com', 'systemadmin', 'active');


### PR DESCRIPTION
These changes address some errors I encountered when trying to start the app with an empty database.