### PR TITLE
105 candidate job detail in candidate source display is too wide see candidatesearchcardcomponent could just display stage and due date with next step appearing as a hover over stage or date

### DIFF
--- a/ui/admin-portal/src/app/components/candidate-opp/candidate-opps/candidate-opps.component.html
+++ b/ui/admin-portal/src/app/components/candidate-opp/candidate-opps/candidate-opps.component.html
@@ -77,13 +77,13 @@
                            *ngIf="searchBy"></app-sorted-by>
             Next step
           </th>
-          <th (click)="toggleSort('nextStepDueDate', 'DESC')">
+          <th *ngIf="!preview" (click)="toggleSort('nextStepDueDate', 'DESC')">
             <app-sorted-by [column]="'nextStepDueDate'" [sortColumn]="sortField" [sortDirection]="sortDirection"
                            *ngIf="searchBy"></app-sorted-by>
             Due
           </th>
           <th *ngIf="preview">
-            Next Step
+            Next...
           </th>
         </tr>
         </thead>
@@ -106,7 +106,7 @@
           </td>
           <td *ngIf="showJobOppName" [title]="opp.jobOpp.name">
             <a [routerLink]="['/opp',opp.id]">
-              {{opp.jobOpp.name | truncate: 25}}
+              {{opp.jobOpp.name}}
             </a>
           </td>
           <td>
@@ -115,13 +115,17 @@
           <td *ngIf="!preview" [title]="getNextStepHoverString(opp)">
             {{opp.nextStep | truncate: 38}}
           </td>
-          <td>
+          <td *ngIf="!preview">
             {{opp.nextStepDueDate}}
           </td>
           <td *ngIf="preview">
-            <div *ngIf="opp?.nextStep" [ngbPopover]="opp.nextStep" triggers="mouseenter:mouseleave" container="body">
-              <i class="far fa-comment-dots hover-color"></i>
+            <div *ngIf="opp?.nextStep" [ngbPopover]="nextStepPopover" triggers="mouseenter:mouseleave" container="body">
+              <i class="fa-solid fa-shoe-prints"></i>
             </div>
+            <ng-template #nextStepPopover>
+              <strong>Due date: </strong>{{opp.nextStepDueDate}}<br>
+              <strong>Next step: </strong>{{opp.nextStep}}
+            </ng-template>
           </td>
         </tr>
         </tbody>

--- a/ui/admin-portal/src/app/components/candidate-opp/candidate-opps/candidate-opps.component.html
+++ b/ui/admin-portal/src/app/components/candidate-opp/candidate-opps/candidate-opps.component.html
@@ -83,7 +83,7 @@
             Due
           </th>
           <th *ngIf="preview">
-            Next...
+            Next?
           </th>
         </tr>
         </thead>

--- a/ui/admin-portal/src/app/components/candidate-opp/candidate-opps/candidate-opps.component.html
+++ b/ui/admin-portal/src/app/components/candidate-opp/candidate-opps/candidate-opps.component.html
@@ -72,7 +72,7 @@
                            *ngIf="searchBy"></app-sorted-by>
             Stage
           </th>
-          <th (click)="toggleSort('updatedDate', 'DESC')">
+          <th *ngIf="!preview" (click)="toggleSort('updatedDate', 'DESC')">
             <app-sorted-by column="updatedDate" [sortColumn]="sortField" [sortDirection]="sortDirection"
                            *ngIf="searchBy"></app-sorted-by>
             Next step
@@ -81,6 +81,9 @@
             <app-sorted-by [column]="'nextStepDueDate'" [sortColumn]="sortField" [sortDirection]="sortDirection"
                            *ngIf="searchBy"></app-sorted-by>
             Due
+          </th>
+          <th *ngIf="preview">
+            Next Step
           </th>
         </tr>
         </thead>
@@ -109,11 +112,16 @@
           <td>
             {{getCandidateOpportunityStageName(opp)}}
           </td>
-          <td [title]="getNextStepHoverString(opp)">
+          <td *ngIf="!preview" [title]="getNextStepHoverString(opp)">
             {{opp.nextStep | truncate: 38}}
           </td>
           <td>
             {{opp.nextStepDueDate}}
+          </td>
+          <td *ngIf="preview">
+            <div *ngIf="opp?.nextStep" [ngbPopover]="opp.nextStep" triggers="mouseenter:mouseleave" container="body">
+              <i class="far fa-comment-dots hover-color"></i>
+            </div>
           </td>
         </tr>
         </tbody>

--- a/ui/admin-portal/src/app/components/candidate-opp/candidate-opps/candidate-opps.component.ts
+++ b/ui/admin-portal/src/app/components/candidate-opp/candidate-opps/candidate-opps.component.ts
@@ -31,6 +31,12 @@ export class CandidateOppsComponent extends FilteredOppsComponentBase<CandidateO
    */
   @Input() showJobOppName: boolean = false;
 
+  /**
+   * This is to determine if the component is being viewed from the candidate preview (from within a list/search) or not.
+   * If preview is true we have less space to display the component so can use this boolean to make space efficient changes of the CSS.
+   */
+  @Input() preview: boolean = false;
+
   //Override text to replace "opps" text with "cases"
   myOppsOnlyLabel = "My cases only";
   myOppsOnlyTip = "Only show cases that I am the contact for";

--- a/ui/admin-portal/src/app/components/candidates/view/jobs/view-candidate-jobs/view-candidate-jobs.component.html
+++ b/ui/admin-portal/src/app/components/candidates/view/jobs/view-candidate-jobs/view-candidate-jobs.component.html
@@ -1,5 +1,6 @@
 <app-candidate-opps
   [candidateOpps]="candidate?.candidateOpportunities"
   [showJobOppName]="true"
+  [preview]="preview"
 >
 </app-candidate-opps>

--- a/ui/admin-portal/src/app/components/candidates/view/jobs/view-candidate-jobs/view-candidate-jobs.component.ts
+++ b/ui/admin-portal/src/app/components/candidates/view/jobs/view-candidate-jobs/view-candidate-jobs.component.ts
@@ -8,6 +8,7 @@ import {Candidate} from "../../../../../model/candidate";
 })
 export class ViewCandidateJobsComponent implements OnInit {
   @Input() candidate: Candidate;
+  @Input() preview: boolean = false;
 
   constructor() { }
 

--- a/ui/admin-portal/src/app/components/candidates/view/tab/candidate-jobs-tab/candidate-jobs-tab.component.html
+++ b/ui/admin-portal/src/app/components/candidates/view/tab/candidate-jobs-tab/candidate-jobs-tab.component.html
@@ -1,3 +1,4 @@
 <app-view-candidate-jobs
-  [candidate]="candidate">
+  [candidate]="candidate"
+  [preview]="preview">
 </app-view-candidate-jobs>

--- a/ui/admin-portal/src/app/components/candidates/view/tab/candidate-jobs-tab/candidate-jobs-tab.component.ts
+++ b/ui/admin-portal/src/app/components/candidates/view/tab/candidate-jobs-tab/candidate-jobs-tab.component.ts
@@ -10,6 +10,8 @@ export class CandidateJobsTabComponent implements OnInit {
 
   @Input() candidate: Candidate;
 
+  @Input() preview: boolean = false;
+
   constructor() { }
 
   ngOnInit(): void {

--- a/ui/admin-portal/src/app/components/util/candidate-search-card/candidate-search-card.component.html
+++ b/ui/admin-portal/src/app/components/util/candidate-search-card/candidate-search-card.component.html
@@ -164,7 +164,8 @@
         <a ngbNavLink>Jobs</a>
         <ng-template ngbNavContent>
           <app-candidate-jobs-tab
-              [candidate]="candidate">
+              [candidate]="candidate"
+              [preview]="true">
           </app-candidate-jobs-tab>
         </ng-template>
       </ng-container>


### PR DESCRIPTION
Added popover AND in another branch I have made the table responsive, which will also improve the appearance of this table.