### PR TITLE
394 candidate context information is not showing in saved searches unless the selection checkbox is checked

### DIFF
--- a/server/gradle.properties
+++ b/server/gradle.properties
@@ -14,4 +14,4 @@
 # along with this program. If not, see https://www.gnu.org/licenses/.
 #
 
-# test-tc-system - see issue to allow us to run job from our local dev machines
+test-tc-system

--- a/server/gradle.properties
+++ b/server/gradle.properties
@@ -14,4 +14,4 @@
 # along with this program. If not, see https://www.gnu.org/licenses/.
 #
 
-test-tc-system
+# test-tc-system

--- a/server/gradle.properties
+++ b/server/gradle.properties
@@ -14,4 +14,4 @@
 # along with this program. If not, see https://www.gnu.org/licenses/.
 #
 
-test-tc-system
+# test-tc-system - see issue to allow us to run job from our local dev machines

--- a/ui/admin-portal/src/app/components/util/candidate-search-card/candidate-search-card.component.ts
+++ b/ui/admin-portal/src/app/components/util/candidate-search-card/candidate-search-card.component.ts
@@ -92,7 +92,7 @@ export class CandidateSearchCardComponent implements OnInit, AfterViewChecked {
   isContextNoteDisplayed() {
     let display: boolean = true;
     if (isSavedSearch(this.candidateSource)) {
-      if (this.candidateSource.defaultSearch || !this.isCandidateSelected) {
+      if (this.candidateSource.defaultSearch) {
         display = false;
       }
     }


### PR DESCRIPTION
This has already gone into production as a hot fix