### PR TITLE
Publishing of submission lists to Google Sheets should exclude closed cases

### DIFF
--- a/server/src/main/java/org/tbbtalent/server/request/candidate/PublishListRequest.java
+++ b/server/src/main/java/org/tbbtalent/server/request/candidate/PublishListRequest.java
@@ -37,6 +37,13 @@ public class PublishListRequest {
   private List<PublishedDocColumnConfig> columns;
 
   /**
+   * If not null, indicates that this list is associated with a job (eg a submission list), and
+   * the boolean value indicates whether to publish candidates who have closed opportunities for
+   * the job.
+   */
+  private Boolean publishClosedOpps;
+
+  /**
    * This extracts the corresponding ExportColumn information - this is what is stored on the 
    * server. 
    */

--- a/server/src/main/java/org/tbbtalent/server/service/db/impl/SavedListServiceImpl.java
+++ b/server/src/main/java/org/tbbtalent/server/service/db/impl/SavedListServiceImpl.java
@@ -931,7 +931,7 @@ public class SavedListServiceImpl implements SavedListService {
         if (sfJob != null && 
             request.getPublishClosedOpps() != null && !request.getPublishClosedOpps()) {
             //For job lists where publishClosedOpps is false, filter out closed opps (unless they
-            // are "won" - we always publish won opps, which a special kind of closed). 
+            //are "won" - we always publish won opps, which are a special kind of closed). 
             candidates = savedList.getCandidates().stream().filter(
                 candidate -> {
                     return candidate.getCandidateOpportunities().stream()

--- a/server/src/main/java/org/tbbtalent/server/service/db/impl/SavedListServiceImpl.java
+++ b/server/src/main/java/org/tbbtalent/server/service/db/impl/SavedListServiceImpl.java
@@ -925,8 +925,26 @@ public class SavedListServiceImpl implements SavedListService {
 
         String publishedSheetDataRangeName = googleDriveConfig.getPublishedSheetDataRangeName();
 
-        //Fetch candidates in list
-        List<Candidate> candidates = new ArrayList<>(savedList.getCandidates());
+        //Candidates to publish
+        List<Candidate> candidates;
+        SalesforceJobOpp sfJob = savedList.getSfJobOpp();
+        if (sfJob != null && 
+            request.getPublishClosedOpps() != null && !request.getPublishClosedOpps()) {
+            //For job lists where publishClosedOpps is false, filter out closed opps (unless they
+            // are "won" - we always publish won opps, which a special kind of closed). 
+            candidates = savedList.getCandidates().stream().filter(
+                candidate -> {
+                    return candidate.getCandidateOpportunities().stream()
+                        .anyMatch(opp -> {
+                            return opp.getJobOpp().getId().equals(sfJob.getId()) 
+                                && (opp.isWon() || !opp.isClosed()); 
+                        });
+                }
+            ).toList();
+        } else {
+            //Publish all for non job lists, or job lists where we have been asked to publish all 
+            candidates = new ArrayList<>(savedList.getCandidates());
+        }
 
         //Create an empty doc - leaving room for the number of candidates
         String link = docPublisherService.createPublishedDoc(listFolder, savedList.getName(),

--- a/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.ts
+++ b/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.ts
@@ -655,6 +655,9 @@ export class ShowCandidatesComponent implements OnInit, OnChanges, OnDestroy {
 
     //Construct the request
     const request: PublishListRequest = new PublishListRequest();
+    if (this.isJobList()) {
+      request.publishClosedOpps = this.showClosedOpps;
+    }
     request.columns = exportColumns;
 
     this.savedListService.publish(this.candidateSource.id, request).subscribe(

--- a/ui/admin-portal/src/app/model/saved-list.ts
+++ b/ui/admin-portal/src/app/model/saved-list.ts
@@ -223,6 +223,7 @@ export class ExportColumn {
 }
 
 export class PublishListRequest {
+  publishClosedOpps?: boolean;
   columns: PublishedDocColumnConfig[] = [];
 }
 


### PR DESCRIPTION
Publish list will publish all visible candidate opportunities - where visibility is determined by the ShowClosedOpps flag.

Add publishClosedOpps to PublishList Request