### PR TITLE
379 description field required when adding a job experience need better errorrequired indicator

### DIFF
--- a/server/src/main/java/org/tctalent/server/request/work/experience/CreateJobExperienceRequest.java
+++ b/server/src/main/java/org/tctalent/server/request/work/experience/CreateJobExperienceRequest.java
@@ -16,13 +16,13 @@
 
 package org.tctalent.server.request.work.experience;
 
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
-import java.time.LocalDate;
-
 import lombok.Getter;
 import lombok.Setter;
 import org.tctalent.server.util.html.HtmlSanitizer;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import java.time.LocalDate;
 
 @Getter
 @Setter
@@ -55,6 +55,10 @@ public class CreateJobExperienceRequest {
     }
 
     public void setDescription(String description) {
-        this.description = HtmlSanitizer.sanitize(description);
+        if (description != null) {
+            this.description = HtmlSanitizer.sanitize(description);
+        } else {
+            this.description = null;
+        }
     }
 }

--- a/server/src/main/java/org/tctalent/server/request/work/experience/CreateJobExperienceRequest.java
+++ b/server/src/main/java/org/tctalent/server/request/work/experience/CreateJobExperienceRequest.java
@@ -55,10 +55,6 @@ public class CreateJobExperienceRequest {
     }
 
     public void setDescription(String description) {
-        if (description != null) {
-            this.description = HtmlSanitizer.sanitize(description);
-        } else {
-            this.description = null;
-        }
+        this.description = description != null ? HtmlSanitizer.sanitize(description) : null;
     }
 }

--- a/server/src/main/java/org/tctalent/server/request/work/experience/UpdateJobExperienceRequest.java
+++ b/server/src/main/java/org/tctalent/server/request/work/experience/UpdateJobExperienceRequest.java
@@ -53,10 +53,6 @@ public class UpdateJobExperienceRequest {
     }
 
     public void setDescription(String description) {
-        if (description != null) {
-            this.description = HtmlSanitizer.sanitize(description);
-        } else {
-            this.description = description;
-        }
+        this.description = description != null ? HtmlSanitizer.sanitize(description) : null;
     }
 }

--- a/server/src/main/java/org/tctalent/server/request/work/experience/UpdateJobExperienceRequest.java
+++ b/server/src/main/java/org/tctalent/server/request/work/experience/UpdateJobExperienceRequest.java
@@ -16,13 +16,13 @@
 
 package org.tctalent.server.request.work.experience;
 
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
-import java.time.LocalDate;
-
 import lombok.Getter;
 import lombok.Setter;
 import org.tctalent.server.util.html.HtmlSanitizer;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import java.time.LocalDate;
 
 @Getter
 @Setter
@@ -53,6 +53,10 @@ public class UpdateJobExperienceRequest {
     }
 
     public void setDescription(String description) {
-        this.description = HtmlSanitizer.sanitize(description);
+        if (description != null) {
+            this.description = HtmlSanitizer.sanitize(description);
+        } else {
+            this.description = description;
+        }
     }
 }

--- a/ui/admin-portal/src/app/components/candidates/view/occupation/experience/create/create-candidate-job-experience.component.html
+++ b/ui/admin-portal/src/app/components/candidates/view/occupation/experience/create/create-candidate-job-experience.component.html
@@ -87,7 +87,7 @@
 
       <!-- DESCRIPTION -->
       <div class="mb-3">
-        <label class="form-label" for="description">Description</label>
+        <label class="form-label" for="description">Description *</label>
         <textarea type="text" class="md-textarea-auto form-control" rows="8" id="description" placeholder="" [formControlName]="'description'"></textarea>
       </div>
 

--- a/ui/admin-portal/src/app/components/candidates/view/occupation/experience/create/create-candidate-job-experience.component.ts
+++ b/ui/admin-portal/src/app/components/candidates/view/occupation/experience/create/create-candidate-job-experience.component.ts
@@ -82,7 +82,7 @@ export class CreateCandidateJobExperienceComponent implements OnInit {
       endDate: [null],
       fullTime: [null],
       paid: [null],
-      description: [null],
+      description: [null, [Validators.required]],
     });
     this.loading = false;
   }

--- a/ui/admin-portal/src/app/components/candidates/view/occupation/experience/edit/edit-candidate-job-experience.component.ts
+++ b/ui/admin-portal/src/app/components/candidates/view/occupation/experience/edit/edit-candidate-job-experience.component.ts
@@ -78,7 +78,7 @@ export class EditCandidateJobExperienceComponent implements OnInit {
       endDate: [this.candidateJobExperience.endDate],
       fullTime: [this.candidateJobExperience.fullTime],
       paid: [this.candidateJobExperience.paid],
-      description: [this.candidateJobExperience.description],
+      description: [this.candidateJobExperience.description, Validators.required],
     });
     this.loading = false;
   }

--- a/ui/admin-portal/src/app/components/candidates/view/occupation/experience/view-candidate-job-experience.component.html
+++ b/ui/admin-portal/src/app/components/candidates/view/occupation/experience/view-candidate-job-experience.component.html
@@ -63,10 +63,10 @@
           <small class="text-muted">
             {{experience.startDate | date: 'customMonthYear' }} - {{experience.endDate | date: 'customMonthYear' }}
           </small>
-          <small class="text-muted">
-            {{experience.fullTime ? 'Full Time' : 'Part Time'}}
-            {{experience.paid ? 'Paid' : 'Voluntary'}}
-          </small>
+          <div>
+            <small *ngIf="experience.fullTime != null" class="text-muted"> {{experience.fullTime ? 'Full Time' : 'Part Time'}} </small>
+            <small *ngIf="experience.paid != null" class="text-muted">{{experience.paid ? 'Paid' : 'Voluntary'}}</small>
+          </div>
         </div>
 
         <div class="col-2" *ngIf="editable">


### PR DESCRIPTION
Fixed the description bug but two additional things to note:

1. On the front end the validation for creating/updating a job experience is not consistent or present. So I added validation for description field to be required, however I thought it best to create a new issue #397 for fixing up the validation on the other fields. 

2. I found another small but quite ugly bug where if there was a null field for the Contract Type & Employment Type fields, it was defaulting to displaying the equivalent as if the field was false. Thought I'd put in this bug fix branch as it's small and fairly nasty so best to do it in the hot fix.