### PR TITLE
I've rewritten this section of the code, which has fixed the bug

### DIFF
--- a/server/src/main/java/org/tbbtalent/server/service/db/impl/UserServiceImpl.java
+++ b/server/src/main/java/org/tbbtalent/server/service/db/impl/UserServiceImpl.java
@@ -250,31 +250,20 @@ public class UserServiceImpl implements UserService {
             user.setPartner((PartnerImpl) newSourcePartner);
         }
 
-        //Possibly update the user's approver
+//      Possibly update the user's approver
+//      Compare the requested approverID and the user's current approverID and if they're different, make the change - if the creatingUser is a systemadmin
         User currentApprover = user.getApprover();
         Long currentApproverId = currentApprover == null ? null : currentApprover.getId();
-        User newApprover = null;
-        Long approverId = request.getApproverId();
-        if (approverId != null) {
-            //Approver specified - is it a new one?
-            if (!approverId.equals(currentApproverId)) {
+        Long newApproverId = request.getApproverId();
+        if (newApproverId != null) {
+            if (!newApproverId.equals(currentApproverId)) {
                 if (creatingUser != null && creatingUser.getRole() != Role.systemadmin) {
-                    //Only system admins can change approver
                     throw new InvalidRequestException("You don't have permission to assign an approver.");
                 } else {
-                    //Changing approver
-                    newApprover = getUser(approverId);
+                    User newApprover = getUser(newApproverId);
+                    user.setApprover(newApprover);
                 }
             }
-        } else {
-            //If user does not already have an approver, assign one
-            if (currentApprover == null) {
-                newApprover = creatingUser.getApprover();
-            }
-        }
-        //If we have a new approver, update it.
-        if (newApprover != null) {
-            user.setApprover(newApprover);
         }
 
         user.setReadOnly(request.getReadOnly());


### PR DESCRIPTION
I found the issue, which was with the code I replicated from the partner function in UserServiceImpl.java, specifically this part:

`            if (currentApprover == null) {
                newApprover = creatingUser.getApprover();
            }`

So, if the user we're creating doesn't already have an approver, then it uses the "creating user's" approver — which in my case, in production, was set to Caroline (ID: 6). But in development, the "creating user" is SystemAdmin, who doesn't have an approver — hence the discrepancy, and my not noticing this bug in development. 

This section of code was appropriate for partners but not for approvers — I shouldn't have replicated it.

I've rewritten it from scratch, which is what I should have done in the first place! All working as before, except without this bug.