### PR TITLE
Fix breaking unit test

### DIFF
--- a/server/src/main/java/org/tbbtalent/server/api/admin/CandidateAdminApi.java
+++ b/server/src/main/java/org/tbbtalent/server/api/admin/CandidateAdminApi.java
@@ -327,9 +327,9 @@ public class CandidateAdminApi {
     public String generateToken(@PathVariable("cn") String candidateNumber,
                                 @RequestParam(defaultValue = "false") boolean restrictCandidateOccupations,
                                 @RequestParam(defaultValue = "") List<Long> candidateOccupationIds) {
-             CvClaims cvClaims = new CvClaims(candidateNumber, restrictCandidateOccupations, candidateOccupationIds);
-             String token = candidateTokenProvider.generateCvToken(cvClaims, 365L);
-             return token;
-        }
+         CvClaims cvClaims = new CvClaims(candidateNumber, restrictCandidateOccupations, candidateOccupationIds);
+         String token = candidateTokenProvider.generateCvToken(cvClaims, 365L);
+         return token;
+    }
 
 }

--- a/server/src/main/java/org/tbbtalent/server/security/CandidateTokenProvider.java
+++ b/server/src/main/java/org/tbbtalent/server/security/CandidateTokenProvider.java
@@ -106,6 +106,7 @@ public class CandidateTokenProvider implements InitializingBean {
                 .signWith(jwtSecret, SignatureAlgorithm.HS256)
                 .compact();
     }
+
     /**
      * Retrieves the candidate number from the token, otherwise throws exceptions if the token
      * is not valid or has expired.

--- a/server/src/test/java/org/tbbtalent/server/api/admin/CandidateAdminApiTest.java
+++ b/server/src/test/java/org/tbbtalent/server/api/admin/CandidateAdminApiTest.java
@@ -538,22 +538,21 @@ class CandidateAdminApiTest extends ApiTestBase {
     @DisplayName("generate token succeeds")
     void generateTokenSucceeds() throws Exception {
         String cn = "99";
-        long expiryTimeDays = 365L;
         String token = "token";
 
-        given(candidateTokenProvider.generateToken(cn, expiryTimeDays))
+        given(candidateTokenProvider.generateCvToken(any(CvClaims.class), anyLong()))
                 .willReturn(token);
 
         mockMvc.perform(get(BASE_PATH + GENERATE_TOKEN_PATH.replace("{cn}", cn))
                         .header("Authorization", "Bearer " + "jwt-token")
-                        .accept(MediaType.APPLICATION_JSON))
+                        .accept(MediaType.TEXT_PLAIN_VALUE))
 
                 .andDo(print())
                 .andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_PLAIN_VALUE))
                 .andExpect(jsonPath("$", is(token)));
 
-        verify(candidateTokenProvider).generateToken(cn, expiryTimeDays);
+        verify(candidateTokenProvider).generateCvToken(any(CvClaims.class), anyLong());
     }
 
     private void postSearchRequestAndVerifyResponse(String path, String body) throws Exception {


### PR DESCRIPTION
This PR fixes the breaking unit test following the addition of the generateCvToken method on CandidateTokenProvider