### PR TITLE
320 remove tabs from candidate preview card when it is a default search

### DIFF
--- a/ui/admin-portal/src/app/components/util/candidate-search-card/candidate-search-card.component.html
+++ b/ui/admin-portal/src/app/components/util/candidate-search-card/candidate-search-card.component.html
@@ -39,7 +39,7 @@
 
         <!-- SHAREABLE DOCS -->
         <ng-container ngbNavItem="docs">
-          <a ngbNavLink>Shareable Docs</a>
+          <a ngbNavLink>{{isList ? "List Specific " : null}}Shareable Docs</a>
           <ng-template ngbNavContent>
             <app-shareable-docs
               [candidate]="candidate"
@@ -74,7 +74,7 @@
           <i class="fas fa-external-link-alt" title="Show candidate in new tab"></i>
         </a>
       </h3>
-      <button (click)="toggleNotes()" id="bt2" class="btn btn-sm btn-secondary-light me-5">
+      <button (click)="toggleNotes()" id="bt2" class="btn btn-sm btn-secondary-light me-1">
         General Notes
         <i *ngIf="!showNotes" class="fas fa-eye"></i>
         <i *ngIf="showNotes" class="fas fa-eye-slash"></i>

--- a/ui/admin-portal/src/app/components/util/candidate-search-card/candidate-search-card.component.html
+++ b/ui/admin-portal/src/app/components/util/candidate-search-card/candidate-search-card.component.html
@@ -17,7 +17,7 @@
   <div class="content">
   <button (click)="close()" type="button" class="btn-close text-reset float-end ms-4" aria-label="Close"></button>
 
-    <div class="list-specific">
+    <div *ngIf="isContextNoteDisplayed()" class="list-specific">
       <div class="candidate-header" >
         <h5 *ngIf="isList">List Specific</h5>
         <h5  *ngIf="isContextNoteDisplayed() && !isList">Search Specific</h5>


### PR DESCRIPTION
Small bug I noticed with my added tabs (shareable docs/context notes/preview CV) which was appearing on default searches