### PR TITLE
Update elasticsearch and kibana versions from 7.12.0 to 7.17.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,15 +85,13 @@ Download and install the latest of the following tools.
     - Install Docker image. 
       See [Elastic search website](https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html)
       Just pull the image to install. See later for how to run. 
-      Currently in dev we use version 7.12.0 rather than the latest because it doesn't require security 
-      enabled.
-    > docker pull docker.elastic.co/elasticsearch/elasticsearch:7.12.0
+    > docker pull docker.elastic.co/elasticsearch/elasticsearch:7.17.11
 
 - Kibana (for monitoring Elasticsearch)
     - Install Docker image.
       See [Elastic search website](https://www.elastic.co/guide/en/kibana/current/docker.html)
       Just pull the image to install. See later for how to run.
-    > docker pull docker.elastic.co/kibana/kibana:7.12.0
+    > docker pull docker.elastic.co/kibana/kibana:7.17.11
 
 - Git - [see Git website](https://git-scm.com/downloads) - Not really necessary now with Intellij 
  which will prompt you install Git if needed
@@ -171,7 +169,7 @@ Can run from Docker desktop for Mac, or (replacing appropriate version number)..
 
 > docker rm elasticsearch
 
-> docker run --name elasticsearch -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch:7.12.0
+> docker run --name elasticsearch -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch:7.17.11
 
 Elasticsearch will run listening on port 9200. 
 You can verify this by going to [localhost:9200](http://localhost:9200) in your browser
@@ -182,7 +180,7 @@ Can run from Docker desktop for Mac, or (replacing appropriate version number)..
 
 > docker rm kibana
 
-> docker run --name kibana --link elasticsearch -p 5601:5601 docker.elastic.co/kibana/kibana:7.12.0
+> docker run --name kibana --link elasticsearch -p 5601:5601 docker.elastic.co/kibana/kibana:7.17.11
 
 Kibana runs listening on port 5601. 
 You can verify this by going to [localhost:5601](http://localhost:5601) in your browser 


### PR DESCRIPTION
This PR:

- Updates the project Readme to the current versions for Elasticsearch and Kibana