### PR TITLE
198 unit tests for candidate admin apis part 2

### DIFF
--- a/server/src/main/java/org/tbbtalent/server/api/admin/CandidateJobExperienceAdminApi.java
+++ b/server/src/main/java/org/tbbtalent/server/api/admin/CandidateJobExperienceAdminApi.java
@@ -16,7 +16,7 @@
 
 package org.tbbtalent.server.api.admin;
 
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -33,18 +33,15 @@ import java.util.Map;
 
 @RestController()
 @RequestMapping("/api/admin/candidate-job-experience")
+@RequiredArgsConstructor
 public class CandidateJobExperienceAdminApi {
 
     private final CandidateJobExperienceService candidateJobExperienceService;
 
-    @Autowired
-    public CandidateJobExperienceAdminApi(CandidateJobExperienceService candidateJobExperienceService) {
-        this.candidateJobExperienceService = candidateJobExperienceService;
-    }
-
     @PostMapping("search")
     public Map<String, Object> search(@RequestBody SearchJobExperienceRequest request) {
-        Page<CandidateJobExperience> candidateJobExperiences = this.candidateJobExperienceService.searchCandidateJobExperience(request);
+        Page<CandidateJobExperience> candidateJobExperiences =
+                candidateJobExperienceService.searchCandidateJobExperience(request);
         return candidateJobExperienceDto().buildPage(candidateJobExperiences);
     }
 
@@ -52,19 +49,21 @@ public class CandidateJobExperienceAdminApi {
     public Map<String, Object> create(@Valid @PathVariable("id") Long candidateId,
                                       @RequestBody CreateJobExperienceRequest request) throws EntityExistsException {
         request.setCandidateId(candidateId);
-        CandidateJobExperience candidateJobExperience = this.candidateJobExperienceService.createCandidateJobExperience(request);
+        CandidateJobExperience candidateJobExperience =
+                candidateJobExperienceService.createCandidateJobExperience(request);
         return candidateJobExperienceDto().build(candidateJobExperience);
     }
 
     @PutMapping("{id}")
     public Map<String, Object> update(@PathVariable("id") Long id,
                                       @RequestBody UpdateJobExperienceRequest request) {
-        CandidateJobExperience candidateJobExperience = this.candidateJobExperienceService.updateCandidateJobExperience(id, request);
+        CandidateJobExperience candidateJobExperience =
+                candidateJobExperienceService.updateCandidateJobExperience(id, request);
         return candidateJobExperienceDto().build(candidateJobExperience);
     }
 
     @DeleteMapping("{id}")
-    public ResponseEntity delete(@PathVariable("id") Long id) {
+    public ResponseEntity<Void> delete(@PathVariable("id") Long id) {
         candidateJobExperienceService.deleteCandidateJobExperience(id);
         return ResponseEntity.ok().build();
     }

--- a/server/src/main/java/org/tbbtalent/server/api/admin/CandidateLanguageAdminApi.java
+++ b/server/src/main/java/org/tbbtalent/server/api/admin/CandidateLanguageAdminApi.java
@@ -16,7 +16,7 @@
 
 package org.tbbtalent.server.api.admin;
 
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.tbbtalent.server.exception.UsernameTakenException;
@@ -29,42 +29,36 @@ import org.tbbtalent.server.util.dto.DtoBuilder;
 import java.util.List;
 import java.util.Map;
 
-@RestController()
+@RestController
 @RequestMapping("/api/admin/candidate-language")
+@RequiredArgsConstructor
 public class CandidateLanguageAdminApi {
 
     private final CandidateLanguageService candidateLanguageService;
 
-    @Autowired
-    public CandidateLanguageAdminApi(CandidateLanguageService candidateLanguageService) {
-        this.candidateLanguageService = candidateLanguageService;
-    }
-
-
     @GetMapping("{id}/list")
     public List<Map<String, Object>> get(@PathVariable("id") long id) {
-        List<CandidateLanguage> candidateLanguages = this.candidateLanguageService.list(id);
+        List<CandidateLanguage> candidateLanguages = candidateLanguageService.list(id);
         return candidateLanguageDto().buildList(candidateLanguages);
     }
 
-    @PostMapping()
+    @PostMapping
     public Map<String, Object> create(@RequestBody CreateCandidateLanguageRequest request) throws UsernameTakenException {
-        CandidateLanguage candidateLanguage = this.candidateLanguageService.createCandidateLanguage(request);
+        CandidateLanguage candidateLanguage = candidateLanguageService.createCandidateLanguage(request);
         return candidateLanguageDto().build(candidateLanguage);
     }
 
-    @PutMapping()
+    @PutMapping
     public Map<String, Object> update(@RequestBody UpdateCandidateLanguageRequest request) {
-        CandidateLanguage candidateLanguage = this.candidateLanguageService.updateCandidateLanguage(request);
+        CandidateLanguage candidateLanguage = candidateLanguageService.updateCandidateLanguage(request);
         return candidateLanguageDto().build(candidateLanguage);
     }
 
     @DeleteMapping("{id}")
-    public ResponseEntity delete(@PathVariable("id") Long id) {
-        this.candidateLanguageService.deleteCandidateLanguage(id);
+    public ResponseEntity<Void> delete(@PathVariable("id") Long id) {
+        candidateLanguageService.deleteCandidateLanguage(id);
         return ResponseEntity.ok().build();
     }
-
 
     private DtoBuilder candidateLanguageDto() {
         return new DtoBuilder()

--- a/server/src/main/java/org/tbbtalent/server/api/admin/CandidateNoteAdminApi.java
+++ b/server/src/main/java/org/tbbtalent/server/api/admin/CandidateNoteAdminApi.java
@@ -18,7 +18,8 @@ package org.tbbtalent.server.api.admin;
 
 import java.util.Map;
 import javax.validation.Valid;
-import org.springframework.beans.factory.annotation.Autowired;
+
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -36,34 +37,29 @@ import org.tbbtalent.server.util.dto.DtoBuilder;
 
 @RestController()
 @RequestMapping("/api/admin/candidate-note")
+@RequiredArgsConstructor
 public class CandidateNoteAdminApi {
 
     private final CandidateNoteService candidateNoteService;
 
-    @Autowired
-    public CandidateNoteAdminApi(CandidateNoteService candidateNoteService) {
-        this.candidateNoteService = candidateNoteService;
-    }
-
     @PostMapping("search")
     public Map<String, Object> search(@RequestBody SearchCandidateNotesRequest request) {
-        Page<CandidateNote> candidateNotes = this.candidateNoteService.searchCandidateNotes(request);
+        Page<CandidateNote> candidateNotes = candidateNoteService.searchCandidateNotes(request);
         return candidateNoteDto().buildPage(candidateNotes);
     }
 
     @PostMapping
     public Map<String, Object> create(@Valid @RequestBody CreateCandidateNoteRequest request) throws EntityExistsException {
-        CandidateNote candidateNote = this.candidateNoteService.createCandidateNote(request);
+        CandidateNote candidateNote = candidateNoteService.createCandidateNote(request);
         return candidateNoteDto().build(candidateNote);
     }
 
     @PutMapping("{id}")
     public Map<String, Object> update(@PathVariable("id") long id,
                                       @RequestBody UpdateCandidateNoteRequest request) {
-        CandidateNote candidateNote = this.candidateNoteService.updateCandidateNote(id, request);
+        CandidateNote candidateNote = candidateNoteService.updateCandidateNote(id, request);
         return candidateNoteDto().build(candidateNote);
     }
-
 
     private DtoBuilder candidateNoteDto() {
         return new DtoBuilder()

--- a/server/src/main/java/org/tbbtalent/server/api/admin/CandidateOccupationAdminApi.java
+++ b/server/src/main/java/org/tbbtalent/server/api/admin/CandidateOccupationAdminApi.java
@@ -21,7 +21,7 @@ import java.util.Map;
 
 import javax.validation.Valid;
 
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -40,30 +40,26 @@ import org.tbbtalent.server.util.dto.DtoBuilder;
 
 @RestController()
 @RequestMapping("/api/admin/candidate-occupation")
+@RequiredArgsConstructor
 public class CandidateOccupationAdminApi {
 
     private final CandidateOccupationService candidateOccupationService;
 
-    @Autowired
-    public CandidateOccupationAdminApi(CandidateOccupationService candidateOccupationService) {
-        this.candidateOccupationService = candidateOccupationService;
-    }
-
     @GetMapping("verified")
     public List<Map<String, Object>> getVerifiedOccupations() {
-        List<Occupation> candidateOccupations = this.candidateOccupationService.listVerifiedOccupations();
+        List<Occupation> candidateOccupations = candidateOccupationService.listVerifiedOccupations();
         return occupationDto().buildList(candidateOccupations);
     }
 
     @GetMapping("occupation")
     public List<Map<String, Object>> getAllOccupations() {
-        List<Occupation> candidateOccupations = this.candidateOccupationService.listOccupations();
+        List<Occupation> candidateOccupations = candidateOccupationService.listOccupations();
         return occupationDto().buildList(candidateOccupations);
     }
 
     @GetMapping("{id}/list")
     public List<Map<String, Object>> get(@PathVariable("id") long candidateId) {
-        List<CandidateOccupation> candidateOccupations = this.candidateOccupationService.listCandidateOccupations(candidateId);
+        List<CandidateOccupation> candidateOccupations = candidateOccupationService.listCandidateOccupations(candidateId);
         return candidateOccupationDto().buildList(candidateOccupations);
     }
 
@@ -71,20 +67,20 @@ public class CandidateOccupationAdminApi {
     public Map<String, Object> update(@PathVariable("id") long id,
                                       @RequestBody VerifyCandidateOccupationRequest request) {
         request.setId(id);
-        CandidateOccupation candidateOccupation = this.candidateOccupationService.verifyCandidateOccupation(request);
+        CandidateOccupation candidateOccupation = candidateOccupationService.verifyCandidateOccupation(request);
         return candidateOccupationDto().build(candidateOccupation);
     }
 
     @PostMapping("{id}")
     public Map<String, Object> create(@Valid @PathVariable("id") Long candidateId,
-                                                         @Valid @RequestBody CreateCandidateOccupationRequest request) {
+                                      @Valid @RequestBody CreateCandidateOccupationRequest request) {
         request.setCandidateId(candidateId);
         CandidateOccupation candidateOccupation = candidateOccupationService.createCandidateOccupation(request);
         return candidateOccupationDto().build(candidateOccupation);
     }
 
     @DeleteMapping("{id}")
-    public ResponseEntity delete(@PathVariable("id") Long id) {
+    public ResponseEntity<Void> delete(@PathVariable("id") Long id) {
         candidateOccupationService.deleteCandidateOccupation(id);
         return ResponseEntity.ok().build();
     }

--- a/server/src/main/java/org/tbbtalent/server/api/admin/CandidateOpportunityAdminApi.java
+++ b/server/src/main/java/org/tbbtalent/server/api/admin/CandidateOpportunityAdminApi.java
@@ -19,8 +19,11 @@ package org.tbbtalent.server.api.admin;
 import java.util.Map;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -34,19 +37,18 @@ import org.tbbtalent.server.request.candidate.opportunity.SearchCandidateOpportu
 import org.tbbtalent.server.service.db.CandidateOpportunityService;
 import org.tbbtalent.server.util.dto.DtoBuilder;
 
-@RestController()
+@RestController
 @RequestMapping("/api/admin/opp")
-public class CandidateOpportunityAdminApi implements
-    ITableApi<SearchCandidateOpportunityRequest, CandidateOpportunityParams, CandidateOpportunityParams> {
+@RequiredArgsConstructor
+public class CandidateOpportunityAdminApi implements ITableApi<SearchCandidateOpportunityRequest,
+                                                               CandidateOpportunityParams,
+                                                               CandidateOpportunityParams> {
 
     private final CandidateOpportunityService candidateOpportunityService;
-    public CandidateOpportunityAdminApi(CandidateOpportunityService candidateOpportunityService) {
-        this.candidateOpportunityService = candidateOpportunityService;
-    }
 
     @Override
     @GetMapping("{id}")
-    public @NotNull Map<String, Object> get(long id) throws NoSuchObjectException {
+    public @NotNull Map<String, Object> get(@PathVariable long id) throws NoSuchObjectException {
         CandidateOpportunity opp = candidateOpportunityService.getCandidateOpportunity(id);
         return candidateOpportunityDto().build(opp);
     }
@@ -61,7 +63,7 @@ public class CandidateOpportunityAdminApi implements
 
     @Override
     @PutMapping("{id}")
-    public @NotNull Map<String, Object> update(long id, CandidateOpportunityParams request)
+    public @NotNull Map<String, Object> update(@PathVariable long id, CandidateOpportunityParams request)
         throws EntityExistsException, InvalidRequestException, NoSuchObjectException {
         CandidateOpportunity opp = candidateOpportunityService.updateCandidateOpportunity(id, request);
         return candidateOpportunityDto().build(opp);

--- a/server/src/main/java/org/tbbtalent/server/api/admin/CandidateReviewStatusAdminApi.java
+++ b/server/src/main/java/org/tbbtalent/server/api/admin/CandidateReviewStatusAdminApi.java
@@ -20,7 +20,7 @@ import java.util.Map;
 
 import javax.validation.Valid;
 
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -35,36 +35,31 @@ import org.tbbtalent.server.request.reviewstatus.UpdateCandidateReviewStatusRequ
 import org.tbbtalent.server.service.db.CandidateReviewStatusService;
 import org.tbbtalent.server.util.dto.DtoBuilder;
 
-@RestController()
+@RestController
 @RequestMapping("/api/admin/candidate-reviewstatus")
+@RequiredArgsConstructor
 public class CandidateReviewStatusAdminApi {
 
     private final CandidateReviewStatusService candidateReviewStatusService;
 
-    @Autowired
-    public CandidateReviewStatusAdminApi(CandidateReviewStatusService candidateReviewStatusService) {
-        this.candidateReviewStatusService = candidateReviewStatusService;
-    }
-
     @GetMapping("{id}")
     public Map<String, Object> get(@PathVariable("id") long id) {
-        CandidateReviewStatusItem reviewStatusItem = this.candidateReviewStatusService.getCandidateReviewStatusItem(id);
+        CandidateReviewStatusItem reviewStatusItem = candidateReviewStatusService.getCandidateReviewStatusItem(id);
         return candidateReviewStatusDto().build(reviewStatusItem);
     }
 
     @PostMapping
     public Map<String, Object> create(@Valid @RequestBody CreateCandidateReviewStatusRequest request) throws EntityExistsException {
-        CandidateReviewStatusItem candidateReviewStatusItem = this.candidateReviewStatusService.createCandidateReviewStatusItem(request);
+        CandidateReviewStatusItem candidateReviewStatusItem = candidateReviewStatusService.createCandidateReviewStatusItem(request);
         return candidateReviewStatusDto().build(candidateReviewStatusItem);
     }
 
     @PutMapping("{id}")
     public Map<String, Object> update(@PathVariable("id") long id,
                                       @RequestBody UpdateCandidateReviewStatusRequest request) {
-        CandidateReviewStatusItem candidateReviewStatusItem = this.candidateReviewStatusService.updateCandidateReviewStatusItem(id, request);
+        CandidateReviewStatusItem candidateReviewStatusItem = candidateReviewStatusService.updateCandidateReviewStatusItem(id, request);
         return candidateReviewStatusDto().build(candidateReviewStatusItem);
     }
-
 
     private DtoBuilder candidateReviewStatusDto() {
         return new DtoBuilder()
@@ -85,10 +80,5 @@ public class CandidateReviewStatusAdminApi {
                 .add("lastName")
                 ;
     }
-
-
-
-
-
 
 }

--- a/server/src/main/java/org/tbbtalent/server/model/db/CandidateJobExperience.java
+++ b/server/src/main/java/org/tbbtalent/server/model/db/CandidateJobExperience.java
@@ -16,6 +16,10 @@
 
 package org.tbbtalent.server.model.db;
 
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
 import java.time.LocalDate;
 
 import javax.persistence.Entity;
@@ -25,9 +29,12 @@ import javax.persistence.ManyToOne;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 
+@Getter
+@Setter
 @Entity
 @Table(name = "candidate_job_experience")
 @SequenceGenerator(name = "seq_gen", sequenceName = "candidate_job_experience_id_seq", allocationSize = 1)
+@NoArgsConstructor
 public class CandidateJobExperience extends AbstractDomainObject<Long> {
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -50,10 +57,9 @@ public class CandidateJobExperience extends AbstractDomainObject<Long> {
     private Boolean paid;
     private String description;
 
-    public CandidateJobExperience() {
-    }
-
-    public CandidateJobExperience(Candidate candidate, Country country, CandidateOccupation candidateOccupation, String companyName, String role, LocalDate startDate, LocalDate endDate, String description) {
+    public CandidateJobExperience(Candidate candidate, Country country, CandidateOccupation candidateOccupation,
+                                  String companyName, String role, LocalDate startDate, LocalDate endDate,
+                                  String description) {
 
         this.candidate = candidate;
         this.country = country;
@@ -64,58 +70,5 @@ public class CandidateJobExperience extends AbstractDomainObject<Long> {
         this.endDate = endDate;
         this.description = description;
     }
-
-    public Candidate getCandidate() {
-        return candidate;
-    }
-
-    public void setCandidate(Candidate candidate) {
-        this.candidate = candidate;
-    }
-
-    public String getCompanyName() { return companyName; }
-
-    public void setCompanyName(String companyName) { this.companyName = companyName; }
-
-    public Country getCountry() { return country; }
-
-    public void setCountry(Country country) { this.country = country; }
-
-    public CandidateOccupation getCandidateOccupation() {
-        return candidateOccupation;
-    }
-
-    public void setCandidateOccupation(CandidateOccupation candidateOccupation) {
-        this.candidateOccupation = candidateOccupation;
-    }
-
-    public String getRole() {
-        return role;
-    }
-
-    public void setRole(String role) {
-        this.role = role;
-    }
-
-    public LocalDate getStartDate() { return startDate; }
-
-    public void setStartDate(LocalDate startDate) { this.startDate = startDate; }
-
-    public LocalDate getEndDate() { return endDate; }
-
-    public void setEndDate(LocalDate endDate) { this.endDate = endDate; }
-
-    public Boolean getFullTime() { return fullTime; }
-
-    public void setFullTime(Boolean fullTime) { this.fullTime = fullTime; }
-
-    public Boolean getPaid() { return paid; }
-
-    public void setPaid(Boolean paid) { this.paid = paid; }
-
-    public String getDescription() { return description; }
-
-    public void setDescription(String description) { this.description = description; }
-
 
 }

--- a/server/src/main/java/org/tbbtalent/server/model/db/CandidateLanguage.java
+++ b/server/src/main/java/org/tbbtalent/server/model/db/CandidateLanguage.java
@@ -16,6 +16,10 @@
 
 package org.tbbtalent.server.model.db;
 
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.JoinColumn;
@@ -23,9 +27,12 @@ import javax.persistence.ManyToOne;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 
+@Getter
+@Setter
 @Entity
 @Table(name = "candidate_language")
 @SequenceGenerator(name = "seq_gen", sequenceName = "candidate_language_id_seq", allocationSize = 1)
+@NoArgsConstructor
 public class CandidateLanguage  extends AbstractDomainObject<Long> {
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -46,54 +53,14 @@ public class CandidateLanguage  extends AbstractDomainObject<Long> {
 
     private String migrationLanguage;
 
-    public CandidateLanguage() {
-    }
 
-    public CandidateLanguage(Candidate candidate, Language language, LanguageLevel writtenLevel, LanguageLevel spokenLevel) {
+    public CandidateLanguage(Candidate candidate, Language language, LanguageLevel writtenLevel,
+                             LanguageLevel spokenLevel) {
+
         this.candidate = candidate;
         this.language = language;
         this.writtenLevel = writtenLevel;
         this.spokenLevel = spokenLevel;
     }
 
-    public Candidate getCandidate() {
-        return candidate;
-    }
-
-    public void setCandidate(Candidate candidate) {
-        this.candidate = candidate;
-    }
-
-    public Language getLanguage() {
-        return language;
-    }
-
-    public void setLanguage(Language language) {
-        this.language = language;
-    }
-
-    public LanguageLevel getWrittenLevel() {
-        return writtenLevel;
-    }
-
-    public void setWrittenLevel(LanguageLevel writtenLevel) {
-        this.writtenLevel = writtenLevel;
-    }
-
-    public LanguageLevel getSpokenLevel() {
-        return spokenLevel;
-    }
-
-    public void setSpokenLevel(LanguageLevel spokenLevel) {
-        this.spokenLevel = spokenLevel;
-    }
-
-    public String getMigrationLanguage() {
-        return migrationLanguage;
-    }
-
-    public void setMigrationLanguage(String migrationLanguage) {
-        this.migrationLanguage = migrationLanguage;
-    }
 }
-

--- a/server/src/main/java/org/tbbtalent/server/model/db/CandidateNote.java
+++ b/server/src/main/java/org/tbbtalent/server/model/db/CandidateNote.java
@@ -16,6 +16,10 @@
 
 package org.tbbtalent.server.model.db;
 
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
@@ -25,9 +29,12 @@ import javax.persistence.ManyToOne;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 
+@Getter
+@Setter
 @Entity
 @Table(name = "candidate_note")
 @SequenceGenerator(name = "seq_gen", sequenceName = "candidate_note_id_seq", allocationSize = 1)
+@NoArgsConstructor
 public class CandidateNote extends AbstractAuditableDomainObject<Long>  {
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -36,41 +43,8 @@ public class CandidateNote extends AbstractAuditableDomainObject<Long>  {
 
     private String title;
     private String comment;
+
     @Enumerated(EnumType.STRING)
     private NoteType noteType;
 
-    public CandidateNote() {
-    }
-
-    public Candidate getCandidate() {
-        return candidate;
-    }
-
-    public void setCandidate(Candidate candidate) {
-        this.candidate = candidate;
-    }
-
-    public String getTitle() {
-        return title;
-    }
-
-    public void setTitle(String title) {
-        this.title = title;
-    }
-
-    public String getComment() {
-        return comment;
-    }
-
-    public void setComment(String comment) {
-        this.comment = comment;
-    }
-
-    public NoteType getNoteType() {
-        return noteType;
-    }
-
-    public void setNoteType(NoteType noteType) {
-        this.noteType = noteType;
-    }
 }

--- a/server/src/main/java/org/tbbtalent/server/model/db/CandidateOccupation.java
+++ b/server/src/main/java/org/tbbtalent/server/model/db/CandidateOccupation.java
@@ -16,6 +16,10 @@
 
 package org.tbbtalent.server.model.db;
 
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
 import java.util.List;
 
 import javax.persistence.CascadeType;
@@ -27,11 +31,13 @@ import javax.persistence.OneToMany;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 
+@Getter
+@Setter
 @Entity
 @Table(name = "candidate_occupation")
 @SequenceGenerator(name = "seq_gen", sequenceName = "candidate_occupation_id_seq", allocationSize = 1)
+@NoArgsConstructor
 public class CandidateOccupation extends AbstractAuditableDomainObject<Long> {
-
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "candidate_id")
@@ -53,8 +59,6 @@ public class CandidateOccupation extends AbstractAuditableDomainObject<Long> {
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "candidateOccupation", cascade = CascadeType.ALL)
     private List<CandidateJobExperience> candidateJobExperiences;
 
-    public CandidateOccupation() {
-    }
 
     public CandidateOccupation(Candidate candidate, Occupation occupation, Long yearsExperience) {
         this.candidate = candidate;
@@ -62,55 +66,4 @@ public class CandidateOccupation extends AbstractAuditableDomainObject<Long> {
         this.yearsExperience = yearsExperience;
     }
 
-    public Candidate getCandidate() {
-        return candidate;
-    }
-
-    public void setCandidate(Candidate candidate) {
-        this.candidate = candidate;
-    }
-
-    public Occupation getOccupation() {
-        return occupation;
-    }
-
-    public void setOccupation(Occupation occupation) {
-        this.occupation = occupation;
-    }
-
-    public Long getYearsExperience() {
-        return yearsExperience;
-    }
-
-    public void setYearsExperience(Long yearsExperience) {
-        this.yearsExperience = yearsExperience;
-    }
-
-    public boolean isVerified() {
-        return verified;
-    }
-
-    public void setVerified(boolean verified) {
-        this.verified = verified;
-    }
-
-    public Boolean getTopCandidate() {
-        return topCandidate;
-    }
-
-    public void setTopCandidate(Boolean topCandidate) {
-        this.topCandidate = topCandidate;
-    }
-
-    public String getMigrationOccupation() {
-        return migrationOccupation;
-    }
-
-    public void setMigrationOccupation(String migrationOccupation) {
-        this.migrationOccupation = migrationOccupation;
-    }
-
-    public List<CandidateJobExperience> getCandidateJobExperiences() { return candidateJobExperiences; }
-
-    public void setCandidateJobExperiences(List<CandidateJobExperience> candidateJobExperiences) { this.candidateJobExperiences = candidateJobExperiences; }
 }

--- a/server/src/main/java/org/tbbtalent/server/model/db/CandidateReviewStatusItem.java
+++ b/server/src/main/java/org/tbbtalent/server/model/db/CandidateReviewStatusItem.java
@@ -16,6 +16,10 @@
 
 package org.tbbtalent.server.model.db;
 
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
@@ -36,9 +40,12 @@ import javax.persistence.Table;
  * - setting the reviewStatus to {@link ReviewStatus#rejected}. Then the candidate will not longer
  * appear in the search (unless you explicitly ask to see candidates rejected from the search).
  */
+@Getter
+@Setter
 @Entity
 @Table(name = "candidate_review_item")
 @SequenceGenerator(name = "seq_gen", sequenceName = "candidate_review_item_id_seq", allocationSize = 1)
+@NoArgsConstructor
 public class CandidateReviewStatusItem extends AbstractAuditableDomainObject<Long>  {
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -54,38 +61,4 @@ public class CandidateReviewStatusItem extends AbstractAuditableDomainObject<Lon
     @Enumerated(EnumType.STRING)
     private ReviewStatus reviewStatus;
 
-    public CandidateReviewStatusItem() {
-    }
-
-    public Candidate getCandidate() {
-        return candidate;
-    }
-
-    public void setCandidate(Candidate candidate) {
-        this.candidate = candidate;
-    }
-
-    public SavedSearch getSavedSearch() {
-        return savedSearch;
-    }
-
-    public void setSavedSearch(SavedSearch savedSearch) {
-        this.savedSearch = savedSearch;
-    }
-
-    public String getComment() {
-        return comment;
-    }
-
-    public void setComment(String comment) {
-        this.comment = comment;
-    }
-
-    public ReviewStatus getReviewStatus() {
-        return reviewStatus;
-    }
-
-    public void setReviewStatus(ReviewStatus reviewStatus) {
-        this.reviewStatus = reviewStatus;
-    }
 }

--- a/server/src/main/java/org/tbbtalent/server/model/db/Language.java
+++ b/server/src/main/java/org/tbbtalent/server/model/db/Language.java
@@ -22,6 +22,7 @@ import javax.persistence.Enumerated;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Entity
@@ -29,6 +30,7 @@ import lombok.Setter;
 @SequenceGenerator(name = "seq_gen", sequenceName = "language_id_seq", allocationSize = 1)
 @Getter
 @Setter
+@NoArgsConstructor
 public class Language  extends AbstractTranslatableDomainObject<Long> {
 
     /**
@@ -38,9 +40,6 @@ public class Language  extends AbstractTranslatableDomainObject<Long> {
 
     @Enumerated(EnumType.STRING)
     private Status status;
-
-    public Language() {
-    }
 
     public Language(String name, Status status) {
         setName(name);

--- a/server/src/main/java/org/tbbtalent/server/model/db/LanguageLevel.java
+++ b/server/src/main/java/org/tbbtalent/server/model/db/LanguageLevel.java
@@ -16,23 +16,28 @@
 
 package org.tbbtalent.server.model.db;
 
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 
+@Getter
+@Setter
 @Entity
 @Table(name = "language_level")
 @SequenceGenerator(name = "language_level_gen", sequenceName = "language_level_id_seq", allocationSize = 1)
+@NoArgsConstructor
 public class LanguageLevel extends AbstractTranslatableDomainObject<Long> {
 
     private int level;
+
     @Enumerated(EnumType.STRING)
     private Status status;
-
-    public LanguageLevel() {
-    }
 
     public LanguageLevel(String name, Status status, int level) {
         setName(name);
@@ -40,19 +45,4 @@ public class LanguageLevel extends AbstractTranslatableDomainObject<Long> {
         this.level = level;
     }
 
-    public int getLevel() {
-        return level;
-    }
-
-    public void setLevel(int level) {
-        this.level = level;
-    }
-
-    public Status getStatus() {
-        return status;
-    }
-
-    public void setStatus(Status status) {
-        this.status = status;
-    }
 }

--- a/server/src/main/java/org/tbbtalent/server/model/db/Occupation.java
+++ b/server/src/main/java/org/tbbtalent/server/model/db/Occupation.java
@@ -16,6 +16,10 @@
 
 package org.tbbtalent.server.model.db;
 
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -23,9 +27,12 @@ import javax.persistence.Enumerated;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 
+@Getter
+@Setter
 @Entity
 @Table(name = "occupation")
 @SequenceGenerator(name = "seq_gen", sequenceName = "occupation_id_seq", allocationSize = 1)
+@NoArgsConstructor
 public class Occupation extends AbstractTranslatableDomainObject<Long> {
 
     @Column(name = "isco08_code")
@@ -34,27 +41,9 @@ public class Occupation extends AbstractTranslatableDomainObject<Long> {
     @Enumerated(EnumType.STRING)
     private Status status;
 
-    public Occupation() {
-    }
-
     public Occupation(String name, Status status) {
         setName(name);
         this.status = status;
     }
 
-    public String getIsco08Code() {
-        return isco08Code;
-    }
-
-    public void setIsco08Code(String isco08Code) {
-        this.isco08Code = isco08Code;
-    }
-
-    public Status getStatus() {
-        return status;
-    }
-
-    public void setStatus(Status status) {
-        this.status = status;
-    }
 }

--- a/server/src/main/java/org/tbbtalent/server/request/candidate/language/CreateCandidateLanguageRequest.java
+++ b/server/src/main/java/org/tbbtalent/server/request/candidate/language/CreateCandidateLanguageRequest.java
@@ -15,8 +15,12 @@
  */
 
 package org.tbbtalent.server.request.candidate.language;
+import lombok.Getter;
+import lombok.Setter;
 import org.springframework.lang.Nullable;
 
+@Getter
+@Setter
 public class CreateCandidateLanguageRequest {
     //todo make subclass? But then need two different methods in service taking in two different requests
     /**
@@ -30,21 +34,4 @@ public class CreateCandidateLanguageRequest {
     private Long writtenLevelId;
     private Long spokenLevelId;
 
-    @Nullable
-    public Long getCandidateId() { return candidateId; }
-
-    public void setCandidateId(@Nullable Long candidateId) { this.candidateId = candidateId; }
-
-    public Long getLanguageId() { return languageId; }
-
-    public void setLanguageId(Long languageId) { this.languageId = languageId; }
-
-    public Long getWrittenLevelId() { return writtenLevelId; }
-
-    public void setWrittenLevelId(Long writtenLevelId) { this.writtenLevelId = writtenLevelId; }
-
-    public Long getSpokenLevelId() { return spokenLevelId; }
-
-    public void setSpokenLevelId(Long spokenLevelId) { this.spokenLevelId = spokenLevelId;
-    }
 }

--- a/server/src/main/java/org/tbbtalent/server/request/candidate/language/UpdateCandidateLanguageRequest.java
+++ b/server/src/main/java/org/tbbtalent/server/request/candidate/language/UpdateCandidateLanguageRequest.java
@@ -16,6 +16,11 @@
 
 package org.tbbtalent.server.request.candidate.language;
 
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
 public class UpdateCandidateLanguageRequest {
 
     private Long id;
@@ -23,19 +28,4 @@ public class UpdateCandidateLanguageRequest {
     private Long writtenLevelId;
     private Long spokenLevelId;
 
-    public Long getId() { return id; }
-
-    public void setId(Long id) { this.id = id; }
-
-    public Long getLanguageId() { return languageId; }
-
-    public void setLanguageId(Long languageId) { this.languageId = languageId; }
-
-    public Long getWrittenLevelId() { return writtenLevelId; }
-
-    public void setWrittenLevelId(Long writtenLevelId) { this.writtenLevelId = writtenLevelId; }
-
-    public Long getSpokenLevelId() { return spokenLevelId; }
-
-    public void setSpokenLevelId(Long spokenLevelId) { this.spokenLevelId = spokenLevelId; }
 }

--- a/server/src/main/java/org/tbbtalent/server/request/candidate/occupation/CreateCandidateOccupationRequest.java
+++ b/server/src/main/java/org/tbbtalent/server/request/candidate/occupation/CreateCandidateOccupationRequest.java
@@ -16,44 +16,26 @@
 
 package org.tbbtalent.server.request.candidate.occupation;
 
+import lombok.Getter;
+import lombok.Setter;
+
 import javax.validation.constraints.NotNull;
 
+@Getter
+@Setter
 public class CreateCandidateOccupationRequest {
 
     private Long candidateId;
+
     @NotNull
     private Long occupationId;
+
     @NotNull
     private Long yearsExperience;
+
     @NotNull
     private boolean verified;
+
     private String comment;
 
-    public Long getCandidateId() { return candidateId; }
-
-    public void setCandidateId(Long candidateId) { this.candidateId = candidateId; }
-
-    public Long getOccupationId() {
-        return occupationId;
-    }
-
-    public void setOccupationId(Long occupationId) {
-        this.occupationId = occupationId;
-    }
-
-    public Long getYearsExperience() {
-        return yearsExperience;
-    }
-
-    public void setYearsExperience(Long yearsExperience) {
-        this.yearsExperience = yearsExperience;
-    }
-
-    public boolean isVerified() { return verified; }
-
-    public void setVerified(boolean verified) { this.verified = verified; }
-
-    public String getComment() { return comment; }
-
-    public void setComment(String comment) { this.comment = comment; }
 }

--- a/server/src/main/java/org/tbbtalent/server/request/candidate/occupation/VerifyCandidateOccupationRequest.java
+++ b/server/src/main/java/org/tbbtalent/server/request/candidate/occupation/VerifyCandidateOccupationRequest.java
@@ -16,6 +16,11 @@
 
 package org.tbbtalent.server.request.candidate.occupation;
 
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
 public class VerifyCandidateOccupationRequest {
 
     private Long id;
@@ -24,35 +29,4 @@ public class VerifyCandidateOccupationRequest {
     private String comment;
     private Long yearsExperience;
 
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
-
-    public boolean isVerified() {
-        return verified;
-    }
-
-    public void setVerified(boolean verified) {
-        this.verified = verified;
-    }
-
-    public Long getOccupationId() { return occupationId; }
-
-    public void setOccupationId(Long occupationId) { this.occupationId = occupationId; }
-
-    public String getComment() {
-        return comment;
-    }
-
-    public void setComment(String comment) {
-        this.comment = comment;
-    }
-
-    public Long getYearsExperience() { return yearsExperience; }
-
-    public void setYearsExperience(Long yearsExperience) { this.yearsExperience = yearsExperience; }
 }

--- a/server/src/main/java/org/tbbtalent/server/request/note/CreateCandidateNoteRequest.java
+++ b/server/src/main/java/org/tbbtalent/server/request/note/CreateCandidateNoteRequest.java
@@ -16,9 +16,18 @@
 
 package org.tbbtalent.server.request.note;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
 public class CreateCandidateNoteRequest {
 
     @NotNull
@@ -29,36 +38,4 @@ public class CreateCandidateNoteRequest {
 
     private String comment;
 
-    public CreateCandidateNoteRequest() {
-    }
-
-    public CreateCandidateNoteRequest(@NotNull Long candidateId, @NotBlank String title, @NotBlank String comment) {
-        this.candidateId = candidateId;
-        this.title = title;
-        this.comment = comment;
-    }
-
-    public Long getCandidateId() {
-        return candidateId;
-    }
-
-    public void setCandidateId(Long candidateId) {
-        this.candidateId = candidateId;
-    }
-
-    public String getTitle() {
-        return title;
-    }
-
-    public void setTitle(String title) {
-        this.title = title;
-    }
-
-    public String getComment() {
-        return comment;
-    }
-
-    public void setComment(String comment) {
-        this.comment = comment;
-    }
 }

--- a/server/src/main/java/org/tbbtalent/server/request/note/SearchCandidateNotesRequest.java
+++ b/server/src/main/java/org/tbbtalent/server/request/note/SearchCandidateNotesRequest.java
@@ -18,19 +18,16 @@ package org.tbbtalent.server.request.note;
 
 import javax.validation.constraints.NotNull;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.tbbtalent.server.request.PagedSearchRequest;
 
+@Getter
+@Setter
 public class SearchCandidateNotesRequest extends PagedSearchRequest {
 
     @NotNull
     private Long candidateId;
 
-    public Long getCandidateId() {
-        return candidateId;
-    }
-
-    public void setCandidateId(Long candidateId) {
-        this.candidateId = candidateId;
-    }
 }
 

--- a/server/src/main/java/org/tbbtalent/server/request/note/UpdateCandidateNoteRequest.java
+++ b/server/src/main/java/org/tbbtalent/server/request/note/UpdateCandidateNoteRequest.java
@@ -16,8 +16,17 @@
 
 package org.tbbtalent.server.request.note;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
 import javax.validation.constraints.NotBlank;
 
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
 public class UpdateCandidateNoteRequest {
 
     @NotBlank
@@ -26,27 +35,4 @@ public class UpdateCandidateNoteRequest {
     @NotBlank
     private String comment;
 
-    public UpdateCandidateNoteRequest() {
-    }
-
-    public UpdateCandidateNoteRequest(@NotBlank String title, @NotBlank String comment) {
-        this.title = title;
-        this.comment = comment;
-    }
-
-    public String getTitle() {
-        return title;
-    }
-
-    public void setTitle(String title) {
-        this.title = title;
-    }
-
-    public String getComment() {
-        return comment;
-    }
-
-    public void setComment(String comment) {
-        this.comment = comment;
-    }
 }

--- a/server/src/main/java/org/tbbtalent/server/request/reviewstatus/CreateCandidateReviewStatusRequest.java
+++ b/server/src/main/java/org/tbbtalent/server/request/reviewstatus/CreateCandidateReviewStatusRequest.java
@@ -18,8 +18,12 @@ package org.tbbtalent.server.request.reviewstatus;
 
 import javax.validation.constraints.NotNull;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.tbbtalent.server.model.db.ReviewStatus;
 
+@Getter
+@Setter
 public class CreateCandidateReviewStatusRequest {
 
     @NotNull
@@ -33,35 +37,4 @@ public class CreateCandidateReviewStatusRequest {
 
     String comment;
 
-    public Long getCandidateId() {
-        return candidateId;
-    }
-
-    public void setCandidateId(Long candidateId) {
-        this.candidateId = candidateId;
-    }
-
-    public Long getSavedSearchId() {
-        return savedSearchId;
-    }
-
-    public void setSavedSearchId(Long savedSearchId) {
-        this.savedSearchId = savedSearchId;
-    }
-
-    public ReviewStatus getReviewStatus() {
-        return reviewStatus;
-    }
-
-    public void setReviewStatus(ReviewStatus reviewStatus) {
-        this.reviewStatus = reviewStatus;
-    }
-
-    public String getComment() {
-        return comment;
-    }
-
-    public void setComment(String comment) {
-        this.comment = comment;
-    }
 }

--- a/server/src/main/java/org/tbbtalent/server/request/reviewstatus/UpdateCandidateReviewStatusRequest.java
+++ b/server/src/main/java/org/tbbtalent/server/request/reviewstatus/UpdateCandidateReviewStatusRequest.java
@@ -18,38 +18,20 @@ package org.tbbtalent.server.request.reviewstatus;
 
 import javax.validation.constraints.NotNull;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.tbbtalent.server.model.db.ReviewStatus;
 
+@Getter
+@Setter
 public class UpdateCandidateReviewStatusRequest {
 
     @NotNull
     private Long candidateReviewStatusId;
+
     @NotNull
     private ReviewStatus reviewStatus;
 
     private String comment;
 
-    public Long getCandidateReviewStatusId() {
-        return candidateReviewStatusId;
-    }
-
-    public void setCandidateReviewStatusId(Long candidateReviewStatusId) {
-        this.candidateReviewStatusId = candidateReviewStatusId;
-    }
-
-    public ReviewStatus getReviewStatus() {
-        return reviewStatus;
-    }
-
-    public void setReviewStatus(ReviewStatus reviewStatus) {
-        this.reviewStatus = reviewStatus;
-    }
-
-    public String getComment() {
-        return comment;
-    }
-
-    public void setComment(String comment) {
-        this.comment = comment;
-    }
 }

--- a/server/src/main/java/org/tbbtalent/server/request/work/experience/CreateJobExperienceRequest.java
+++ b/server/src/main/java/org/tbbtalent/server/request/work/experience/CreateJobExperienceRequest.java
@@ -19,79 +19,40 @@ package org.tbbtalent.server.request.work.experience;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import java.time.LocalDate;
+
+import lombok.Getter;
+import lombok.Setter;
 import org.tbbtalent.server.util.html.HtmlSanitizer;
 
+@Getter
+@Setter
 public class CreateJobExperienceRequest {
 
     private Long candidateId;
+
     @NotBlank
     private String companyName;
+
     @NotNull
     private Long countryId;
+
     @NotNull
     private Long candidateOccupationId;
+
     @NotBlank
     private String role;
+
     private LocalDate startDate;
     private LocalDate endDate;
     private Boolean fullTime;
     private Boolean paid;
+
     @NotBlank
     private String description;
-
-    public Long getCandidateId() {
-        return candidateId;
-    }
-
-    public void setCandidateId(Long candidateId) {
-        this.candidateId = candidateId;
-    }
-
-    public void setCountryId(Long countryId) {
-        this.countryId = countryId;
-    }
-
-    public String getCompanyName() { return companyName; }
-
-    public void setCompanyName(String companyName) { this.companyName = companyName; }
-
-    public Long getCountryId() {
-        return countryId;
-    }
 
     public void setCountry(Long countryId) {
         this.countryId = countryId;
     }
-
-    public Long getCandidateOccupationId() {
-        return candidateOccupationId;
-    }
-
-    public void setCandidateOccupationId(Long candidateOccupationId) {
-        this.candidateOccupationId = candidateOccupationId;
-    }
-
-    public String getRole() { return role; }
-
-    public void setRole(String role) { this.role = role; }
-
-    public LocalDate getStartDate() { return startDate; }
-
-    public void setStartDate(LocalDate startDate) { this.startDate = startDate; }
-
-    public LocalDate getEndDate() { return endDate; }
-
-    public void setEndDate(LocalDate endDate) { this.endDate = endDate; }
-
-    public Boolean getFullTime() { return fullTime; }
-
-    public void setFullTime(Boolean fullTime) { this.fullTime = fullTime; }
-
-    public Boolean getPaid() { return paid; }
-
-    public void setPaid(Boolean paid) { this.paid = paid; }
-
-    public String getDescription() { return description; }
 
     public void setDescription(String description) {
         this.description = HtmlSanitizer.sanitize(description);

--- a/server/src/main/java/org/tbbtalent/server/request/work/experience/SearchJobExperienceRequest.java
+++ b/server/src/main/java/org/tbbtalent/server/request/work/experience/SearchJobExperienceRequest.java
@@ -18,8 +18,12 @@ package org.tbbtalent.server.request.work.experience;
 
 import javax.validation.constraints.NotNull;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.tbbtalent.server.request.PagedSearchRequest;
 
+@Getter
+@Setter
 public class SearchJobExperienceRequest extends PagedSearchRequest {
 
     @NotNull
@@ -27,20 +31,4 @@ public class SearchJobExperienceRequest extends PagedSearchRequest {
 
     private Long candidateId;
 
-    public Long getCandidateOccupationId() {
-        return candidateOccupationId;
-    }
-
-    public void setCandidateOccupationId(Long candidateOccupationId) {
-        this.candidateOccupationId = candidateOccupationId;
-    }
-
-    public Long getCandidateId() {
-        return candidateId;
-    }
-
-    public void setCandidateId(Long candidateId) {
-        this.candidateId = candidateId;
-    }
 }
-

--- a/server/src/main/java/org/tbbtalent/server/request/work/experience/UpdateJobExperienceRequest.java
+++ b/server/src/main/java/org/tbbtalent/server/request/work/experience/UpdateJobExperienceRequest.java
@@ -19,78 +19,38 @@ package org.tbbtalent.server.request.work.experience;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import java.time.LocalDate;
+
+import lombok.Getter;
+import lombok.Setter;
 import org.tbbtalent.server.util.html.HtmlSanitizer;
 
+@Getter
+@Setter
 public class UpdateJobExperienceRequest {
 
     private Long id;
     private Long candidateOccupationId;
+
     @NotBlank
     private String companyName;
+
     @NotNull
     private Long countryId;
+
     @NotBlank
     private String role;
+
     private LocalDate startDate;
     private LocalDate endDate;
     private Boolean fullTime;
     private Boolean paid;
+
     @NotBlank
     private String description;
-
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
-
-    public Long getCandidateOccupationId() {
-        return candidateOccupationId;
-    }
-
-    public void setCandidateOccupationId(Long candidateOccupationId) {
-        this.candidateOccupationId = candidateOccupationId;
-    }
-
-    public void setCountryId(Long countryId) {
-        this.countryId = countryId;
-    }
-
-    public String getCompanyName() { return companyName; }
-
-    public void setCompanyName(String companyName) { this.companyName = companyName; }
-
-    public Long getCountryId() {
-        return countryId;
-    }
 
     public void setCountry(Long countryId) {
         this.countryId = countryId;
     }
-
-    public String getRole() { return role; }
-
-    public void setRole(String role) { this.role = role; }
-
-    public LocalDate getStartDate() { return startDate; }
-
-    public void setStartDate(LocalDate startDate) { this.startDate = startDate; }
-
-    public LocalDate getEndDate() { return endDate; }
-
-    public void setEndDate(LocalDate endDate) { this.endDate = endDate; }
-
-    public Boolean getFullTime() { return fullTime; }
-
-    public void setFullTime(Boolean fullTime) { this.fullTime = fullTime; }
-
-    public Boolean getPaid() { return paid; }
-
-    public void setPaid(Boolean paid) { this.paid = paid; }
-
-    public String getDescription() { return description; }
 
     public void setDescription(String description) {
         this.description = HtmlSanitizer.sanitize(description);

--- a/server/src/test/java/org/tbbtalent/server/api/admin/AdminApiTestUtil.java
+++ b/server/src/test/java/org/tbbtalent/server/api/admin/AdminApiTestUtil.java
@@ -183,4 +183,13 @@ public class AdminApiTestUtil {
                 new LanguageLevel("Good", Status.active, 9)
         );
     }
+
+    static CandidateNote getCandidateNote() {
+        CandidateNote candidateNote = new CandidateNote();
+        candidateNote.setCandidate(getCandidate());
+        candidateNote.setTitle("A title");
+        candidateNote.setComment("Some comments");
+        candidateNote.setNoteType(NoteType.candidate);
+        return candidateNote;
+    }
 }

--- a/server/src/test/java/org/tbbtalent/server/api/admin/AdminApiTestUtil.java
+++ b/server/src/test/java/org/tbbtalent/server/api/admin/AdminApiTestUtil.java
@@ -170,4 +170,17 @@ public class AdminApiTestUtil {
                 10L
         );
     }
+
+    static List<CandidateLanguage> getListOfCandidateLanguages() {
+        return List.of(getCandidateLanguage());
+    }
+
+    static CandidateLanguage getCandidateLanguage() {
+        return new CandidateLanguage(
+                getCandidate(),
+                new Language("Arabic", Status.active),
+                new LanguageLevel("Good", Status.active, 9),
+                new LanguageLevel("Good", Status.active, 9)
+        );
+    }
 }

--- a/server/src/test/java/org/tbbtalent/server/api/admin/AdminApiTestUtil.java
+++ b/server/src/test/java/org/tbbtalent/server/api/admin/AdminApiTestUtil.java
@@ -147,4 +147,27 @@ public class AdminApiTestUtil {
         return exam;
     }
 
+    static CandidateJobExperience getCandidateJobExperience() {
+        CandidateJobExperience jobExperience = new CandidateJobExperience(
+                getCandidate(),
+                new Country("Syria", Status.active),
+                getCandidateOccupation(),
+                "Microsoft",
+                "Software Engineer",
+                LocalDate.of(1998, 1, 1),
+                LocalDate.of(2008, 1, 1),
+                "Some job experience description"
+        );
+        jobExperience.setFullTime(true);
+        jobExperience.setPaid(true);
+        return jobExperience;
+    }
+
+    static CandidateOccupation getCandidateOccupation() {
+        return new CandidateOccupation(
+                getCandidate(),
+                new Occupation("Software Engineer", Status.active),
+                10L
+        );
+    }
 }

--- a/server/src/test/java/org/tbbtalent/server/api/admin/AdminApiTestUtil.java
+++ b/server/src/test/java/org/tbbtalent/server/api/admin/AdminApiTestUtil.java
@@ -163,6 +163,17 @@ public class AdminApiTestUtil {
         return jobExperience;
     }
 
+    static List<Occupation> getListOfOccupations() {
+        return List.of(
+                new Occupation("Builder", Status.active),
+                new Occupation("Baker", Status.active)
+        );
+    }
+
+    static List<CandidateOccupation> getListOfCandidateOccupations() {
+        return List.of(getCandidateOccupation());
+    }
+
     static CandidateOccupation getCandidateOccupation() {
         return new CandidateOccupation(
                 getCandidate(),

--- a/server/src/test/java/org/tbbtalent/server/api/admin/AdminApiTestUtil.java
+++ b/server/src/test/java/org/tbbtalent/server/api/admin/AdminApiTestUtil.java
@@ -217,4 +217,13 @@ public class AdminApiTestUtil {
     static SalesforceJobOpp getSalesforceJobOpp() {
         return new SalesforceJobOpp();
     }
+
+    static CandidateReviewStatusItem getCandidateReviewStatusItem() {
+        CandidateReviewStatusItem reviewStatusItem = new CandidateReviewStatusItem();
+        reviewStatusItem.setCandidate(getCandidate());
+        reviewStatusItem.setSavedSearch(new SavedSearch());
+        reviewStatusItem.setComment("A review comment");
+        reviewStatusItem.setReviewStatus(ReviewStatus.verified);
+        return reviewStatusItem;
+    }
 }

--- a/server/src/test/java/org/tbbtalent/server/api/admin/AdminApiTestUtil.java
+++ b/server/src/test/java/org/tbbtalent/server/api/admin/AdminApiTestUtil.java
@@ -203,4 +203,18 @@ public class AdminApiTestUtil {
         candidateNote.setNoteType(NoteType.candidate);
         return candidateNote;
     }
+
+    static CandidateOpportunity getCandidateOpportunity() {
+        CandidateOpportunity opportunity = new CandidateOpportunity();
+        opportunity.setCandidate(getCandidate());
+        opportunity.setClosingCommentsForCandidate("Some closing comments for candidate");
+        opportunity.setEmployerFeedback("Some employer feedback");
+        opportunity.setStage(CandidateOpportunityStage.offer);
+        opportunity.setJobOpp(getSalesforceJobOpp());
+        return opportunity;
+    }
+
+    static SalesforceJobOpp getSalesforceJobOpp() {
+        return new SalesforceJobOpp();
+    }
 }

--- a/server/src/test/java/org/tbbtalent/server/api/admin/CandidateJobExperienceAdminApiTest.java
+++ b/server/src/test/java/org/tbbtalent/server/api/admin/CandidateJobExperienceAdminApiTest.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright (c) 2023 Talent Beyond Boundaries.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tbbtalent.server.api.admin;
+
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.tbbtalent.server.model.db.CandidateJobExperience;
+import org.tbbtalent.server.request.work.experience.CreateJobExperienceRequest;
+import org.tbbtalent.server.request.work.experience.SearchJobExperienceRequest;
+import org.tbbtalent.server.request.work.experience.UpdateJobExperienceRequest;
+import org.tbbtalent.server.service.db.CandidateJobExperienceService;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.tbbtalent.server.api.admin.AdminApiTestUtil.getCandidateJobExperience;
+
+/**
+ * Unit tests for Candidate Job Experience Admin Api endpoints.
+ *
+ * @author sadatmalik
+ */
+@WebMvcTest(CandidateJobExperienceAdminApi.class)
+@AutoConfigureMockMvc
+class CandidateJobExperienceAdminApiTest extends ApiTestBase {
+
+    private static final long CANDIDATE_ID = 99L;
+    private static final String BASE_PATH = "/api/admin/candidate-job-experience";
+    private static final String SEARCH_PATH = "/search";
+
+    private static final CandidateJobExperience candidateJobExperience = getCandidateJobExperience();
+
+    private final Page<CandidateJobExperience> candidateJobExperiencePage =
+            new PageImpl<>(
+                    List.of(candidateJobExperience),
+                    PageRequest.of(0,10, Sort.unsorted()),
+                    1
+            );
+
+    @MockBean CandidateJobExperienceService candidateJobExperienceService;
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+    @Autowired CandidateJobExperienceAdminApi candidateJobExperienceAdminApi;
+
+    @BeforeEach
+    void setUp() {
+        configureAuthentication();
+    }
+
+    @Test
+    public void testWebOnlyContextLoads() {
+        assertThat(candidateJobExperienceAdminApi).isNotNull();
+    }
+
+    @Test
+    @DisplayName("search candidate job experience succeeds")
+    void searchJobExperienceSucceeds() throws Exception {
+        SearchJobExperienceRequest request = new SearchJobExperienceRequest();
+
+        given(candidateJobExperienceService
+                .searchCandidateJobExperience(any(SearchJobExperienceRequest.class)))
+                .willReturn(candidateJobExperiencePage);
+
+        mockMvc.perform(post(BASE_PATH + SEARCH_PATH)
+                        .header("Authorization", "Bearer " + "jwt-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                        .accept(MediaType.APPLICATION_JSON))
+
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.totalElements", is(1)))
+                .andExpect(jsonPath("$.totalPages", is(1)))
+                .andExpect(jsonPath("$.number", is(0)))
+                .andExpect(jsonPath("$.hasNext", is(false)))
+                .andExpect(jsonPath("$.hasPrevious", is(false)))
+                .andExpect(jsonPath("$.content", notNullValue()))
+                .andExpect(jsonPath("$.content.[0].country.name", is("Syria")))
+                .andExpect(jsonPath("$.content.[0].country.status", is("active")))
+                .andExpect(jsonPath("$.content.[0].role", is("Software Engineer")))
+                .andExpect(jsonPath("$.content.[0].candidateOccupation.occupation.name", is("Software Engineer")))
+                .andExpect(jsonPath("$.content.[0].candidateOccupation.yearsExperience", is(10)))
+                .andExpect(jsonPath("$.content.[0].startDate", is("1998-01-01")))
+                .andExpect(jsonPath("$.content.[0].endDate", is("2008-01-01")))
+                .andExpect(jsonPath("$.content.[0].companyName", is("Microsoft")))
+                .andExpect(jsonPath("$.content.[0].paid", is(true)))
+                .andExpect(jsonPath("$.content.[0].description", is("Some job experience description")))
+                .andExpect(jsonPath("$.content.[0].fullTime", is(true)));
+
+        verify(candidateJobExperienceService).searchCandidateJobExperience(any(SearchJobExperienceRequest.class));
+    }
+
+    @Test
+    @DisplayName("create candidate job experience by candidate id succeeds")
+    void createCandidateJobExperienceByCandidateIdSucceeds() throws Exception {
+        CreateJobExperienceRequest request = new CreateJobExperienceRequest();
+        request.setCompanyName("Microsoft");
+        request.setCountry(1L);
+        request.setCandidateOccupationId(2L);
+        request.setRole("Software Engineer");
+        request.setDescription("Some job experience description");
+
+        given(candidateJobExperienceService
+                .createCandidateJobExperience(any(CreateJobExperienceRequest.class)))
+                .willReturn(candidateJobExperience);
+
+        mockMvc.perform(post(BASE_PATH + "/" + CANDIDATE_ID)
+                        .header("Authorization", "Bearer " + "jwt-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                        .accept(MediaType.APPLICATION_JSON))
+
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$", notNullValue()))
+                .andExpect(jsonPath("$.country.name", is("Syria")))
+                .andExpect(jsonPath("$.country.status", is("active")))
+                .andExpect(jsonPath("$.role", is("Software Engineer")))
+                .andExpect(jsonPath("$.candidateOccupation.occupation.name", is("Software Engineer")))
+                .andExpect(jsonPath("$.candidateOccupation.yearsExperience", is(10)))
+                .andExpect(jsonPath("$.startDate", is("1998-01-01")))
+                .andExpect(jsonPath("$.endDate", is("2008-01-01")))
+                .andExpect(jsonPath("$.companyName", is("Microsoft")))
+                .andExpect(jsonPath("$.paid", is(true)))
+                .andExpect(jsonPath("$.description", is("Some job experience description")))
+                .andExpect(jsonPath("$.fullTime", is(true)));
+
+        verify(candidateJobExperienceService).createCandidateJobExperience(any(CreateJobExperienceRequest.class));
+    }
+
+    @Test
+    @DisplayName("update candidate job experience by id succeeds")
+    void updateCandidateJobExperienceByIdSucceeds() throws Exception {
+        UpdateJobExperienceRequest request = new UpdateJobExperienceRequest();
+        request.setCompanyName("Microsoft");
+        request.setCountryId(1L);
+        request.setRole("Software Engineer");
+        request.setDescription("Some job experience description");
+
+        given(candidateJobExperienceService
+                .updateCandidateJobExperience(anyLong(), any(UpdateJobExperienceRequest.class)))
+                .willReturn(candidateJobExperience);
+
+        mockMvc.perform(put(BASE_PATH + "/" + CANDIDATE_ID)
+                        .header("Authorization", "Bearer " + "jwt-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                        .accept(MediaType.APPLICATION_JSON))
+
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$", notNullValue()))
+                .andExpect(jsonPath("$.country.name", is("Syria")))
+                .andExpect(jsonPath("$.country.status", is("active")))
+                .andExpect(jsonPath("$.role", is("Software Engineer")))
+                .andExpect(jsonPath("$.candidateOccupation.occupation.name", is("Software Engineer")))
+                .andExpect(jsonPath("$.candidateOccupation.yearsExperience", is(10)))
+                .andExpect(jsonPath("$.startDate", is("1998-01-01")))
+                .andExpect(jsonPath("$.endDate", is("2008-01-01")))
+                .andExpect(jsonPath("$.companyName", is("Microsoft")))
+                .andExpect(jsonPath("$.paid", is(true)))
+                .andExpect(jsonPath("$.description", is("Some job experience description")))
+                .andExpect(jsonPath("$.fullTime", is(true)));
+
+        verify(candidateJobExperienceService).updateCandidateJobExperience(anyLong(), any(UpdateJobExperienceRequest.class));
+    }
+
+    @Test
+    @DisplayName("delete candidate job experience by id succeeds")
+    void deleteCandidateJobExperienceByIdSucceeds() throws Exception {
+        mockMvc.perform(delete(BASE_PATH + "/" + CANDIDATE_ID)
+                        .header("Authorization", "Bearer " + "jwt-token"))
+
+                .andExpect(status().isOk());
+
+        verify(candidateJobExperienceService).deleteCandidateJobExperience(anyLong());
+    }
+}

--- a/server/src/test/java/org/tbbtalent/server/api/admin/CandidateLanguageAdminApiTest.java
+++ b/server/src/test/java/org/tbbtalent/server/api/admin/CandidateLanguageAdminApiTest.java
@@ -29,7 +29,6 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.tbbtalent.server.model.db.CandidateLanguage;
 import org.tbbtalent.server.request.candidate.language.CreateCandidateLanguageRequest;
 import org.tbbtalent.server.request.candidate.language.UpdateCandidateLanguageRequest;
-import org.tbbtalent.server.request.work.experience.SearchJobExperienceRequest;
 import org.tbbtalent.server.service.db.CandidateLanguageService;
 
 import java.util.List;

--- a/server/src/test/java/org/tbbtalent/server/api/admin/CandidateLanguageAdminApiTest.java
+++ b/server/src/test/java/org/tbbtalent/server/api/admin/CandidateLanguageAdminApiTest.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2023 Talent Beyond Boundaries.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tbbtalent.server.api.admin;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.tbbtalent.server.model.db.CandidateLanguage;
+import org.tbbtalent.server.request.candidate.language.CreateCandidateLanguageRequest;
+import org.tbbtalent.server.request.candidate.language.UpdateCandidateLanguageRequest;
+import org.tbbtalent.server.request.work.experience.SearchJobExperienceRequest;
+import org.tbbtalent.server.service.db.CandidateLanguageService;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.tbbtalent.server.api.admin.AdminApiTestUtil.getCandidateLanguage;
+import static org.tbbtalent.server.api.admin.AdminApiTestUtil.getListOfCandidateLanguages;
+
+/**
+ * Unit tests for Candidate Language Admin Api endpoints.
+ *
+ * @author sadatmalik
+ */
+@WebMvcTest(CandidateLanguageAdminApi.class)
+@AutoConfigureMockMvc
+class CandidateLanguageAdminApiTest extends ApiTestBase {
+
+    private static final long CANDIDATE_ID = 99L;
+    private static final String BASE_PATH = "/api/admin/candidate-language";
+    private static final String GET_LIST_PATH = "/{id}/list";
+
+    private static final CandidateLanguage candidateLanguage = getCandidateLanguage();
+
+    private static final List<CandidateLanguage> candidateLanguageList = getListOfCandidateLanguages();
+
+    @MockBean CandidateLanguageService candidateLanguageService;
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+    @Autowired CandidateLanguageAdminApi candidateLanguageAdminApi;
+
+    @BeforeEach
+    void setUp() {
+        configureAuthentication();
+    }
+
+    @Test
+    public void testWebOnlyContextLoads() {
+        assertThat(candidateLanguageAdminApi).isNotNull();
+    }
+
+    @Test
+    @DisplayName("get candidate languages succeeds")
+    void getCandidateLanguagesSucceeds() throws Exception {
+        SearchJobExperienceRequest request = new SearchJobExperienceRequest();
+
+        given(candidateLanguageService
+                .list(anyLong()))
+                .willReturn(candidateLanguageList);
+
+        mockMvc.perform(get(BASE_PATH + GET_LIST_PATH.replace("{id}", String.valueOf(CANDIDATE_ID)))
+                        .header("Authorization", "Bearer " + "jwt-token")
+                        .contentType(MediaType.APPLICATION_JSON))
+
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$", hasSize(1)))
+                .andExpect(jsonPath("$.[0].spokenLevel.level", is(9)))
+                .andExpect(jsonPath("$.[0].spokenLevel.name", is("Good")))
+                .andExpect(jsonPath("$.[0].writtenLevel.level", is(9)))
+                .andExpect(jsonPath("$.[0].writtenLevel.name", is("Good")))
+                .andExpect(jsonPath("$.[0].language.name", is("Arabic")));
+
+        verify(candidateLanguageService).list(anyLong());
+    }
+
+    @Test
+    @DisplayName("create candidate language succeeds")
+    void createCandidateLanguageSucceeds() throws Exception {
+        CreateCandidateLanguageRequest request = new CreateCandidateLanguageRequest();
+
+        given(candidateLanguageService
+                .createCandidateLanguage(any(CreateCandidateLanguageRequest.class)))
+                .willReturn(candidateLanguage);
+
+        mockMvc.perform(post(BASE_PATH)
+                        .header("Authorization", "Bearer " + "jwt-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                        .accept(MediaType.APPLICATION_JSON))
+
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$", notNullValue()))
+                .andExpect(jsonPath("$.spokenLevel.level", is(9)))
+                .andExpect(jsonPath("$.spokenLevel.name", is("Good")))
+                .andExpect(jsonPath("$.writtenLevel.level", is(9)))
+                .andExpect(jsonPath("$.writtenLevel.name", is("Good")))
+                .andExpect(jsonPath("$.language.name", is("Arabic")));
+
+        verify(candidateLanguageService).createCandidateLanguage(any(CreateCandidateLanguageRequest.class));
+    }
+
+    @Test
+    @DisplayName("update candidate language succeeds")
+    void updateCandidateLanguageSucceeds() throws Exception {
+        UpdateCandidateLanguageRequest request = new UpdateCandidateLanguageRequest();
+
+        given(candidateLanguageService
+                .updateCandidateLanguage(any(UpdateCandidateLanguageRequest.class)))
+                .willReturn(candidateLanguage);
+
+        mockMvc.perform(put(BASE_PATH)
+                        .header("Authorization", "Bearer " + "jwt-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                        .accept(MediaType.APPLICATION_JSON))
+
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$", notNullValue()))
+                .andExpect(jsonPath("$.spokenLevel.level", is(9)))
+                .andExpect(jsonPath("$.spokenLevel.name", is("Good")))
+                .andExpect(jsonPath("$.writtenLevel.level", is(9)))
+                .andExpect(jsonPath("$.writtenLevel.name", is("Good")))
+                .andExpect(jsonPath("$.language.name", is("Arabic")));
+
+        verify(candidateLanguageService).updateCandidateLanguage(any(UpdateCandidateLanguageRequest.class));
+    }
+
+    @Test
+    @DisplayName("delete candidate language by id succeeds")
+    void deleteCandidateLanguageByIdSucceeds() throws Exception {
+        mockMvc.perform(delete(BASE_PATH + "/" + CANDIDATE_ID)
+                        .header("Authorization", "Bearer " + "jwt-token"))
+
+                .andExpect(status().isOk());
+
+        verify(candidateLanguageService).deleteCandidateLanguage(anyLong());
+    }
+}

--- a/server/src/test/java/org/tbbtalent/server/api/admin/CandidateLanguageAdminApiTest.java
+++ b/server/src/test/java/org/tbbtalent/server/api/admin/CandidateLanguageAdminApiTest.java
@@ -89,7 +89,6 @@ class CandidateLanguageAdminApiTest extends ApiTestBase {
     @Test
     @DisplayName("get candidate languages succeeds")
     void getCandidateLanguagesSucceeds() throws Exception {
-        SearchJobExperienceRequest request = new SearchJobExperienceRequest();
 
         given(candidateLanguageService
                 .list(anyLong()))

--- a/server/src/test/java/org/tbbtalent/server/api/admin/CandidateNoteAdminApiTest.java
+++ b/server/src/test/java/org/tbbtalent/server/api/admin/CandidateNoteAdminApiTest.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2023 Talent Beyond Boundaries.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tbbtalent.server.api.admin;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.tbbtalent.server.model.db.CandidateNote;
+import org.tbbtalent.server.request.note.CreateCandidateNoteRequest;
+import org.tbbtalent.server.request.note.SearchCandidateNotesRequest;
+import org.tbbtalent.server.request.note.UpdateCandidateNoteRequest;
+import org.tbbtalent.server.service.db.CandidateNoteService;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.tbbtalent.server.api.admin.AdminApiTestUtil.getCandidateNote;
+
+/**
+ * Unit tests for Candidate Note Admin Api endpoints.
+ *
+ * @author sadatmalik
+ */
+@WebMvcTest(CandidateNoteAdminApi.class)
+@AutoConfigureMockMvc
+class CandidateNoteAdminApiTest extends ApiTestBase {
+
+    private static final long CANDIDATE_ID = 99L;
+    private static final String BASE_PATH = "/api/admin/candidate-note";
+    private static final String SEARCH_PATH = "/search";
+
+    private static final CandidateNote candidateNote = getCandidateNote();
+
+    private final Page<CandidateNote> candidateNotesPage =
+            new PageImpl<>(
+                    List.of(candidateNote),
+                    PageRequest.of(0,10, Sort.unsorted()),
+                    1
+            );
+
+    @MockBean CandidateNoteService candidateNoteService;
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+    @Autowired CandidateNoteAdminApi candidateNoteAdminApi;
+
+    @BeforeEach
+    void setUp() {
+        configureAuthentication();
+    }
+
+    @Test
+    public void testWebOnlyContextLoads() {
+        assertThat(candidateNoteAdminApi).isNotNull();
+    }
+
+    @Test
+    @DisplayName("search candidate notes succeeds")
+    void searchCandidateNotesSucceeds() throws Exception {
+        SearchCandidateNotesRequest request = new SearchCandidateNotesRequest();
+
+        given(candidateNoteService
+                .searchCandidateNotes(any(SearchCandidateNotesRequest.class)))
+                .willReturn(candidateNotesPage);
+
+        mockMvc.perform(post(BASE_PATH + SEARCH_PATH)
+                        .header("Authorization", "Bearer " + "jwt-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                        .accept(MediaType.APPLICATION_JSON))
+
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.totalElements", is(1)))
+                .andExpect(jsonPath("$.totalPages", is(1)))
+                .andExpect(jsonPath("$.number", is(0)))
+                .andExpect(jsonPath("$.hasNext", is(false)))
+                .andExpect(jsonPath("$.hasPrevious", is(false)))
+                .andExpect(jsonPath("$.content", notNullValue()))
+                .andExpect(jsonPath("$.content.[0].noteType", is("candidate")))
+                .andExpect(jsonPath("$.content.[0].comment", is("Some comments")))
+                .andExpect(jsonPath("$.content.[0].title", is("A title")));
+
+        verify(candidateNoteService).searchCandidateNotes(any(SearchCandidateNotesRequest.class));
+    }
+
+    @Test
+    @DisplayName("create candidate note succeeds")
+    void createCandidateNoteSucceeds() throws Exception {
+        CreateCandidateNoteRequest request = new CreateCandidateNoteRequest(
+                CANDIDATE_ID, "A title", "Some Comments"
+        );
+
+        given(candidateNoteService
+                .createCandidateNote(any(CreateCandidateNoteRequest.class)))
+                .willReturn(candidateNote);
+
+        mockMvc.perform(post(BASE_PATH)
+                        .header("Authorization", "Bearer " + "jwt-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                        .accept(MediaType.APPLICATION_JSON))
+
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$", notNullValue()))
+                .andExpect(jsonPath("$.noteType", is("candidate")))
+                .andExpect(jsonPath("$.comment", is("Some comments")))
+                .andExpect(jsonPath("$.title", is("A title")));
+
+        verify(candidateNoteService).createCandidateNote(any(CreateCandidateNoteRequest.class));
+    }
+
+    @Test
+    @DisplayName("update candidate note by id succeeds")
+    void updateCandidateNoteByIdSucceeds() throws Exception {
+        UpdateCandidateNoteRequest request = new UpdateCandidateNoteRequest();
+        request.setTitle("A title");
+        request.setComment("A comment");
+
+        given(candidateNoteService
+                .updateCandidateNote(anyLong(), any(UpdateCandidateNoteRequest.class)))
+                .willReturn(candidateNote);
+
+        mockMvc.perform(put(BASE_PATH + "/" + CANDIDATE_ID)
+                        .header("Authorization", "Bearer " + "jwt-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                        .accept(MediaType.APPLICATION_JSON))
+
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$", notNullValue()))
+                .andExpect(jsonPath("$.noteType", is("candidate")))
+                .andExpect(jsonPath("$.comment", is("Some comments")))
+                .andExpect(jsonPath("$.title", is("A title")));
+
+        verify(candidateNoteService).updateCandidateNote(anyLong(), any(UpdateCandidateNoteRequest.class));
+    }
+
+}

--- a/server/src/test/java/org/tbbtalent/server/api/admin/CandidateOccupationAdminApiTest.java
+++ b/server/src/test/java/org/tbbtalent/server/api/admin/CandidateOccupationAdminApiTest.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright (c) 2023 Talent Beyond Boundaries.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tbbtalent.server.api.admin;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.tbbtalent.server.model.db.CandidateOccupation;
+import org.tbbtalent.server.model.db.Occupation;
+import org.tbbtalent.server.request.candidate.occupation.CreateCandidateOccupationRequest;
+import org.tbbtalent.server.request.candidate.occupation.VerifyCandidateOccupationRequest;
+import org.tbbtalent.server.service.db.CandidateOccupationService;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.tbbtalent.server.api.admin.AdminApiTestUtil.getCandidateOccupation;
+import static org.tbbtalent.server.api.admin.AdminApiTestUtil.getListOfCandidateOccupations;
+import static org.tbbtalent.server.api.admin.AdminApiTestUtil.getListOfOccupations;
+
+/**
+ * Unit tests for Candidate Occupation Admin Api endpoints.
+ *
+ * @author sadatmalik
+ */
+@WebMvcTest(CandidateOccupationAdminApi.class)
+@AutoConfigureMockMvc
+class CandidateOccupationAdminApiTest extends ApiTestBase {
+
+    private static final long CANDIDATE_ID = 99L;
+
+    private static final String BASE_PATH = "/api/admin/candidate-occupation";
+    private static final String GET_VERIFIED_OCCUPATIONS_PATH = "/verified";
+    private static final String GET_ALL_OCCUPATIONS_PATH = "/occupation";
+    private static final String GET_CANDIDATE_OCCUPATIONS_BY_ID_PATH = "/{id}/list";
+
+    private static final List<Occupation> occupationsList = getListOfOccupations();
+    private static final CandidateOccupation candidateOccupation = getCandidateOccupation();
+    private static final List<CandidateOccupation> candidateOccupationsList = getListOfCandidateOccupations();
+
+    @MockBean CandidateOccupationService candidateOccupationService;
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+    @Autowired CandidateOccupationAdminApi candidateOccupationAdminApi;
+
+    @BeforeEach
+    void setUp() {
+        configureAuthentication();
+    }
+
+    @Test
+    public void testWebOnlyContextLoads() {
+        assertThat(candidateOccupationAdminApi).isNotNull();
+    }
+
+    @Test
+    @DisplayName("get verified occupations succeeds")
+    void getVerifiedOccupationsSucceeds() throws Exception {
+
+        given(candidateOccupationService
+                .listVerifiedOccupations())
+                .willReturn(occupationsList);
+
+        mockMvc.perform(get(BASE_PATH + GET_VERIFIED_OCCUPATIONS_PATH)
+                        .header("Authorization", "Bearer " + "jwt-token")
+                        .contentType(MediaType.APPLICATION_JSON))
+
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$", hasSize(2)))
+                .andExpect(jsonPath("$.[0].name", is("Builder")))
+                .andExpect(jsonPath("$.[1].name", is("Baker")));
+
+        verify(candidateOccupationService).listVerifiedOccupations();
+    }
+
+    @Test
+    @DisplayName("get all occupations succeeds")
+    void getAllOccupationsSucceeds() throws Exception {
+
+        given(candidateOccupationService
+                .listOccupations())
+                .willReturn(occupationsList);
+
+        mockMvc.perform(get(BASE_PATH + GET_ALL_OCCUPATIONS_PATH)
+                        .header("Authorization", "Bearer " + "jwt-token")
+                        .contentType(MediaType.APPLICATION_JSON))
+
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$", hasSize(2)))
+                .andExpect(jsonPath("$.[0].name", is("Builder")))
+                .andExpect(jsonPath("$.[1].name", is("Baker")));
+
+        verify(candidateOccupationService).listOccupations();
+    }
+
+    @Test
+    @DisplayName("get candidate occupations by id succeeds")
+    void getCandidateOccupationsByIdSucceeds() throws Exception {
+
+        given(candidateOccupationService
+                .listCandidateOccupations(anyLong()))
+                .willReturn(candidateOccupationsList);
+
+        mockMvc.perform(get(BASE_PATH + GET_CANDIDATE_OCCUPATIONS_BY_ID_PATH.replace("{id}", String.valueOf(CANDIDATE_ID)))
+                        .header("Authorization", "Bearer " + "jwt-token")
+                        .contentType(MediaType.APPLICATION_JSON))
+
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$", hasSize(1)))
+                .andExpect(jsonPath("$.[0].occupation.name", is("Software Engineer")))
+                .andExpect(jsonPath("$.[0].verified", is(false)))
+                .andExpect(jsonPath("$.[0].yearsExperience", is(10)));
+
+        verify(candidateOccupationService).listCandidateOccupations(anyLong());
+    }
+
+    @Test
+    @DisplayName("create candidate occupation by candidate id succeeds")
+    void createCandidateOccupationByCandidateIdSucceeds() throws Exception {
+        CreateCandidateOccupationRequest request = new CreateCandidateOccupationRequest();
+        request.setOccupationId(1L);
+        request.setYearsExperience(10L);
+        request.setVerified(false);
+
+        given(candidateOccupationService
+                .createCandidateOccupation(any(CreateCandidateOccupationRequest.class)))
+                .willReturn(candidateOccupation);
+
+        mockMvc.perform(post(BASE_PATH + "/" + CANDIDATE_ID)
+                        .header("Authorization", "Bearer " + "jwt-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                        .accept(MediaType.APPLICATION_JSON))
+
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$", notNullValue()))
+                .andExpect(jsonPath("$.occupation.name", is("Software Engineer")))
+                .andExpect(jsonPath("$.verified", is(false)))
+                .andExpect(jsonPath("$.yearsExperience", is(10)));
+
+        verify(candidateOccupationService).createCandidateOccupation(any(CreateCandidateOccupationRequest.class));
+    }
+
+    @Test
+    @DisplayName("update candidate occupation by id succeeds")
+    void updateCandidateOccupationByIdSucceeds() throws Exception {
+        VerifyCandidateOccupationRequest request = new VerifyCandidateOccupationRequest();
+
+        given(candidateOccupationService
+                .verifyCandidateOccupation(any(VerifyCandidateOccupationRequest.class)))
+                .willReturn(candidateOccupation);
+
+        mockMvc.perform(put(BASE_PATH + "/" + CANDIDATE_ID)
+                        .header("Authorization", "Bearer " + "jwt-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                        .accept(MediaType.APPLICATION_JSON))
+
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$", notNullValue()))
+                .andExpect(jsonPath("$.occupation.name", is("Software Engineer")))
+                .andExpect(jsonPath("$.verified", is(false)))
+                .andExpect(jsonPath("$.yearsExperience", is(10)));
+
+        verify(candidateOccupationService).verifyCandidateOccupation(any(VerifyCandidateOccupationRequest.class));
+    }
+
+    @Test
+    @DisplayName("delete candidate occupation by id succeeds")
+    void deleteCandidateOccupationByIdSucceeds() throws Exception {
+        mockMvc.perform(delete(BASE_PATH + "/" + CANDIDATE_ID)
+                        .header("Authorization", "Bearer " + "jwt-token"))
+
+                .andExpect(status().isOk());
+
+        verify(candidateOccupationService).deleteCandidateOccupation(CANDIDATE_ID);
+    }
+}

--- a/server/src/test/java/org/tbbtalent/server/api/admin/CandidateOpportunityAdminApiTest.java
+++ b/server/src/test/java/org/tbbtalent/server/api/admin/CandidateOpportunityAdminApiTest.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) 2023 Talent Beyond Boundaries.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tbbtalent.server.api.admin;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.tbbtalent.server.model.db.CandidateOpportunity;
+import org.tbbtalent.server.request.candidate.opportunity.CandidateOpportunityParams;
+import org.tbbtalent.server.request.candidate.opportunity.SearchCandidateOpportunityRequest;
+import org.tbbtalent.server.service.db.CandidateOpportunityService;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.tbbtalent.server.api.admin.AdminApiTestUtil.getCandidateOpportunity;
+
+/**
+ * Unit tests for Candidate Opportunity Admin Api endpoints.
+ *
+ * @author sadatmalik
+ */
+@WebMvcTest(CandidateOpportunityAdminApi.class)
+@AutoConfigureMockMvc
+class CandidateOpportunityAdminApiTest extends ApiTestBase {
+
+    private static final long CANDIDATE_ID = 99L;
+
+    private static final String BASE_PATH = "/api/admin/opp";
+    private static final String SEARCH_PAGED_PATH = "/search-paged";
+
+    private static final CandidateOpportunity candidateOpportunity = getCandidateOpportunity();
+    private final Page<CandidateOpportunity> candidateOpportunityPage =
+            new PageImpl<>(
+                    List.of(candidateOpportunity),
+                    PageRequest.of(0,10, Sort.unsorted()),
+                    1
+            );
+
+    @MockBean CandidateOpportunityService candidateOpportunityService;
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+    @Autowired CandidateOpportunityAdminApi candidateOpportunityAdminApi;
+
+    @BeforeEach
+    void setUp() {
+        configureAuthentication();
+    }
+
+    @Test
+    public void testWebOnlyContextLoads() {
+        assertThat(candidateOpportunityAdminApi).isNotNull();
+    }
+
+    @Test
+    @DisplayName("get candidate opportunity by id succeeds")
+    void getCandidateOpportunityByIdSucceeds() throws Exception {
+
+        given(candidateOpportunityService
+                .getCandidateOpportunity(anyLong()))
+                .willReturn(candidateOpportunity);
+
+        mockMvc.perform(get(BASE_PATH + "/" + CANDIDATE_ID)
+                        .header("Authorization", "Bearer " + "jwt-token")
+                        .contentType(MediaType.APPLICATION_JSON))
+
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$", notNullValue()))
+                .andExpect(jsonPath("$.candidate.user.firstName", is("test")))
+                .andExpect(jsonPath("$.candidate.user.lastName", is("candidate1")))
+                .andExpect(jsonPath("$.candidate.user.email", is("test.candidate1@some.thing")))
+                .andExpect(jsonPath("$.candidate.user.username", is("candidate1")))
+                .andExpect(jsonPath("$.stage", is("offer")))
+                .andExpect(jsonPath("$.closingCommentsForCandidate", is("Some closing comments for candidate")))
+                .andExpect(jsonPath("$.closed", is(false)))
+                .andExpect(jsonPath("$.employerFeedback", is("Some employer feedback")));
+
+        verify(candidateOpportunityService).getCandidateOpportunity(anyLong());
+    }
+
+    @Test
+    @DisplayName("search opportunities paged succeeds")
+    void searchPagedSucceeds() throws Exception {
+        SearchCandidateOpportunityRequest request = new SearchCandidateOpportunityRequest();
+
+        given(candidateOpportunityService
+                .searchCandidateOpportunities(any(SearchCandidateOpportunityRequest.class)))
+                .willReturn(candidateOpportunityPage);
+
+        mockMvc.perform(post(BASE_PATH + SEARCH_PAGED_PATH)
+                        .header("Authorization", "Bearer " + "jwt-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                        .accept(MediaType.APPLICATION_JSON))
+
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.totalElements", is(1)))
+                .andExpect(jsonPath("$.totalPages", is(1)))
+                .andExpect(jsonPath("$.number", is(0)))
+                .andExpect(jsonPath("$.hasNext", is(false)))
+                .andExpect(jsonPath("$.hasPrevious", is(false)))
+                .andExpect(jsonPath("$.content", notNullValue()))
+                .andExpect(jsonPath("$.content.[0].candidate.user.firstName", is("test")))
+                .andExpect(jsonPath("$.content.[0].candidate.user.lastName", is("candidate1")))
+                .andExpect(jsonPath("$.content.[0].candidate.user.email", is("test.candidate1@some.thing")))
+                .andExpect(jsonPath("$.content.[0].candidate.user.username", is("candidate1")))
+                .andExpect(jsonPath("$.content.[0].stage", is("offer")))
+                .andExpect(jsonPath("$.content.[0].closingCommentsForCandidate", is("Some closing comments for candidate")))
+                .andExpect(jsonPath("$.content.[0].closed", is(false)))
+                .andExpect(jsonPath("$.content.[0].employerFeedback", is("Some employer feedback")));
+
+        verify(candidateOpportunityService).searchCandidateOpportunities(any(SearchCandidateOpportunityRequest.class));
+    }
+
+    @Test
+    @DisplayName("update opportunity by id succeeds")
+    void updateCandidateOccupationByIdSucceeds() throws Exception {
+        CandidateOpportunityParams request = new CandidateOpportunityParams();
+
+        given(candidateOpportunityService
+                .updateCandidateOpportunity(anyLong(), any(CandidateOpportunityParams.class)))
+                .willReturn(candidateOpportunity);
+
+        mockMvc.perform(put(BASE_PATH + "/" + CANDIDATE_ID)
+                        .header("Authorization", "Bearer " + "jwt-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                        .accept(MediaType.APPLICATION_JSON))
+
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$", notNullValue()))
+                .andExpect(jsonPath("$.candidate.user.firstName", is("test")))
+                .andExpect(jsonPath("$.candidate.user.lastName", is("candidate1")))
+                .andExpect(jsonPath("$.candidate.user.email", is("test.candidate1@some.thing")))
+                .andExpect(jsonPath("$.candidate.user.username", is("candidate1")))
+                .andExpect(jsonPath("$.stage", is("offer")))
+                .andExpect(jsonPath("$.closingCommentsForCandidate", is("Some closing comments for candidate")))
+                .andExpect(jsonPath("$.closed", is(false)))
+                .andExpect(jsonPath("$.employerFeedback", is("Some employer feedback")));
+
+        verify(candidateOpportunityService).updateCandidateOpportunity(anyLong(), any(CandidateOpportunityParams.class));
+    }
+}

--- a/server/src/test/java/org/tbbtalent/server/api/admin/CandidateReviewStatusAdminApiTest.java
+++ b/server/src/test/java/org/tbbtalent/server/api/admin/CandidateReviewStatusAdminApiTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2023 Talent Beyond Boundaries.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tbbtalent.server.api.admin;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.tbbtalent.server.model.db.CandidateReviewStatusItem;
+import org.tbbtalent.server.model.db.ReviewStatus;
+import org.tbbtalent.server.request.reviewstatus.CreateCandidateReviewStatusRequest;
+import org.tbbtalent.server.request.reviewstatus.UpdateCandidateReviewStatusRequest;
+import org.tbbtalent.server.service.db.CandidateReviewStatusService;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.tbbtalent.server.api.admin.AdminApiTestUtil.getCandidateReviewStatusItem;
+
+/**
+ * Unit tests for Candidate Review Status Admin Api endpoints.
+ *
+ * @author sadatmalik
+ */
+@WebMvcTest(CandidateReviewStatusAdminApi.class)
+@AutoConfigureMockMvc
+class CandidateReviewStatusAdminApiTest extends ApiTestBase {
+
+    private static final long CANDIDATE_ID = 99L;
+
+    private static final String BASE_PATH = "/api/admin/candidate-reviewstatus";
+
+    private static final CandidateReviewStatusItem reviewStatusItem = getCandidateReviewStatusItem();
+
+    @MockBean CandidateReviewStatusService candidateReviewStatusService;
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+    @Autowired CandidateReviewStatusAdminApi candidateReviewStatusAdminApi;
+
+    @BeforeEach
+    void setUp() {
+        configureAuthentication();
+    }
+
+    @Test
+    public void testWebOnlyContextLoads() {
+        assertThat(candidateReviewStatusAdminApi).isNotNull();
+    }
+
+    @Test
+    @DisplayName("get candidate review status succeeds")
+    void getCandidateReviewStatusSucceeds() throws Exception {
+        given(candidateReviewStatusService
+                .getCandidateReviewStatusItem(anyLong()))
+                .willReturn(reviewStatusItem);
+
+        mockMvc.perform(get(BASE_PATH + "/" + CANDIDATE_ID)
+                        .header("Authorization", "Bearer " + "jwt-token")
+                        .contentType(MediaType.APPLICATION_JSON))
+
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$", notNullValue()))
+                .andExpect(jsonPath("$.reviewStatus", is("verified")))
+                .andExpect(jsonPath("$.comment", is("A review comment")));
+
+        verify(candidateReviewStatusService).getCandidateReviewStatusItem(CANDIDATE_ID);
+    }
+
+    @Test
+    @DisplayName("create candidate review status succeeds")
+    void createCandidateReviewStatusSucceeds() throws Exception {
+        CreateCandidateReviewStatusRequest request = new CreateCandidateReviewStatusRequest();
+        request.setCandidateId(1L);
+        request.setSavedSearchId(2L);
+        request.setReviewStatus(ReviewStatus.verified);
+
+        given(candidateReviewStatusService
+                .createCandidateReviewStatusItem(any(CreateCandidateReviewStatusRequest.class)))
+                .willReturn(reviewStatusItem);
+
+        mockMvc.perform(post(BASE_PATH)
+                        .header("Authorization", "Bearer " + "jwt-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                        .accept(MediaType.APPLICATION_JSON))
+
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$", notNullValue()))
+                .andExpect(jsonPath("$.reviewStatus", is("verified")))
+                .andExpect(jsonPath("$.comment", is("A review comment")));
+
+        verify(candidateReviewStatusService).createCandidateReviewStatusItem(any(CreateCandidateReviewStatusRequest.class));
+    }
+
+    @Test
+    @DisplayName("update candidate review status by id succeeds")
+    void updateCandidateReviewStatusByIdSucceeds() throws Exception {
+        UpdateCandidateReviewStatusRequest request = new UpdateCandidateReviewStatusRequest();
+        request.setCandidateReviewStatusId(1L);
+        request.setReviewStatus(ReviewStatus.verified);
+
+        given(candidateReviewStatusService
+                .updateCandidateReviewStatusItem(anyLong(), any(UpdateCandidateReviewStatusRequest.class)))
+                .willReturn(reviewStatusItem);
+
+        mockMvc.perform(put(BASE_PATH + "/" + CANDIDATE_ID)
+                        .header("Authorization", "Bearer " + "jwt-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                        .accept(MediaType.APPLICATION_JSON))
+
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$", notNullValue()))
+                .andExpect(jsonPath("$.reviewStatus", is("verified")))
+                .andExpect(jsonPath("$.comment", is("A review comment")));
+
+        verify(candidateReviewStatusService).updateCandidateReviewStatusItem(anyLong(), any(UpdateCandidateReviewStatusRequest.class));
+    }
+
+}


### PR DESCRIPTION
Unit tests for:

- CandidateJobExperienceAdminApi
- CandidateLanguageAdminApi
- CandidateNoteAdminApi
- CandidateOccupationAdminApi
- CandidateOpportunityAdminApi
- CandidateReviewStatusAdminApi

And some minor refactoring of unit tested classes:

- Use Lombok annotations where appropriate
- Resolve IntelliJ warning
