### PR TITLE
35 we need more flexible mapping of salesforce json api responses to map to java objects

### DIFF
--- a/server/src/main/java/org/tbbtalent/server/api/admin/SystemAdminApi.java
+++ b/server/src/main/java/org/tbbtalent/server/api/admin/SystemAdminApi.java
@@ -554,7 +554,7 @@ public class SystemAdminApi {
         log.info("Updating " + contacts.size() + " candidates");
         int count = 0;
         for (Contact contact : contacts) {
-            final String candidateNumber = contact.getTBBid__c().toString();
+            final String candidateNumber = contact.getTbbId().toString();
             Candidate candidate = candidateRepository.findByCandidateNumber(candidateNumber);
             if (candidate == null) {
                 log.warn("No candidate found for TBBid " + candidateNumber
@@ -581,7 +581,7 @@ public class SystemAdminApi {
         int count = 0;
         for (Contact contact : contacts) {
 
-            final Long sfTbbId = contact.getTBBid__c();
+            final Long sfTbbId = contact.getTbbId();
             if (sfTbbId == null) {
                 log.warn("Contact is not a TBB candidate: " + contact.getUrl());
             } else {

--- a/server/src/main/java/org/tbbtalent/server/model/sf/Contact.java
+++ b/server/src/main/java/org/tbbtalent/server/model/sf/Contact.java
@@ -16,6 +16,7 @@
 
 package org.tbbtalent.server.model.sf;
 
+import com.fasterxml.jackson.annotation.JsonSetter;
 import org.tbbtalent.server.model.db.Candidate;
 
 import lombok.Getter;
@@ -36,14 +37,18 @@ import lombok.ToString;
 @Setter
 @ToString
 public class Contact extends SalesforceObjectBase {
-    public String AccountId;
-    public Long TBBid__c;
+
+    @JsonSetter("AccountId")
+    private String accountId;
+
+    @JsonSetter("TBBid__c")
+    private Long tbbId;
 
     public Contact() {
     }
 
     public Contact(Candidate candidate) {
-        TBBid__c = Long.valueOf(candidate.getCandidateNumber());
+        tbbId = Long.valueOf(candidate.getCandidateNumber());
     }
 
     @Override

--- a/server/src/main/java/org/tbbtalent/server/model/sf/Opportunity.java
+++ b/server/src/main/java/org/tbbtalent/server/model/sf/Opportunity.java
@@ -16,6 +16,7 @@
 
 package org.tbbtalent.server.model.sf;
 
+import com.fasterxml.jackson.annotation.JsonSetter;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
@@ -26,18 +27,15 @@ import lombok.ToString;
  * This is created from incoming JSON in the body of the response to a HTTP GET request for
  * opportunity details.
  * The problem with Salesforce fields is that they all start with upper case - so "Name" rather
- * that "name". This doesn't map well to Java bean objects where field values by convention start
+ * than "name". This doesn't map well to Java bean objects where field values by convention start
  * with lower case.
  * <p/>
  * If you just code this as a standard Java Bean with private fields accessed by standard
  * getter and setters, the Salesforce JSON won't map to corresponding fields in the Java object
  * because "Name" does not map to "name".
  * <p/>
- * The (crappy) way around it is to make all the fields public and capitalized. Then the JSON
- * will map to the fields.
- * <p/>
- * NOTE: You can request fields using their names starting with lower case, but they are always
- * returned in the response with their standard upper case names.
+ * Therefore, the Java properties are each annotated with the @JsonSetter annotation which provides
+ * a convenient mapping from the SalesForce field names to standard Java field names.
  * <p/>
  * NOTE: The getters (added here automatically by Lombok) mean that utilities that process this
  * object as a normal bean, will see a normal (lower case) "name" attribute on the bean because
@@ -50,24 +48,59 @@ import lombok.ToString;
 @Setter
 @ToString(callSuper = true)
 public class Opportunity extends SalesforceObjectBase {
-    public String Name;
-    public String AccountId;
-    public String AccountCountry__c;
-    public String AccountName__c;
-    public String Candidate_TC_id__c;
-    public String Closing_Comments__c;
-    public String Employer_Feedback__c;
-    public boolean IsClosed;
-    public String NextStep;
-    public String Next_Step_Due_Date__c;
-    public String OwnerId;
-    public String Parent_Opportunity__c;
-    public String RecordTypeId;
-    public String StageName;
-    public String TBBCandidateExternalId__c;
-    public Long Hiring_Commitment__c;
-    public String AccountWebsite__c;
-    public String AccountHasHiredInternationally__c;
+    @JsonSetter("Name")
+    private String name;
+
+    @JsonSetter("AccountId")
+    private String accountId;
+
+    @JsonSetter("AccountCountry__c")
+    private String accountCountry;
+
+    @JsonSetter("AccountName__c")
+    private String accountName;
+
+    @JsonSetter("Candidate_TC_id__c")
+    private String candidateId;
+
+    @JsonSetter("Closing_Comments__c")
+    private String closingComments;
+
+    @JsonSetter("Employer_Feedback__c")
+    private String employerFeedback;
+
+    @JsonSetter("IsClosed")
+    private boolean isClosed;
+
+    @JsonSetter("NextStep")
+    private String nextStep;
+
+    @JsonSetter("Next_Step_Due_Date__c")
+    private String nextStepDueDate;
+
+    @JsonSetter("OwnerId")
+    private String ownerId;
+
+    @JsonSetter("Parent_Opportunity__c")
+    private String parentOpportunityId;
+
+    @JsonSetter("RecordTypeId")
+    private String recordTypeId;
+
+    @JsonSetter("StageName")
+    private String stageName;
+
+    @JsonSetter("TBBCandidateExternalId__c")
+    private String candidateExternalId;
+
+    @JsonSetter("Hiring_Commitment__c")
+    private Long hiringCommitment;
+
+    @JsonSetter("AccountWebsite__c")
+    private String accountWebsite;
+
+    @JsonSetter("AccountHasHiredInternationally__c")
+    private String accountHasHiredInternationally;
 
     @Override
     String getSfObjectName() {

--- a/server/src/main/java/org/tbbtalent/server/model/sf/Opportunity.java
+++ b/server/src/main/java/org/tbbtalent/server/model/sf/Opportunity.java
@@ -60,6 +60,9 @@ public class Opportunity extends SalesforceObjectBase {
     @JsonSetter("AccountName__c")
     private String accountName;
 
+    @JsonSetter("Account.Description")
+    private String accountDescription;
+
     @JsonSetter("Candidate_TC_id__c")
     private String candidateId;
 

--- a/server/src/main/java/org/tbbtalent/server/model/sf/SalesforceObjectBase.java
+++ b/server/src/main/java/org/tbbtalent/server/model/sf/SalesforceObjectBase.java
@@ -16,6 +16,7 @@
 
 package org.tbbtalent.server.model.sf;
 
+import com.fasterxml.jackson.annotation.JsonSetter;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
@@ -35,7 +36,8 @@ public abstract class SalesforceObjectBase {
   /**
    * This is the Salesforce Id that every Salesforce record has.
    */
-  public String Id;
+  @JsonSetter("Id")
+  private String id;
 
   /**
    * This is the name of this class of object as referred to in SF urls
@@ -45,8 +47,8 @@ public abstract class SalesforceObjectBase {
 
   public String getUrl() {
     String url = null;
-    if (Id != null) {
-      url = urlRoot + getSfObjectName() + "/" + Id + urlSuffix;
+    if (id != null) {
+      url = urlRoot + getSfObjectName() + "/" + id + urlSuffix;
     }
     return url;
   }

--- a/server/src/main/java/org/tbbtalent/server/service/db/impl/CandidateOpportunityServiceImpl.java
+++ b/server/src/main/java/org/tbbtalent/server/service/db/impl/CandidateOpportunityServiceImpl.java
@@ -99,7 +99,7 @@ public class CandidateOpportunityServiceImpl implements CandidateOpportunityServ
         //Update DB with data from op
 
         //Look up job opp from parent
-        String jobOppSfid = op.getParent_Opportunity__c();
+        String jobOppSfid = op.getParentOpportunityId();
         SalesforceJobOpp jobOpp = salesforceJobOppService.getJobOppById(jobOppSfid);
         if (jobOpp == null) {
             log.error("Could not find job opp: " + jobOppSfid + " parent of " + op.getName());
@@ -107,18 +107,18 @@ public class CandidateOpportunityServiceImpl implements CandidateOpportunityServ
         candidateOpportunity.setJobOpp(jobOpp);
 
         //Look up candidate from id
-        String candidateNumber = op.Candidate_TC_id__c;
+        String candidateNumber = op.getCandidateId();
         Candidate candidate = candidateService.findByCandidateNumber(candidateNumber);
         if (candidate == null) {
             log.error("Could not find candidate number: " + candidateNumber + " in candidate op " + op.getName());
         }
         candidateOpportunity.setCandidate(candidate);
 
-        candidateOpportunity.setEmployerFeedback(op.getEmployer_Feedback__c());
+        candidateOpportunity.setEmployerFeedback(op.getEmployerFeedback());
         candidateOpportunity.setName(op.getName());
         candidateOpportunity.setNextStep(op.getNextStep());
 
-        final String nextStepDueDate = op.getNext_Step_Due_Date__c();
+        final String nextStepDueDate = op.getNextStepDueDate();
         if (nextStepDueDate != null) {
             try {
                 candidateOpportunity.setNextStepDueDate(

--- a/server/src/main/java/org/tbbtalent/server/service/db/impl/SalesforceBridgeServiceImpl.java
+++ b/server/src/main/java/org/tbbtalent/server/service/db/impl/SalesforceBridgeServiceImpl.java
@@ -59,7 +59,7 @@ public class SalesforceBridgeServiceImpl implements SalesforceBridgeService {
         SavedList list = savedListService.createSavedList(req);
 
         for (Opportunity opp : opps) {
-            String candidateNumber = opp.getCandidate_TC_id__c();
+            String candidateNumber = opp.getCandidateId();
             Candidate candidate = candidateService.findByCandidateNumber(candidateNumber);
             if (candidate == null) {
                 log.error("Candidate number " + candidateNumber +

--- a/server/src/main/java/org/tbbtalent/server/service/db/impl/SalesforceJobOppServiceImpl.java
+++ b/server/src/main/java/org/tbbtalent/server/service/db/impl/SalesforceJobOppServiceImpl.java
@@ -166,15 +166,15 @@ public class SalesforceJobOppServiceImpl implements SalesforceJobOppService {
     private void copyOpportunityToJobOpp(@NonNull Opportunity op, SalesforceJobOpp salesforceJobOpp) {
         //Update DB with data from op
         salesforceJobOpp.setName(op.getName());
-        final String sfCountryName = op.getAccountCountry__c();
+        final String sfCountryName = op.getAccountCountry();
         salesforceJobOpp.setCountry(sfCountryName);
-        salesforceJobOpp.setEmployer(op.getAccountName__c());
+        salesforceJobOpp.setEmployer(op.getAccountName());
         salesforceJobOpp.setAccountId(op.getAccountId());
         salesforceJobOpp.setOwnerId(op.getOwnerId());
-        salesforceJobOpp.setClosed(op.isIsClosed());
-        salesforceJobOpp.setHiringCommitment(op.getHiring_Commitment__c());
-        salesforceJobOpp.setEmployerWebsite(op.getAccountWebsite__c());
-        salesforceJobOpp.setEmployerHiredInternationally(op.getAccountHasHiredInternationally__c());
+        salesforceJobOpp.setClosed(op.isClosed());
+        salesforceJobOpp.setHiringCommitment(op.getHiringCommitment());
+        salesforceJobOpp.setEmployerWebsite(op.getAccountWebsite());
+        salesforceJobOpp.setEmployerHiredInternationally(op.getAccountHasHiredInternationally());
         JobOpportunityStage stage;
         try {
             stage = JobOpportunityStage.textToEnum(op.getStageName());

--- a/server/src/main/java/org/tbbtalent/server/service/db/impl/SalesforceServiceImpl.java
+++ b/server/src/main/java/org/tbbtalent/server/service/db/impl/SalesforceServiceImpl.java
@@ -138,7 +138,7 @@ public class SalesforceServiceImpl implements SalesforceService, InitializingBea
             + candidateOpportunitySFFieldName;
     private final String jobOpportunityRetrievalFields =
         commonOpportunityFields +
-        ",RecordTypeId,OwnerId,Hiring_Commitment__c,AccountName__c,AccountWebsite__c,AccountHasHiredInternationally__c";
+        ",RecordTypeId,OwnerId,Hiring_Commitment__c,AccountName__c,Account.Description,AccountWebsite__c,AccountHasHiredInternationally__c";
 
     private final EmailHelper emailHelper;
 

--- a/server/src/main/java/org/tbbtalent/server/service/db/impl/SalesforceServiceImpl.java
+++ b/server/src/main/java/org/tbbtalent/server/service/db/impl/SalesforceServiceImpl.java
@@ -195,7 +195,7 @@ public class SalesforceServiceImpl implements SalesforceService, InitializingBea
             List<Opportunity> candidateOpps = findCandidateOpportunitiesByJobOpps(id);
             for (Opportunity candidateOpp : candidateOpps) {
                 Candidate candidate = oppIdCandidateMap.get(
-                    candidateOpp.getTBBCandidateExternalId__c());
+                    candidateOpp.getCandidateExternalId());
                 if (candidate != null) {
                     candidate.setStage(candidateOpp.getStageName());
                     candidate.setSfOpportunityLink(candidateOpp.getUrl());
@@ -371,7 +371,7 @@ public class SalesforceServiceImpl implements SalesforceService, InitializingBea
 
         //Remove these from map, leaving just those that need to be created
         for (Opportunity opp : opps) {
-            idCandidateMap.remove(opp.getTBBCandidateExternalId__c());
+            idCandidateMap.remove(opp.getCandidateExternalId());
         }
 
         //Extract these candidates from the map.

--- a/server/src/test/java/org/tbbtalent/server/model/sf/ContactTest.java
+++ b/server/src/test/java/org/tbbtalent/server/model/sf/ContactTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2023 Talent Beyond Boundaries.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tbbtalent.server.model.sf;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ContactTest {
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    @DisplayName("convert json string to contact pojo succeeds")
+    void jsonStringToContactPojo() throws JsonProcessingException {
+        String contactJson = """
+                {
+                  "AccountId": "12345",
+                  "TBBid__c": "67890"
+                }""";
+
+        Contact contact = objectMapper.readValue(contactJson, Contact.class);
+
+        assertThat(contact.getAccountId()).isEqualTo("12345");
+        assertThat(contact.getTbbId()).isEqualTo(67890L);
+    }
+
+}

--- a/server/src/test/java/org/tbbtalent/server/model/sf/OpportunityTest.java
+++ b/server/src/test/java/org/tbbtalent/server/model/sf/OpportunityTest.java
@@ -51,7 +51,8 @@ class OpportunityTest {
                   "TBBCandidateExternalId__c": "67890_ext_id",
                   "Hiring_Commitment__c": "25",
                   "AccountWebsite__c": "https://www.rolls-roycemotorcars.com",
-                  "AccountHasHiredInternationally__c": "Yes"
+                  "AccountHasHiredInternationally__c": "Yes",
+                  "Id": "13579"
                 }""";
 
         Opportunity opportunity = objectMapper.readValue(opportunityJson, Opportunity.class);
@@ -74,6 +75,7 @@ class OpportunityTest {
         assertThat(opportunity.getHiringCommitment()).isEqualTo(25L);
         assertThat(opportunity.getAccountWebsite()).isEqualTo("https://www.rolls-roycemotorcars.com");
         assertThat(opportunity.getAccountHasHiredInternationally()).isEqualTo("Yes");
+        assertThat(opportunity.getId()).isEqualTo("13579");
     }
 
 }

--- a/server/src/test/java/org/tbbtalent/server/model/sf/OpportunityTest.java
+++ b/server/src/test/java/org/tbbtalent/server/model/sf/OpportunityTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2023 Talent Beyond Boundaries.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tbbtalent.server.model.sf;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+class OpportunityTest {
+
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    @DisplayName("convert json string to opportunity pojo succeeds")
+    void jsonStringToOpportunityPojo() throws JsonProcessingException {
+        String opportunityJson = """
+                {
+                  "Name": "Jalil",
+                  "AccountId": "12345",
+                  "AccountCountry__c": "UK",
+                  "AccountName__c": "Rolls Royce",
+                  "Candidate_TC_id__c": "67890",
+                  "Closing_Comments__c": "Some closing comments",
+                  "Employer_Feedback__c": "Employer feedback text",
+                  "IsClosed": "false",
+                  "NextStep": "Next step",
+                  "Next_Step_Due_Date__c": "01-06-2023",
+                  "OwnerId": "999",
+                  "Parent_Opportunity__c": "23456",
+                  "RecordTypeId": "Y",
+                  "StageName": "Offer",
+                  "TBBCandidateExternalId__c": "67890_ext_id",
+                  "Hiring_Commitment__c": "25",
+                  "AccountWebsite__c": "https://www.rolls-roycemotorcars.com",
+                  "AccountHasHiredInternationally__c": "Yes"
+                }""";
+
+        Opportunity opportunity = objectMapper.readValue(opportunityJson, Opportunity.class);
+
+        assertThat(opportunity.getName()).isEqualTo("Jalil");
+        assertThat(opportunity.getAccountId()).isEqualTo("12345");
+        assertThat(opportunity.getAccountCountry()).isEqualTo("UK");
+        assertThat(opportunity.getAccountName()).isEqualTo("Rolls Royce");
+        assertThat(opportunity.getCandidateId()).isEqualTo("67890");
+        assertThat(opportunity.getClosingComments()).isEqualTo("Some closing comments");
+        assertThat(opportunity.getEmployerFeedback()).isEqualTo("Employer feedback text");
+        assertFalse(opportunity.isClosed());
+        assertThat(opportunity.getNextStep()).isEqualTo("Next step");
+        assertThat(opportunity.getNextStepDueDate()).isEqualTo("01-06-2023");
+        assertThat(opportunity.getOwnerId()).isEqualTo("999");
+        assertThat(opportunity.getParentOpportunityId()).isEqualTo("23456");
+        assertThat(opportunity.getRecordTypeId()).isEqualTo("Y");
+        assertThat(opportunity.getStageName()).isEqualTo("Offer");
+        assertThat(opportunity.getCandidateExternalId()).isEqualTo("67890_ext_id");
+        assertThat(opportunity.getHiringCommitment()).isEqualTo(25L);
+        assertThat(opportunity.getAccountWebsite()).isEqualTo("https://www.rolls-roycemotorcars.com");
+        assertThat(opportunity.getAccountHasHiredInternationally()).isEqualTo("Yes");
+    }
+
+}


### PR DESCRIPTION
- Use JsonSetters to map SF field names to Java field names in Opportunity, Contact and SalesforceObjectBase
- Create unit tests to verify for json string to Opportunity and Contact mappings
- Update all related classes to use the correct getter methods
- Adding Account.Description to accountDescription mapping in Opportunity