### PR TITLE
Converted search tip text to NgbTooltips, triggered on question icons that are clickable and keyboard-focusable

### DIFF
--- a/ui/admin-portal/src/app/components/search/define-search/define-search.component.html
+++ b/ui/admin-portal/src/app/components/search/define-search/define-search.component.html
@@ -81,16 +81,16 @@
             <li>Use brackets to group terms - e.g. <code>accountant + (excel powerpoint)</code> finds profiles containing the word 'accountant' AND <em>either</em> 'excel' or 'powerpoint', whereas <code>(accountant + excel) powerpoint</code> finds profiles containing 'accountant' AND 'excel', OR profiles containing the word 'powerpoint'.</li>
           </ul>
           Once you've entered your query, you will need to click the 'Search' button below.
-          <!-- TODO: add the fields that can be combined with elastic search -->
+          <!-- TODO: add note re fields that can be combined with elastic search -->
         </ng-template>
 
         <div class="container-fluid">
           <div class="row">
             <div class="mb-3 col-md-6">
-              <!-- providing 'placement' as an empty string makes the tooltip appear over the element in a suitable direction for the viewport -->
+              <!-- providing 'placement' as an empty string makes the tooltip appear over the element in a suitable direction for the viewport - adding the keydown.enter event stops the tooltip from being triggered by pressing enter while using the input field -->
               <label class="form-label" for="simpleQueryString">Keyword Search</label><button class="search-tip-button" [ngbTooltip]="keywordSearchTip" placement="" triggers="click" tooltipClass="search-tips"><i class="fa-regular fa-circle-question fa-xs"></i></button>
               <input id="simpleQueryString" type="text" class="form-control" placeholder="E.g. 'welder diesel+mechanic'" aria-label="Keyword Search"
-                     formControlName="simpleQueryString"
+                     formControlName="simpleQueryString" (keydown.enter)="$event.preventDefault()"
                      >
             </div>
 

--- a/ui/admin-portal/src/app/components/search/define-search/define-search.component.html
+++ b/ui/admin-portal/src/app/components/search/define-search/define-search.component.html
@@ -87,6 +87,7 @@
         <div class="container-fluid">
           <div class="row">
             <div class="mb-3 col-md-6">
+              <!-- providing 'placement' as an empty string makes the tooltip appear over the element in a suitable direction for the viewport -->
               <label class="form-label" for="simpleQueryString">Keyword Search</label><button class="search-tip-button" [ngbTooltip]="keywordSearchTip" placement="" triggers="click" tooltipClass="search-tips"><i class="fa-regular fa-circle-question fa-xs"></i></button>
               <input id="simpleQueryString" type="text" class="form-control" placeholder="E.g. 'welder diesel+mechanic'" aria-label="Keyword Search"
                      formControlName="simpleQueryString"
@@ -95,7 +96,7 @@
 
             <!-- STATUS -->
             <div class="mb-3 col-md-3">
-              <label class="form-label">Status</label><button class="search-tip-button" ngbTooltip="If nothing is specified, the default is to exclude inactive statuses - e.g. 'draft', 'deleted' or 'ineligible'." placement="" triggers="click" tooltipClass="search-tips"><i class="fa-regular fa-circle-question fa-xs"></i></button>
+              <label class="form-label">Status</label><button class="search-tip-button" ngbTooltip="If nothing is specified here, the default is to exclude inactive statuses - e.g. 'draft', 'deleted' or 'ineligible'." placement="" triggers="click" tooltipClass="search-tips"><i class="fa-regular fa-circle-question fa-xs"></i></button>
               <ng-select
                 id="statuses"
                 [items]="candidateStatusOptions"

--- a/ui/admin-portal/src/app/components/search/define-search/define-search.component.html
+++ b/ui/admin-portal/src/app/components/search/define-search/define-search.component.html
@@ -76,7 +76,7 @@
           Search candidate CVs using these tips to create powerful queries:
           <ul id="keyword-search-tip-list">
             <li><code>+</code> means AND, <code>space</code> means OR - e.g. <code>welder diesel+mechanic</code> finds all profiles containing the word 'welder' OR <em>both</em> the words 'diesel' AND 'mechanic'.</li>
-            <li>Match the first part of a word using <code>*</code> - e.g. <code>account*</code> will find 'accounting' or 'accountant'.</li>
+            <li>Match the first part of a word using <code>*</code> - e.g. <code>account*</code> will find 'accounting' and 'accountant'.</li>
             <li>Search for phrases as well as words by using double quotes - e.g. <code>accountant + "hospital director"</code> will find profiles with the word 'accountant' AND the phrase 'hospital director'.</li>
             <li>Use brackets to group terms - e.g. <code>accountant + (excel powerpoint)</code> finds profiles containing the word 'accountant' AND <em>either</em> 'excel' or 'powerpoint', whereas <code>(accountant + excel) powerpoint</code> finds profiles containing 'accountant' AND 'excel', OR profiles containing the word 'powerpoint'.</li>
           </ul>

--- a/ui/admin-portal/src/app/components/search/define-search/define-search.component.html
+++ b/ui/admin-portal/src/app/components/search/define-search/define-search.component.html
@@ -80,8 +80,7 @@
             <li>Search for phrases as well as words by using double quotes - e.g. <code>accountant + "hospital director"</code> will find profiles with the word 'accountant' AND the phrase 'hospital director'.</li>
             <li>Use brackets to group terms - e.g. <code>accountant + (excel powerpoint)</code> finds profiles containing the word 'accountant' AND <em>either</em> 'excel' or 'powerpoint', whereas <code>(accountant + excel) powerpoint</code> finds profiles containing 'accountant' AND 'excel', OR profiles containing the word 'powerpoint'.</li>
           </ul>
-          Once you've entered your query, you will need to click the 'Search' button below.
-          <!-- TODO: add note re fields that can be combined with elastic search -->
+          You can further refine your query by applying the available filters below. Click the 'Search' button to execute.
         </ng-template>
 
         <div class="container-fluid">

--- a/ui/admin-portal/src/app/components/search/define-search/define-search.component.html
+++ b/ui/admin-portal/src/app/components/search/define-search/define-search.component.html
@@ -72,35 +72,30 @@
       </div>
 
       <form class="filter-form" [formGroup]="searchForm" (ngSubmit)="apply()" #formWrapper>
-        <div class="container-fluid">
-          <div class="row">
-            <div class="col">
-              <p>Introducing Elasticsearch which <strong>searches all CV's as well!</strong> When searching + means AND, space means OR. For example <strong>welder diesel+mechanic</strong>
-                will find all candidate profiles containing the word 'welder' OR both words 'diesel' AND 'mechanic'.
-                You can just match the first part of a word using *. For example 'account*' will match 'accounting' or
-                'accountant'. You can also search for phrases as well as words by using double quotes.
-                For example <strong>accountant + "hospital director"</strong> will find profiles with the word 'accountant'
-                AND the phrase 'hospital director'. You can use brackets to group terms. For example
-                <strong>accountant + (excel powerpoint)</strong> means find profiles
-                containing the word 'accountant' AND either one of 'excel' or 'powerpoint'.
-                But <strong>(accountant + excel) powerpoint</strong> means find profiles containing both words
-                'accountant' and 'excel' OR profiles containing the word 'powerpoint'.</p>
-            </div>
-          </div>
-        </div>
-        <hr/>
+        <ng-template #keywordSearchTip>
+          Search candidate CVs using these tips to create powerful queries:
+          <ul id="keyword-search-tip-list">
+            <li><code>+</code> means AND, <code>space</code> means OR - e.g. <code>welder diesel+mechanic</code> finds all profiles containing the word 'welder' OR <em>both</em> the words 'diesel' AND 'mechanic'.</li>
+            <li>Match the first part of a word using <code>*</code> - e.g. <code>account*</code> will find 'accounting' or 'accountant'.</li>
+            <li>Search for phrases as well as words by using double quotes - e.g. <code>accountant + "hospital director"</code> will find profiles with the word 'accountant' AND the phrase 'hospital director'.</li>
+            <li>Use brackets to group terms - e.g. <code>accountant + (excel powerpoint)</code> finds profiles containing the word 'accountant' AND <em>either</em> 'excel' or 'powerpoint', whereas <code>(accountant + excel) powerpoint</code> finds profiles containing 'accountant' AND 'excel', OR profiles containing the word 'powerpoint'.</li>
+          </ul>
+          Once you've entered your query, you will need to click the 'Search' button below.
+          <!-- TODO: add the fields that can be combined with elastic search -->
+        </ng-template>
+
         <div class="container-fluid">
           <div class="row">
             <div class="mb-3 col-md-6">
-              <label class="form-label" for="simpleQueryString">Elasticsearch</label>
-              <input id="simpleQueryString" type="text" class="form-control" placeholder="eg welder diesel+mechanic" aria-label="Elastic"
+              <label class="form-label" for="simpleQueryString">Keyword Search</label><button class="search-tip-button" [ngbTooltip]="keywordSearchTip" placement="" triggers="click" tooltipClass="search-tips"><i class="fa-regular fa-circle-question fa-xs"></i></button>
+              <input id="simpleQueryString" type="text" class="form-control" placeholder="E.g. 'welder diesel+mechanic'" aria-label="Keyword Search"
                      formControlName="simpleQueryString"
-              >
+                     >
             </div>
 
             <!-- STATUS -->
             <div class="mb-3 col-md-3">
-              <label class="form-label">Status</label>
+              <label class="form-label">Status</label><button class="search-tip-button" ngbTooltip="If nothing is specified, the default is to exclude inactive statuses - e.g. 'draft', 'deleted' or 'ineligible'." placement="" triggers="click" tooltipClass="search-tips"><i class="fa-regular fa-circle-question fa-xs"></i></button>
               <ng-select
                 id="statuses"
                 [items]="candidateStatusOptions"
@@ -132,9 +127,6 @@
                   </div>
                 </ng-template>
               </ng-select>
-              <p class="small text-muted mt-1">
-                If nothing is specified, the default is to exclude inactive statuses such as draft,
-                deleted, employed, ineligible etc</p>
             </div>
 
             <!-- ENGLISH LANGUAGE -->
@@ -444,7 +436,8 @@
 
             <!-- EXCLUSION LIST -->
             <div class="col-md-4">
-              <label class="form-label" for="exclusion">Exclusion list</label>
+              <label class="form-label" for="exclusion">Exclusion list</label><button class="search-tip-button" ngbTooltip="Select from lists you created, global lists (e.g. job lists) or lists that you have
+                starred." placement="" triggers="click" tooltipClass="search-tips"><i class="fa-regular fa-circle-question fa-xs"></i></button>
               <ng-select
                 id="exclusion"
                 [items]="lists"
@@ -456,15 +449,11 @@
                 bindValue="id"
                 formControlName="exclusionListId">
               </ng-select>
-              <p class="small text-muted mt-1">
-                You can select from lists you created, global lists (like job lists) or lists that you have
-                starred.
-              </p>
             </div>
 
             <!-- PARTNERS  -->
             <div class="col-md-4">
-              <label class="form-label">Partners</label>
+              <label class="form-label">Partners</label><button class="search-tip-button" ngbTooltip="{{getPartnerDefaultMessage()}}" placement="" triggers="click" tooltipClass="search-tips"><i class="fa-regular fa-circle-question fa-xs"></i></button>
               <ng-select
                 id="partner"
                 [items]="partners"
@@ -491,9 +480,6 @@
                   </div>
                 </ng-template>
               </ng-select>
-              <p class="small text-muted mt-1">
-                {{getPartnerDefaultMessage()}}
-              </p>
             </div>
 
 

--- a/ui/admin-portal/src/app/components/search/define-search/define-search.component.scss
+++ b/ui/admin-portal/src/app/components/search/define-search/define-search.component.scss
@@ -160,3 +160,23 @@ $candidate-card-width: 375px;
 .ng-dropdown-panel > .ng-dropdown-panel-items {
     max-height: fit-content;
 }
+
+// ::ng-deep is used here since the NgbTooltip directive is outside this component's encapsulation scope
+::ng-deep .search-tips .tooltip-inner {
+  text-align: left;
+  font-size: small;
+  max-width: 50%;
+  background-color: #212529;
+  padding: 1em
+}
+
+// Making the search tip icon a button enables it to be keyboard-focusable, per Bootstrap doc advice https://getbootstrap.com/docs/5.0/components/tooltips/#markup - overriding the native button style fixes the visual aspect
+.search-tip-button {
+  border: none;
+  padding: 0;
+}
+
+// To make example search queries more visible
+#keyword-search-tip-list code {
+  color: #0cd5e4;
+}

--- a/ui/admin-portal/src/app/components/search/define-search/define-search.component.ts
+++ b/ui/admin-portal/src/app/components/search/define-search/define-search.component.ts
@@ -717,9 +717,9 @@ export class DefineSearchComponent implements OnInit, OnChanges, OnDestroy {
 
     //Source partners default to seeing only their candidates (unless they are the default partner)
     if (this.authService.isSourcePartner() && !this.authService.isDefaultPartner()) {
-      s = "If nothing is specified, the default is just to show candidates belonging to your partner.";
+      s = "If nothing is specified here, the default is just to show candidates belonging to your partner.";
     } else {
-      s = "If nothing is specified, the default is to show candidates managed by any partner.";
+      s = "If nothing is specified here, the default is to show candidates managed by any partner.";
     }
 
     return s;

--- a/ui/admin-portal/src/app/components/search/define-search/define-search.component.ts
+++ b/ui/admin-portal/src/app/components/search/define-search/define-search.component.ts
@@ -717,9 +717,9 @@ export class DefineSearchComponent implements OnInit, OnChanges, OnDestroy {
 
     //Source partners default to seeing only their candidates (unless they are the default partner)
     if (this.authService.isSourcePartner() && !this.authService.isDefaultPartner()) {
-      s = "If nothing is specified, the default is to just show candidates belonging to your partner";
+      s = "If nothing is specified, the default is just to show candidates belonging to your partner.";
     } else {
-      s = "If nothing is specified, the default is to show candidates managed by any partner";
+      s = "If nothing is specified, the default is to show candidates managed by any partner.";
     }
 
     return s;


### PR DESCRIPTION
The extra touches are advised as accessibility measures, per https://getbootstrap.com/docs/5.0/components/tooltips/#markup

Also lightly edited the copy to make it more easily readable — doing so required some styling on the tips.

Open to suggestions here and I realise the changes go a little further than the issue outline, so I'm very happy to undo any parts not required - but to my eyes this streamlines the search menu while retaining the key info and its accessibility. 

<img width="1052" alt="Screenshot 2023-08-09 at 11 54 30 am" src="https://github.com/Talent-Catalog/talentcatalog/assets/111261894/44e34947-25e8-477e-ac5e-03019aa23214">
<img width="452" alt="Screenshot 2023-08-09 at 11 47 39 am" src="https://github.com/Talent-Catalog/talentcatalog/assets/111261894/c683aab8-ec49-4b00-b437-d6ad3ea29658">
<img width="714" alt="Screenshot 2023-08-09 at 11 47 33 am" src="https://github.com/Talent-Catalog/talentcatalog/assets/111261894/f5ce1931-a7e4-41a3-aa5a-2e52072b1ff5">
<img width="481" alt="Screenshot 2023-08-09 at 11 47 59 am" src="https://github.com/Talent-Catalog/talentcatalog/assets/111261894/8a3d48b2-699f-4f2b-85f5-959bb3271679">
<img width="473" alt="Screenshot 2023-08-09 at 11 47 47 am" src="https://github.com/Talent-Catalog/talentcatalog/assets/111261894/ad26856c-1d94-