### PR TITLE
Server no longer includes regoReferrerParam in a search request if populated by empty string or null

### DIFF
--- a/server/src/main/java/org/tbbtalent/server/repository/db/CandidateSpecification.java
+++ b/server/src/main/java/org/tbbtalent/server/repository/db/CandidateSpecification.java
@@ -286,7 +286,7 @@ public class CandidateSpecification {
             }
 
             // REFERRER
-            if (request.getRegoReferrerParam() != null) {
+            if (request.getRegoReferrerParam() != null && !request.getRegoReferrerParam().equals("")) {
                 conjunction.getExpressions().add(
                         builder.equal(candidate.get("regoReferrerParam"), request.getRegoReferrerParam())
                 );


### PR DESCRIPTION
Server no longer includes regoReferrerParam in a search request if populated by empty string or null.