### PR TITLE
249 use talent catalog image repository

### DIFF
--- a/.github/workflows/tbb-prod-build-deploy.yml
+++ b/.github/workflows/tbb-prod-build-deploy.yml
@@ -31,7 +31,9 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Build with Gradle
-        run: ./gradlew build -Pprod-tc-system
+        run: ./gradlew build
+      - name: Deploy with Jib
+        run: ./gradlew jib -Pprod-tc-system
 
         # These env variables will be used by the jib stage of the gradle
         # build which is configured to use the ecr credential helper.

--- a/.github/workflows/tbb-test-build-deploy.yml
+++ b/.github/workflows/tbb-test-build-deploy.yml
@@ -31,7 +31,9 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Build with Gradle
-        run: ./gradlew build -Ptest-tc-system
+        run: ./gradlew build
+      - name: Deploy with Jib
+        run: ./gradlew jib -Ptest-tc-system
 
         # These env variables will be used by the jib stage of the gradle
         # build which is configured to use the ecr credential helper.

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -126,7 +126,7 @@ jib {
         if (project.hasProperty("test-tc-system")) {
             image = "231168606641.dkr.ecr.us-east-1.amazonaws.com/test-ecs"
         } else if (project.hasProperty("prod-tc-system")) {
-            image = "968457613372.dkr.ecr.us-east-1.amazonaws.com/tbbtalentv2"
+            image = "968457613372.dkr.ecr.us-east-1.amazonaws.com/talent-catalog"
         }
         credHelper = 'ecr-login'
     }


### PR DESCRIPTION
This PR

- Updates build.gradle to point the prod jib task to the new prod "talent-catalog" image repository.

- Adds a step to the prod and staging Git Actions to ensure that Jib is run. This must now be an explicit step because the build.gradle file no longer has an implicit build dependency on jib.

(The build dependency on Jib was removed in #226 to prevent jib from automatically running for local Gradle builds.)
