### PR TITLE
112-cannot-delete-list

### DIFF
--- a/server/src/main/java/org/tbbtalent/server/model/db/SavedList.java
+++ b/server/src/main/java/org/tbbtalent/server/model/db/SavedList.java
@@ -202,7 +202,7 @@ public class SavedList extends AbstractCandidateSource {
     @ManyToMany(fetch = FetchType.LAZY, mappedBy = "sharedLists", cascade = CascadeType.MERGE)
     private Set<User> users = new HashSet<>();
 
-    @OneToMany(fetch = FetchType.LAZY, mappedBy = "savedList", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "savedList", cascade = CascadeType.ALL)
     @OrderBy("index ASC")
     private List<ExportColumn> exportColumns;
 

--- a/server/src/main/java/org/tbbtalent/server/model/db/SavedList.java
+++ b/server/src/main/java/org/tbbtalent/server/model/db/SavedList.java
@@ -202,7 +202,7 @@ public class SavedList extends AbstractCandidateSource {
     @ManyToMany(fetch = FetchType.LAZY, mappedBy = "sharedLists", cascade = CascadeType.MERGE)
     private Set<User> users = new HashSet<>();
 
-    @OneToMany(fetch = FetchType.LAZY, mappedBy = "savedList", cascade = CascadeType.MERGE)
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "savedList", cascade = CascadeType.ALL, orphanRemoval = true)
     @OrderBy("index ASC")
     private List<ExportColumn> exportColumns;
 


### PR DESCRIPTION
This only required a small change to the entity relationship between the saved_list and export_column, to avoid violating a foreign key constraint which was causing the error.