### PR TITLE
Unit tests for candidate stat admin api

### DIFF
--- a/server/src/main/java/org/tctalent/server/api/admin/CandidateStatAdminApi.java
+++ b/server/src/main/java/org/tctalent/server/api/admin/CandidateStatAdminApi.java
@@ -242,13 +242,13 @@ public class CandidateStatAdminApi {
         statReports.add(new StatReport(title + " (female)",
             candidateService.computeSurveyStats(Gender.female, null, dateFrom, dateTo, sourceCountryIds)));
 
-        addSpokenLanguageStatReports("English", dateFrom, dateTo, sourceCountryIds, statReports);
-        addSpokenLanguageStatReports("French", dateFrom, dateTo, sourceCountryIds, statReports);
+        addSpokenLanguageLevelStatReports("English", dateFrom, dateTo, sourceCountryIds, statReports);
+        addSpokenLanguageLevelStatReports("French", dateFrom, dateTo, sourceCountryIds, statReports);
 
         return statReports;
     }
 
-    private void addSpokenLanguageStatReports(String language, LocalDate dateFrom, LocalDate dateTo, List<Long> sourceCountryIds,
+    private void addSpokenLanguageLevelStatReports(String language, LocalDate dateFrom, LocalDate dateTo, List<Long> sourceCountryIds,
         List<StatReport> statReports) {
         String title = "Spoken " + language + " Language Level";
         statReports.add(new StatReport(title,
@@ -380,13 +380,13 @@ public class CandidateStatAdminApi {
         statReports.add(new StatReport(title + " (female)",
             candidateService.computeSurveyStats(Gender.female, null, dateFrom, dateTo, candidateIds, sourceCountryIds)));
 
-        addSpokenLanguageStatReports("English", dateFrom, dateTo, candidateIds, sourceCountryIds, statReports);
-        addSpokenLanguageStatReports("French", dateFrom, dateTo, candidateIds, sourceCountryIds, statReports);
+        addSpokenLanguageLevelStatReports("English", dateFrom, dateTo, candidateIds, sourceCountryIds, statReports);
+        addSpokenLanguageLevelStatReports("French", dateFrom, dateTo, candidateIds, sourceCountryIds, statReports);
 
         return statReports;
     }
 
-    private void addSpokenLanguageStatReports(String language, LocalDate dateFrom, LocalDate dateTo, Set<Long> candidateIds, List<Long> sourceCountryIds,
+    private void addSpokenLanguageLevelStatReports(String language, LocalDate dateFrom, LocalDate dateTo, Set<Long> candidateIds, List<Long> sourceCountryIds,
         List<StatReport> statReports) {
         String title = "Spoken " + language + " Language Level";
         statReports.add(new StatReport(title,

--- a/server/src/main/java/org/tctalent/server/api/admin/CandidateStatAdminApi.java
+++ b/server/src/main/java/org/tctalent/server/api/admin/CandidateStatAdminApi.java
@@ -125,7 +125,6 @@ public class CandidateStatAdminApi {
             LocalDate dateFrom,
             LocalDate dateTo,
             List<Long> sourceCountryIds ) {
-        String language;
         String title;
         String chartType;
 
@@ -260,14 +259,12 @@ public class CandidateStatAdminApi {
             candidateService.computeSpokenLanguageLevelStats(Gender.female, language, dateFrom, dateTo, sourceCountryIds)));
     }
 
-
     private List<StatReport> createReports(
         LocalDate dateFrom,
         LocalDate dateTo,
         Set<Long> candidateIds,
         List<Long> sourceCountryIds) {
 
-        String language;
         String title;
         String chartType;
 
@@ -383,30 +380,25 @@ public class CandidateStatAdminApi {
         statReports.add(new StatReport(title + " (female)",
             candidateService.computeSurveyStats(Gender.female, null, dateFrom, dateTo, candidateIds, sourceCountryIds)));
 
-
-        language = "English";
-        title = "Spoken " + language + " Language Level";
-        statReports.add(new StatReport(title,
-            candidateService.computeSpokenLanguageLevelStats(null, language, dateFrom, dateTo, candidateIds, sourceCountryIds)));
-        statReports.add(new StatReport(title + " (male)",
-            candidateService.computeSpokenLanguageLevelStats(Gender.male, language, dateFrom, dateTo, candidateIds, sourceCountryIds)));
-        statReports.add(new StatReport(title + " (female)",
-            candidateService.computeSpokenLanguageLevelStats(Gender.female, language, dateFrom, dateTo, candidateIds, sourceCountryIds)));
-
-        language = "French";
-        title = "Spoken " + language + " Language Level";
-        statReports.add(new StatReport(title,
-            candidateService.computeSpokenLanguageLevelStats(null, language, dateFrom, dateTo, candidateIds, sourceCountryIds)));
-        statReports.add(new StatReport(title + " (male)",
-            candidateService.computeSpokenLanguageLevelStats(Gender.male, language, dateFrom, dateTo, candidateIds, sourceCountryIds)));
-        statReports.add(new StatReport(title + " (female)",
-            candidateService.computeSpokenLanguageLevelStats(Gender.female, language, dateFrom, dateTo, candidateIds, sourceCountryIds)));
+        addSpokenLanguageStatsReport("English", dateFrom, dateTo, candidateIds, sourceCountryIds, statReports);
+        addSpokenLanguageStatsReport("French", dateFrom, dateTo, candidateIds, sourceCountryIds, statReports);
 
         return statReports;
     }
 
+    private void addSpokenLanguageStatsReport(String language, LocalDate dateFrom, LocalDate dateTo, Set<Long> candidateIds, List<Long> sourceCountryIds,
+        List<StatReport> statReports) {
+        String title = "Spoken " + language + " Language Level";
+        statReports.add(new StatReport(title,
+            candidateService.computeSpokenLanguageLevelStats(null, language, dateFrom, dateTo, candidateIds, sourceCountryIds)));
+        statReports.add(new StatReport(title + " (male)",
+            candidateService.computeSpokenLanguageLevelStats(Gender.male, language, dateFrom, dateTo, candidateIds, sourceCountryIds)));
+        statReports.add(new StatReport(title + " (female)",
+            candidateService.computeSpokenLanguageLevelStats(Gender.female, language, dateFrom, dateTo, candidateIds, sourceCountryIds)));
+    }
+
     /**
-     * Get logged in user’s source country Ids, defaulting to all countries if empty
+     * Get logged-in user’s source country Ids, defaulting to all countries if empty
      */
     private List<Long> getDefaultSourceCountryIds(){
         User user = authService.getLoggedInUser()

--- a/server/src/main/java/org/tctalent/server/api/admin/CandidateStatAdminApi.java
+++ b/server/src/main/java/org/tctalent/server/api/admin/CandidateStatAdminApi.java
@@ -242,13 +242,13 @@ public class CandidateStatAdminApi {
         statReports.add(new StatReport(title + " (female)",
             candidateService.computeSurveyStats(Gender.female, null, dateFrom, dateTo, sourceCountryIds)));
 
-        addSpokenLanguageStatsReport("English", dateFrom, dateTo, sourceCountryIds, statReports);
-        addSpokenLanguageStatsReport("French", dateFrom, dateTo, sourceCountryIds, statReports);
+        addSpokenLanguageStatReports("English", dateFrom, dateTo, sourceCountryIds, statReports);
+        addSpokenLanguageStatReports("French", dateFrom, dateTo, sourceCountryIds, statReports);
 
         return statReports;
     }
 
-    private void addSpokenLanguageStatsReport(String language, LocalDate dateFrom, LocalDate dateTo, List<Long> sourceCountryIds,
+    private void addSpokenLanguageStatReports(String language, LocalDate dateFrom, LocalDate dateTo, List<Long> sourceCountryIds,
         List<StatReport> statReports) {
         String title = "Spoken " + language + " Language Level";
         statReports.add(new StatReport(title,
@@ -380,13 +380,13 @@ public class CandidateStatAdminApi {
         statReports.add(new StatReport(title + " (female)",
             candidateService.computeSurveyStats(Gender.female, null, dateFrom, dateTo, candidateIds, sourceCountryIds)));
 
-        addSpokenLanguageStatsReport("English", dateFrom, dateTo, candidateIds, sourceCountryIds, statReports);
-        addSpokenLanguageStatsReport("French", dateFrom, dateTo, candidateIds, sourceCountryIds, statReports);
+        addSpokenLanguageStatReports("English", dateFrom, dateTo, candidateIds, sourceCountryIds, statReports);
+        addSpokenLanguageStatReports("French", dateFrom, dateTo, candidateIds, sourceCountryIds, statReports);
 
         return statReports;
     }
 
-    private void addSpokenLanguageStatsReport(String language, LocalDate dateFrom, LocalDate dateTo, Set<Long> candidateIds, List<Long> sourceCountryIds,
+    private void addSpokenLanguageStatReports(String language, LocalDate dateFrom, LocalDate dateTo, Set<Long> candidateIds, List<Long> sourceCountryIds,
         List<StatReport> statReports) {
         String title = "Spoken " + language + " Language Level";
         statReports.add(new StatReport(title,

--- a/server/src/main/java/org/tctalent/server/api/admin/CandidateStatAdminApi.java
+++ b/server/src/main/java/org/tctalent/server/api/admin/CandidateStatAdminApi.java
@@ -243,25 +243,21 @@ public class CandidateStatAdminApi {
         statReports.add(new StatReport(title + " (female)",
             candidateService.computeSurveyStats(Gender.female, null, dateFrom, dateTo, sourceCountryIds)));
 
-        language = "English";
-        title = "Spoken " + language + " Language Level";
-        statReports.add(new StatReport(title,
-            candidateService.computeSpokenLanguageLevelStats(null, language, dateFrom, dateTo, sourceCountryIds)));
-        statReports.add(new StatReport(title + " (male)",
-            candidateService.computeSpokenLanguageLevelStats(Gender.male, language, dateFrom, dateTo, sourceCountryIds)));
-        statReports.add(new StatReport(title + " (female)",
-            candidateService.computeSpokenLanguageLevelStats(Gender.female, language, dateFrom, dateTo, sourceCountryIds)));
-
-        language = "French";
-        title = "Spoken " + language + " Language Level";
-        statReports.add(new StatReport(title,
-            candidateService.computeSpokenLanguageLevelStats(null, language, dateFrom, dateTo, sourceCountryIds)));
-        statReports.add(new StatReport(title + " (male)",
-            candidateService.computeSpokenLanguageLevelStats(Gender.male, language, dateFrom, dateTo, sourceCountryIds)));
-        statReports.add(new StatReport(title + " (female)",
-            candidateService.computeSpokenLanguageLevelStats(Gender.female, language, dateFrom, dateTo, sourceCountryIds)));
+        addSpokenLanguageStatsReport("English", dateFrom, dateTo, sourceCountryIds, statReports);
+        addSpokenLanguageStatsReport("French", dateFrom, dateTo, sourceCountryIds, statReports);
 
         return statReports;
+    }
+
+    private void addSpokenLanguageStatsReport(String language, LocalDate dateFrom, LocalDate dateTo, List<Long> sourceCountryIds,
+        List<StatReport> statReports) {
+        String title = "Spoken " + language + " Language Level";
+        statReports.add(new StatReport(title,
+            candidateService.computeSpokenLanguageLevelStats(null, language, dateFrom, dateTo, sourceCountryIds)));
+        statReports.add(new StatReport(title + " (male)",
+            candidateService.computeSpokenLanguageLevelStats(Gender.male, language, dateFrom, dateTo, sourceCountryIds)));
+        statReports.add(new StatReport(title + " (female)",
+            candidateService.computeSpokenLanguageLevelStats(Gender.female, language, dateFrom, dateTo, sourceCountryIds)));
     }
 
 

--- a/server/src/main/java/org/tctalent/server/api/admin/CandidateStatAdminApi.java
+++ b/server/src/main/java/org/tctalent/server/api/admin/CandidateStatAdminApi.java
@@ -191,7 +191,7 @@ public class CandidateStatAdminApi {
             candidateService.computeStatusStats(null, "lebanon", dateFrom, dateTo, sourceCountryIds)));
 
         title = "Occupations";
-        statReports.add(new StatReport(title + "",
+        statReports.add(new StatReport(title,
             candidateService.computeOccupationStats(null, dateFrom, dateTo, sourceCountryIds)));
         statReports.add(new StatReport(title + " (male)",
             candidateService.computeOccupationStats(Gender.male, dateFrom, dateTo, sourceCountryIds)));
@@ -199,7 +199,7 @@ public class CandidateStatAdminApi {
             candidateService.computeOccupationStats(Gender.female, dateFrom, dateTo, sourceCountryIds)));
 
         title = "Most Common Occupations";
-        statReports.add(new StatReport(title + "",
+        statReports.add(new StatReport(title,
             candidateService.computeMostCommonOccupationStats(null, dateFrom, dateTo, sourceCountryIds)));
         statReports.add(new StatReport(title + " (male)",
             candidateService.computeMostCommonOccupationStats(Gender.male, dateFrom, dateTo, sourceCountryIds)));
@@ -344,7 +344,7 @@ public class CandidateStatAdminApi {
             candidateService.computeStatusStats(null, "lebanon", dateFrom, dateTo, candidateIds, sourceCountryIds)));
 
         title = "Occupations";
-        statReports.add(new StatReport(title + "",
+        statReports.add(new StatReport(title,
             candidateService.computeOccupationStats(null, dateFrom, dateTo, candidateIds, sourceCountryIds)));
         statReports.add(new StatReport(title + " (male)",
             candidateService.computeOccupationStats(Gender.male, dateFrom, dateTo, candidateIds, sourceCountryIds)));
@@ -352,7 +352,7 @@ public class CandidateStatAdminApi {
             candidateService.computeOccupationStats(Gender.female, dateFrom, dateTo, candidateIds, sourceCountryIds)));
 
         title = "Most Common Occupations";
-        statReports.add(new StatReport(title + "",
+        statReports.add(new StatReport(title,
             candidateService.computeMostCommonOccupationStats(null, dateFrom, dateTo, candidateIds, sourceCountryIds)));
         statReports.add(new StatReport(title + " (male)",
             candidateService.computeMostCommonOccupationStats(Gender.male, dateFrom, dateTo, candidateIds, sourceCountryIds)));

--- a/server/src/main/java/org/tctalent/server/api/admin/CandidateStatAdminApi.java
+++ b/server/src/main/java/org/tctalent/server/api/admin/CandidateStatAdminApi.java
@@ -23,8 +23,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
 import org.apache.commons.collections.CollectionUtils;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -47,6 +47,7 @@ import org.tctalent.server.util.dto.DtoBuilder;
 
 @RestController()
 @RequestMapping("/api/admin/candidate/stat")
+@RequiredArgsConstructor
 public class CandidateStatAdminApi {
 
     private final CandidateService candidateService;
@@ -54,20 +55,6 @@ public class CandidateStatAdminApi {
     private final SavedListService savedListService;
     private final SavedSearchService savedSearchService;
     private final AuthService authService;
-
-    @Autowired
-    public CandidateStatAdminApi(
-        CandidateService candidateService,
-        CountryRepository countryRepository,
-        SavedListService savedListService,
-        SavedSearchService savedSearchService,
-        AuthService authService) {
-        this.candidateService = candidateService;
-        this.countryRepository = countryRepository;
-        this.savedListService = savedListService;
-        this.savedSearchService = savedSearchService;
-        this.authService = authService;
-    }
 
     /**
      * Runs queries to generate all our supported reports.
@@ -147,133 +134,132 @@ public class CandidateStatAdminApi {
         title = "Gender";
         chartType = "bar";
         statReports.add(new StatReport(title,
-                this.candidateService.computeGenderStats(dateFrom, dateTo, sourceCountryIds), chartType));
+            candidateService.computeGenderStats(dateFrom, dateTo, sourceCountryIds), chartType));
 
         title = "Registrations";
         chartType = "bar";
         statReports.add(new StatReport(title,
-                this.candidateService.computeRegistrationStats(dateFrom, dateTo, sourceCountryIds), chartType));
+            candidateService.computeRegistrationStats(dateFrom, dateTo, sourceCountryIds), chartType));
         statReports.add(new StatReport(title + " (by occupations)",
-                this.candidateService.computeRegistrationOccupationStats(dateFrom, dateTo, sourceCountryIds)));
+            candidateService.computeRegistrationOccupationStats(dateFrom, dateTo, sourceCountryIds)));
 
         title = "Birth years";
         chartType = "bar";
         statReports.add(new StatReport(title,
-                this.candidateService.computeBirthYearStats(null, dateFrom, dateTo, sourceCountryIds), chartType));
+            candidateService.computeBirthYearStats(null, dateFrom, dateTo, sourceCountryIds), chartType));
         statReports.add(new StatReport(title + " (male)",
-                this.candidateService.computeBirthYearStats(Gender.male, dateFrom, dateTo, sourceCountryIds), chartType));
+            candidateService.computeBirthYearStats(Gender.male, dateFrom, dateTo, sourceCountryIds), chartType));
         statReports.add(new StatReport(title + " (female)",
-                this.candidateService.computeBirthYearStats(Gender.female, dateFrom, dateTo, sourceCountryIds), chartType));
+            candidateService.computeBirthYearStats(Gender.female, dateFrom, dateTo, sourceCountryIds), chartType));
 
         title = "LinkedIn";
         chartType = "bar";
         statReports.add(new StatReport(title + " links",
-            this.candidateService.computeLinkedInExistsStats(dateFrom, dateTo, sourceCountryIds), chartType));
+            candidateService.computeLinkedInExistsStats(dateFrom, dateTo, sourceCountryIds), chartType));
         statReports.add(new StatReport(title + " links by candidate registration date",
-            this.candidateService.computeLinkedInStats(dateFrom, dateTo, sourceCountryIds), chartType));
+            candidateService.computeLinkedInStats(dateFrom, dateTo, sourceCountryIds), chartType));
 
         title = "UNHCR";
         chartType = "bar";
         statReports.add(new StatReport(title + " Registered",
-            this.candidateService.computeUnhcrRegisteredStats(dateFrom, dateTo, sourceCountryIds), chartType));
+            candidateService.computeUnhcrRegisteredStats(dateFrom, dateTo, sourceCountryIds), chartType));
         statReports.add(new StatReport(title + " Status",
-            this.candidateService.computeUnhcrStatusStats(dateFrom, dateTo, sourceCountryIds), chartType));
+            candidateService.computeUnhcrStatusStats(dateFrom, dateTo, sourceCountryIds), chartType));
 
         title = "Nationalities by Country";
         statReports.add(new StatReport(title,
-                this.candidateService.computeNationalityStats(null, null, dateFrom, dateTo, sourceCountryIds)));
+            candidateService.computeNationalityStats(null, null, dateFrom, dateTo, sourceCountryIds)));
         statReports.add(new StatReport(title + " (male)",
-                this.candidateService.computeNationalityStats(Gender.male, null, dateFrom, dateTo, sourceCountryIds)));
+            candidateService.computeNationalityStats(Gender.male, null, dateFrom, dateTo, sourceCountryIds)));
         statReports.add(new StatReport(title + " (female)",
-                this.candidateService.computeNationalityStats(Gender.female, null, dateFrom, dateTo, sourceCountryIds)));
+            candidateService.computeNationalityStats(Gender.female, null, dateFrom, dateTo, sourceCountryIds)));
         statReports.add(new StatReport(title + " (Jordan)",
-                this.candidateService.computeNationalityStats(null, "jordan", dateFrom, dateTo, sourceCountryIds)));
+            candidateService.computeNationalityStats(null, "jordan", dateFrom, dateTo, sourceCountryIds)));
         statReports.add(new StatReport(title + " (Lebanon)",
-                this.candidateService.computeNationalityStats(null, "lebanon", dateFrom, dateTo, sourceCountryIds)));
+            candidateService.computeNationalityStats(null, "lebanon", dateFrom, dateTo, sourceCountryIds)));
 
         title = "Statuses";
         statReports.add(new StatReport(title,
-                this.candidateService.computeStatusStats(null, null, dateFrom, dateTo, sourceCountryIds)));
+            candidateService.computeStatusStats(null, null, dateFrom, dateTo, sourceCountryIds)));
         statReports.add(new StatReport(title + " (male)",
-                this.candidateService.computeStatusStats(Gender.male, null, dateFrom, dateTo, sourceCountryIds)));
+            candidateService.computeStatusStats(Gender.male, null, dateFrom, dateTo, sourceCountryIds)));
         statReports.add(new StatReport(title + " (female)",
-                this.candidateService.computeStatusStats(Gender.female, null, dateFrom, dateTo, sourceCountryIds)));
+            candidateService.computeStatusStats(Gender.female, null, dateFrom, dateTo, sourceCountryIds)));
         statReports.add(new StatReport(title + " (Jordan)",
-                this.candidateService.computeStatusStats(null, "jordan", dateFrom, dateTo, sourceCountryIds)));
+            candidateService.computeStatusStats(null, "jordan", dateFrom, dateTo, sourceCountryIds)));
         statReports.add(new StatReport(title + " (Lebanon)",
-                this.candidateService.computeStatusStats(null, "lebanon", dateFrom, dateTo, sourceCountryIds)));
+            candidateService.computeStatusStats(null, "lebanon", dateFrom, dateTo, sourceCountryIds)));
 
         title = "Occupations";
         statReports.add(new StatReport(title + "",
-                this.candidateService.computeOccupationStats(null, dateFrom, dateTo, sourceCountryIds)));
+            candidateService.computeOccupationStats(null, dateFrom, dateTo, sourceCountryIds)));
         statReports.add(new StatReport(title + " (male)",
-                this.candidateService.computeOccupationStats(Gender.male, dateFrom, dateTo, sourceCountryIds)));
+            candidateService.computeOccupationStats(Gender.male, dateFrom, dateTo, sourceCountryIds)));
         statReports.add(new StatReport(title + " (female)",
-                this.candidateService.computeOccupationStats(Gender.female, dateFrom, dateTo, sourceCountryIds)));
+            candidateService.computeOccupationStats(Gender.female, dateFrom, dateTo, sourceCountryIds)));
 
         title = "Most Common Occupations";
         statReports.add(new StatReport(title + "",
-                this.candidateService.computeMostCommonOccupationStats(null, dateFrom, dateTo, sourceCountryIds)));
+            candidateService.computeMostCommonOccupationStats(null, dateFrom, dateTo, sourceCountryIds)));
         statReports.add(new StatReport(title + " (male)",
-                this.candidateService.computeMostCommonOccupationStats(Gender.male, dateFrom, dateTo, sourceCountryIds)));
+            candidateService.computeMostCommonOccupationStats(Gender.male, dateFrom, dateTo, sourceCountryIds)));
         statReports.add(new StatReport(title + " (female)",
-                this.candidateService.computeMostCommonOccupationStats(Gender.female, dateFrom, dateTo, sourceCountryIds)));
+            candidateService.computeMostCommonOccupationStats(Gender.female, dateFrom, dateTo, sourceCountryIds)));
 
         title = "Max Education Level";
         statReports.add(new StatReport(title,
-                this.candidateService.computeMaxEducationStats(null, dateFrom, dateTo, sourceCountryIds)));
+            candidateService.computeMaxEducationStats(null, dateFrom, dateTo, sourceCountryIds)));
         statReports.add(new StatReport(title + " (male)",
-                this.candidateService.computeMaxEducationStats(Gender.male, dateFrom, dateTo, sourceCountryIds)));
+            candidateService.computeMaxEducationStats(Gender.male, dateFrom, dateTo, sourceCountryIds)));
         statReports.add(new StatReport(title + " (female)",
-                this.candidateService.computeMaxEducationStats(Gender.female, dateFrom, dateTo, sourceCountryIds)));
+            candidateService.computeMaxEducationStats(Gender.female, dateFrom, dateTo, sourceCountryIds)));
 
         title = "Languages";
         statReports.add(new StatReport(title,
-                this.candidateService.computeLanguageStats(null, dateFrom, dateTo, sourceCountryIds)));
+            candidateService.computeLanguageStats(null, dateFrom, dateTo, sourceCountryIds)));
         statReports.add(new StatReport(title + " (male)",
-                this.candidateService.computeLanguageStats(Gender.male, dateFrom, dateTo, sourceCountryIds)));
+            candidateService.computeLanguageStats(Gender.male, dateFrom, dateTo, sourceCountryIds)));
         statReports.add(new StatReport(title + " (female)",
-                this.candidateService.computeLanguageStats(Gender.female, dateFrom, dateTo, sourceCountryIds)));
+            candidateService.computeLanguageStats(Gender.female, dateFrom, dateTo, sourceCountryIds)));
 
         title = "Referrers";
         chartType = "bar";
         statReports.add(new StatReport(title,
-            this.candidateService.computeReferrerStats(null, null, dateFrom, dateTo, sourceCountryIds), chartType));
+            candidateService.computeReferrerStats(null, null, dateFrom, dateTo, sourceCountryIds), chartType));
         statReports.add(new StatReport(title + " (male)",
-            this.candidateService.computeReferrerStats(Gender.male, null, dateFrom, dateTo, sourceCountryIds), chartType));
+            candidateService.computeReferrerStats(Gender.male, null, dateFrom, dateTo, sourceCountryIds), chartType));
         statReports.add(new StatReport(title + " (female)",
-            this.candidateService.computeReferrerStats(Gender.female, null, dateFrom, dateTo, sourceCountryIds), chartType));
+            candidateService.computeReferrerStats(Gender.female, null, dateFrom, dateTo, sourceCountryIds), chartType));
 
         title = "Survey";
         statReports.add(new StatReport(title,
-                this.candidateService.computeSurveyStats(null, null, dateFrom, dateTo, sourceCountryIds)));
+            candidateService.computeSurveyStats(null, null, dateFrom, dateTo, sourceCountryIds)));
         statReports.add(new StatReport(title + " (Jordan)",
-                this.candidateService.computeSurveyStats(null, "jordan", dateFrom, dateTo, sourceCountryIds)));
+            candidateService.computeSurveyStats(null, "jordan", dateFrom, dateTo, sourceCountryIds)));
         statReports.add(new StatReport(title + " (Lebanon)",
-                this.candidateService.computeSurveyStats(null, "lebanon", dateFrom, dateTo, sourceCountryIds)));
+            candidateService.computeSurveyStats(null, "lebanon", dateFrom, dateTo, sourceCountryIds)));
         statReports.add(new StatReport(title + " (male)",
-                this.candidateService.computeSurveyStats(Gender.male, null, dateFrom, dateTo, sourceCountryIds)));
+            candidateService.computeSurveyStats(Gender.male, null, dateFrom, dateTo, sourceCountryIds)));
         statReports.add(new StatReport(title + " (female)",
-                this.candidateService.computeSurveyStats(Gender.female, null, dateFrom, dateTo, sourceCountryIds)));
-
+            candidateService.computeSurveyStats(Gender.female, null, dateFrom, dateTo, sourceCountryIds)));
 
         language = "English";
         title = "Spoken " + language + " Language Level";
         statReports.add(new StatReport(title,
-                this.candidateService.computeSpokenLanguageLevelStats(null, language, dateFrom, dateTo, sourceCountryIds)));
+            candidateService.computeSpokenLanguageLevelStats(null, language, dateFrom, dateTo, sourceCountryIds)));
         statReports.add(new StatReport(title + " (male)",
-                this.candidateService.computeSpokenLanguageLevelStats(Gender.male, language, dateFrom, dateTo, sourceCountryIds)));
+            candidateService.computeSpokenLanguageLevelStats(Gender.male, language, dateFrom, dateTo, sourceCountryIds)));
         statReports.add(new StatReport(title + " (female)",
-                this.candidateService.computeSpokenLanguageLevelStats(Gender.female, language, dateFrom, dateTo, sourceCountryIds)));
+            candidateService.computeSpokenLanguageLevelStats(Gender.female, language, dateFrom, dateTo, sourceCountryIds)));
 
         language = "French";
         title = "Spoken " + language + " Language Level";
         statReports.add(new StatReport(title,
-                this.candidateService.computeSpokenLanguageLevelStats(null, language, dateFrom, dateTo, sourceCountryIds)));
+            candidateService.computeSpokenLanguageLevelStats(null, language, dateFrom, dateTo, sourceCountryIds)));
         statReports.add(new StatReport(title + " (male)",
-                this.candidateService.computeSpokenLanguageLevelStats(Gender.male, language, dateFrom, dateTo, sourceCountryIds)));
+            candidateService.computeSpokenLanguageLevelStats(Gender.male, language, dateFrom, dateTo, sourceCountryIds)));
         statReports.add(new StatReport(title + " (female)",
-                this.candidateService.computeSpokenLanguageLevelStats(Gender.female, language, dateFrom, dateTo, sourceCountryIds)));
+            candidateService.computeSpokenLanguageLevelStats(Gender.female, language, dateFrom, dateTo, sourceCountryIds)));
 
         return statReports;
     }
@@ -292,133 +278,133 @@ public class CandidateStatAdminApi {
         List<StatReport> statReports = new ArrayList<>();
         chartType = "bar";
         statReports.add(new StatReport("Gender",
-                this.candidateService.computeGenderStats(dateFrom, dateTo, candidateIds, sourceCountryIds), chartType));
+            candidateService.computeGenderStats(dateFrom, dateTo, candidateIds, sourceCountryIds), chartType));
 
         title = "Registrations";
         chartType = "bar";
         statReports.add(new StatReport(title,
-                this.candidateService.computeRegistrationStats(dateFrom, dateTo, candidateIds, sourceCountryIds), chartType));
+            candidateService.computeRegistrationStats(dateFrom, dateTo, candidateIds, sourceCountryIds), chartType));
         statReports.add(new StatReport(title + " (by occupations)",
-                this.candidateService.computeRegistrationOccupationStats(dateFrom, dateTo, candidateIds, sourceCountryIds)));
+            candidateService.computeRegistrationOccupationStats(dateFrom, dateTo, candidateIds, sourceCountryIds)));
 
         title = "Birth years";
         chartType = "bar";
         statReports.add(new StatReport(title,
-                this.candidateService.computeBirthYearStats(null, dateFrom, dateTo, candidateIds, sourceCountryIds), chartType));
+            candidateService.computeBirthYearStats(null, dateFrom, dateTo, candidateIds, sourceCountryIds), chartType));
         statReports.add(new StatReport(title + " (male)",
-                this.candidateService.computeBirthYearStats(Gender.male, dateFrom, dateTo, candidateIds, sourceCountryIds), chartType));
+            candidateService.computeBirthYearStats(Gender.male, dateFrom, dateTo, candidateIds, sourceCountryIds), chartType));
         statReports.add(new StatReport(title + " (female)",
-                this.candidateService.computeBirthYearStats(Gender.female, dateFrom, dateTo, candidateIds, sourceCountryIds), chartType));
+            candidateService.computeBirthYearStats(Gender.female, dateFrom, dateTo, candidateIds, sourceCountryIds), chartType));
 
         title = "LinkedIn";
         chartType = "bar";
         statReports.add(new StatReport(title + " links",
-            this.candidateService.computeLinkedInExistsStats(dateFrom, dateTo, candidateIds, sourceCountryIds), chartType));
+            candidateService.computeLinkedInExistsStats(dateFrom, dateTo, candidateIds, sourceCountryIds), chartType));
         statReports.add(new StatReport(title + " links by candidate registration date",
-            this.candidateService.computeLinkedInStats(dateFrom, dateTo, candidateIds, sourceCountryIds), chartType));
+            candidateService.computeLinkedInStats(dateFrom, dateTo, candidateIds, sourceCountryIds), chartType));
 
         title = "UNHCR";
         chartType = "bar";
         statReports.add(new StatReport(title + " Registered",
-            this.candidateService.computeUnhcrRegisteredStats(dateFrom, dateTo, candidateIds, sourceCountryIds), chartType));
+            candidateService.computeUnhcrRegisteredStats(dateFrom, dateTo, candidateIds, sourceCountryIds), chartType));
         statReports.add(new StatReport(title + " Status",
-            this.candidateService.computeUnhcrStatusStats(dateFrom, dateTo, candidateIds, sourceCountryIds), chartType));
+            candidateService.computeUnhcrStatusStats(dateFrom, dateTo, candidateIds, sourceCountryIds), chartType));
 
         title = "Referrers";
         chartType = "bar";
         statReports.add(new StatReport(title,
-            this.candidateService.computeReferrerStats(null, null, dateFrom, dateTo, candidateIds, sourceCountryIds), chartType));
+            candidateService.computeReferrerStats(null, null, dateFrom, dateTo, candidateIds, sourceCountryIds), chartType));
         statReports.add(new StatReport(title + " (male)",
-            this.candidateService.computeReferrerStats(Gender.male, null, dateFrom, dateTo, candidateIds, sourceCountryIds), chartType));
+            candidateService.computeReferrerStats(Gender.male, null, dateFrom, dateTo, candidateIds, sourceCountryIds), chartType));
         statReports.add(new StatReport(title + " (female)",
-            this.candidateService.computeReferrerStats(Gender.female, null, dateFrom, dateTo, candidateIds, sourceCountryIds), chartType));
+            candidateService.computeReferrerStats(Gender.female, null, dateFrom, dateTo, candidateIds, sourceCountryIds), chartType));
 
         title = "Nationalities";
         statReports.add(new StatReport(title,
-                this.candidateService.computeNationalityStats(null, null, dateFrom, dateTo, candidateIds, sourceCountryIds)));
+            candidateService.computeNationalityStats(null, null, dateFrom, dateTo, candidateIds, sourceCountryIds)));
         statReports.add(new StatReport(title + " (male)",
-                this.candidateService.computeNationalityStats(Gender.male, null, dateFrom, dateTo, candidateIds, sourceCountryIds)));
+            candidateService.computeNationalityStats(Gender.male, null, dateFrom, dateTo, candidateIds, sourceCountryIds)));
         statReports.add(new StatReport(title + " (female)",
-                this.candidateService.computeNationalityStats(Gender.female, null, dateFrom, dateTo, candidateIds, sourceCountryIds)));
+            candidateService.computeNationalityStats(Gender.female, null, dateFrom, dateTo, candidateIds, sourceCountryIds)));
         statReports.add(new StatReport(title + " (Jordan)",
-                this.candidateService.computeNationalityStats(null, "jordan", dateFrom, dateTo, candidateIds, sourceCountryIds)));
+            candidateService.computeNationalityStats(null, "jordan", dateFrom, dateTo, candidateIds, sourceCountryIds)));
         statReports.add(new StatReport(title + " (Lebanon)",
-                this.candidateService.computeNationalityStats(null, "lebanon", dateFrom, dateTo, candidateIds, sourceCountryIds)));
+            candidateService.computeNationalityStats(null, "lebanon", dateFrom, dateTo, candidateIds, sourceCountryIds)));
 
         title = "Statuses";
         statReports.add(new StatReport(title,
-                this.candidateService.computeStatusStats(null, null, dateFrom, dateTo, candidateIds, sourceCountryIds)));
+            candidateService.computeStatusStats(null, null, dateFrom, dateTo, candidateIds, sourceCountryIds)));
         statReports.add(new StatReport(title + " (male)",
-                this.candidateService.computeStatusStats(Gender.male, null, dateFrom, dateTo, candidateIds, sourceCountryIds)));
+            candidateService.computeStatusStats(Gender.male, null, dateFrom, dateTo, candidateIds, sourceCountryIds)));
         statReports.add(new StatReport(title + " (female)",
-                this.candidateService.computeStatusStats(Gender.female, null, dateFrom, dateTo, candidateIds, sourceCountryIds)));
+            candidateService.computeStatusStats(Gender.female, null, dateFrom, dateTo, candidateIds, sourceCountryIds)));
         statReports.add(new StatReport(title + " (Jordan)",
-                this.candidateService.computeStatusStats(null, "jordan", dateFrom, dateTo, candidateIds, sourceCountryIds)));
+            candidateService.computeStatusStats(null, "jordan", dateFrom, dateTo, candidateIds, sourceCountryIds)));
         statReports.add(new StatReport(title + " (Lebanon)",
-                this.candidateService.computeStatusStats(null, "lebanon", dateFrom, dateTo, candidateIds, sourceCountryIds)));
+            candidateService.computeStatusStats(null, "lebanon", dateFrom, dateTo, candidateIds, sourceCountryIds)));
 
         title = "Occupations";
         statReports.add(new StatReport(title + "",
-                this.candidateService.computeOccupationStats(null, dateFrom, dateTo, candidateIds, sourceCountryIds)));
+            candidateService.computeOccupationStats(null, dateFrom, dateTo, candidateIds, sourceCountryIds)));
         statReports.add(new StatReport(title + " (male)",
-                this.candidateService.computeOccupationStats(Gender.male, dateFrom, dateTo, candidateIds, sourceCountryIds)));
+            candidateService.computeOccupationStats(Gender.male, dateFrom, dateTo, candidateIds, sourceCountryIds)));
         statReports.add(new StatReport(title + " (female)",
-                this.candidateService.computeOccupationStats(Gender.female, dateFrom, dateTo, candidateIds, sourceCountryIds)));
+            candidateService.computeOccupationStats(Gender.female, dateFrom, dateTo, candidateIds, sourceCountryIds)));
 
         title = "Most Common Occupations";
         statReports.add(new StatReport(title + "",
-                this.candidateService.computeMostCommonOccupationStats(null, dateFrom, dateTo, candidateIds, sourceCountryIds)));
+            candidateService.computeMostCommonOccupationStats(null, dateFrom, dateTo, candidateIds, sourceCountryIds)));
         statReports.add(new StatReport(title + " (male)",
-                this.candidateService.computeMostCommonOccupationStats(Gender.male, dateFrom, dateTo, candidateIds, sourceCountryIds)));
+            candidateService.computeMostCommonOccupationStats(Gender.male, dateFrom, dateTo, candidateIds, sourceCountryIds)));
         statReports.add(new StatReport(title + " (female)",
-                this.candidateService.computeMostCommonOccupationStats(Gender.female, dateFrom, dateTo, candidateIds, sourceCountryIds)));
+            candidateService.computeMostCommonOccupationStats(Gender.female, dateFrom, dateTo, candidateIds, sourceCountryIds)));
 
         title = "Max Education Level";
         statReports.add(new StatReport(title,
-                this.candidateService.computeMaxEducationStats(null, dateFrom, dateTo, candidateIds, sourceCountryIds)));
+            candidateService.computeMaxEducationStats(null, dateFrom, dateTo, candidateIds, sourceCountryIds)));
         statReports.add(new StatReport(title + " (male)",
-                this.candidateService.computeMaxEducationStats(Gender.male, dateFrom, dateTo, candidateIds, sourceCountryIds)));
+            candidateService.computeMaxEducationStats(Gender.male, dateFrom, dateTo, candidateIds, sourceCountryIds)));
         statReports.add(new StatReport(title + " (female)",
-                this.candidateService.computeMaxEducationStats(Gender.female, dateFrom, dateTo, candidateIds, sourceCountryIds)));
+            candidateService.computeMaxEducationStats(Gender.female, dateFrom, dateTo, candidateIds, sourceCountryIds)));
 
         title = "Languages";
         statReports.add(new StatReport(title,
-                this.candidateService.computeLanguageStats(null, dateFrom, dateTo, candidateIds, sourceCountryIds)));
+            candidateService.computeLanguageStats(null, dateFrom, dateTo, candidateIds, sourceCountryIds)));
         statReports.add(new StatReport(title + " (male)",
-                this.candidateService.computeLanguageStats(Gender.male, dateFrom, dateTo, candidateIds, sourceCountryIds)));
+            candidateService.computeLanguageStats(Gender.male, dateFrom, dateTo, candidateIds, sourceCountryIds)));
         statReports.add(new StatReport(title + " (female)",
-                this.candidateService.computeLanguageStats(Gender.female, dateFrom, dateTo, candidateIds, sourceCountryIds)));
+            candidateService.computeLanguageStats(Gender.female, dateFrom, dateTo, candidateIds, sourceCountryIds)));
 
         title = "Survey";
         statReports.add(new StatReport(title,
-                this.candidateService.computeSurveyStats(null, null, dateFrom, dateTo, candidateIds, sourceCountryIds)));
+            candidateService.computeSurveyStats(null, null, dateFrom, dateTo, candidateIds, sourceCountryIds)));
         statReports.add(new StatReport(title + " (Jordan)",
-                this.candidateService.computeSurveyStats(null, "jordan", dateFrom, dateTo, candidateIds, sourceCountryIds)));
+            candidateService.computeSurveyStats(null, "jordan", dateFrom, dateTo, candidateIds, sourceCountryIds)));
         statReports.add(new StatReport(title + " (Lebanon)",
-                this.candidateService.computeSurveyStats(null, "lebanon", dateFrom, dateTo, candidateIds, sourceCountryIds)));
+            candidateService.computeSurveyStats(null, "lebanon", dateFrom, dateTo, candidateIds, sourceCountryIds)));
         statReports.add(new StatReport(title + " (male)",
-                this.candidateService.computeSurveyStats(Gender.male, null, dateFrom, dateTo, candidateIds, sourceCountryIds)));
+            candidateService.computeSurveyStats(Gender.male, null, dateFrom, dateTo, candidateIds, sourceCountryIds)));
         statReports.add(new StatReport(title + " (female)",
-                this.candidateService.computeSurveyStats(Gender.female, null, dateFrom, dateTo, candidateIds, sourceCountryIds)));
+            candidateService.computeSurveyStats(Gender.female, null, dateFrom, dateTo, candidateIds, sourceCountryIds)));
 
 
         language = "English";
         title = "Spoken " + language + " Language Level";
         statReports.add(new StatReport(title,
-                this.candidateService.computeSpokenLanguageLevelStats(null, language, dateFrom, dateTo, candidateIds, sourceCountryIds)));
+            candidateService.computeSpokenLanguageLevelStats(null, language, dateFrom, dateTo, candidateIds, sourceCountryIds)));
         statReports.add(new StatReport(title + " (male)",
-                this.candidateService.computeSpokenLanguageLevelStats(Gender.male, language, dateFrom, dateTo, candidateIds, sourceCountryIds)));
+            candidateService.computeSpokenLanguageLevelStats(Gender.male, language, dateFrom, dateTo, candidateIds, sourceCountryIds)));
         statReports.add(new StatReport(title + " (female)",
-                this.candidateService.computeSpokenLanguageLevelStats(Gender.female, language, dateFrom, dateTo, candidateIds, sourceCountryIds)));
+            candidateService.computeSpokenLanguageLevelStats(Gender.female, language, dateFrom, dateTo, candidateIds, sourceCountryIds)));
 
         language = "French";
         title = "Spoken " + language + " Language Level";
         statReports.add(new StatReport(title,
-                this.candidateService.computeSpokenLanguageLevelStats(null, language, dateFrom, dateTo, candidateIds, sourceCountryIds)));
+            candidateService.computeSpokenLanguageLevelStats(null, language, dateFrom, dateTo, candidateIds, sourceCountryIds)));
         statReports.add(new StatReport(title + " (male)",
-                this.candidateService.computeSpokenLanguageLevelStats(Gender.male, language, dateFrom, dateTo, candidateIds, sourceCountryIds)));
+            candidateService.computeSpokenLanguageLevelStats(Gender.male, language, dateFrom, dateTo, candidateIds, sourceCountryIds)));
         statReports.add(new StatReport(title + " (female)",
-                this.candidateService.computeSpokenLanguageLevelStats(Gender.female, language, dateFrom, dateTo, candidateIds, sourceCountryIds)));
+            candidateService.computeSpokenLanguageLevelStats(Gender.female, language, dateFrom, dateTo, candidateIds, sourceCountryIds)));
 
         return statReports;
     }

--- a/server/src/test/java/org/tctalent/server/api/admin/CandidateStatAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/CandidateStatAdminApiTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2023 Talent Beyond Boundaries.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.api.admin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.tctalent.server.api.admin.StatsApiTestUtil.getGenderStats;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.tctalent.server.model.db.Country;
+import org.tctalent.server.model.db.Status;
+import org.tctalent.server.repository.db.CountryRepository;
+import org.tctalent.server.request.candidate.stat.CandidateStatsRequest;
+import org.tctalent.server.security.AuthService;
+import org.tctalent.server.service.db.CandidateService;
+import org.tctalent.server.service.db.SavedListService;
+import org.tctalent.server.service.db.SavedSearchService;
+
+/**
+ * Unit tests for Candidate Stats Admin Api endpoints.
+ *
+ * @author sadatmalik
+ */
+@WebMvcTest(CandidateStatAdminApi.class)
+@AutoConfigureMockMvc
+class CandidateStatAdminApiTest extends ApiTestBase {
+
+  private static final String BASE_PATH = "/api/admin/candidate/stat";
+
+  private static final String ALL_STATS_PATH = "/all";
+
+  @MockBean CandidateService candidateService;
+  @MockBean CountryRepository countryRepository;
+  @MockBean SavedListService savedListService;
+  @MockBean SavedSearchService savedSearchService;
+  @MockBean AuthService authService;
+
+  @Autowired MockMvc mockMvc;
+  @Autowired ObjectMapper objectMapper;
+  @Autowired CandidateStatAdminApi candidateStatAdminApi;
+
+  @BeforeEach
+  void setUp() {
+    configureAuthentication();
+
+    user.setSourceCountries(Set.of(
+        new Country("Jordan", Status.active),
+        new Country("Lebanon", Status.active),
+        new Country("Pakistan", Status.active)
+    ));
+
+    given(authService
+        .getLoggedInUser())
+        .willReturn(Optional.of(user));
+  }
+
+  @Test
+  public void testWebOnlyContextLoads() {
+    assertThat(candidateStatAdminApi).isNotNull();
+  }
+
+  @Test
+  @DisplayName("get all stats - gender report succeeds")
+  void getAllStatsGenderReportSucceeds() throws Exception {
+    CandidateStatsRequest request = new CandidateStatsRequest();
+
+    given(candidateService
+        .computeGenderStats(any(), any(), any()))
+        .willReturn(getGenderStats());
+
+    mockMvc.perform(post(BASE_PATH + ALL_STATS_PATH)
+            .header("Authorization", "Bearer " + "jwt-token")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request))
+            .accept(MediaType.APPLICATION_JSON))
+
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$", notNullValue()))
+        .andExpect(jsonPath("$", hasSize(46)))
+
+        // Gender
+        .andExpect(jsonPath("$[0].name", is("Gender")))
+        .andExpect(jsonPath("$[0].chartType", is("bar")))
+        .andExpect(jsonPath("$[0].rows", notNullValue()))
+        .andExpect(jsonPath("$[0].rows", hasSize(3)))
+        .andExpect(jsonPath("$[0].rows[0].label", is("male")))
+        .andExpect(jsonPath("$[0].rows[0].value", is(15111)))
+        .andExpect(jsonPath("$[0].rows[1].label", is("undefined")))
+        .andExpect(jsonPath("$[0].rows[1].value", is(3772)))
+        .andExpect(jsonPath("$[0].rows[2].label", is("female")))
+        .andExpect(jsonPath("$[0].rows[2].value", is(2588)));
+
+    verify(authService).getLoggedInUser();
+    verify(candidateService).computeGenderStats(any(), any(), any());
+  }
+
+}

--- a/server/src/test/java/org/tctalent/server/api/admin/CandidateStatAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/CandidateStatAdminApiTest.java
@@ -155,8 +155,8 @@ class CandidateStatAdminApiTest extends ApiTestBase {
         .andExpect(jsonPath("$", hasSize(46)))
 
         // Registrations
-        .andExpect(jsonPath("$[0].name", is("Gender")))
-        .andExpect(jsonPath("$[0].chartType", is("bar")))
+        .andExpect(jsonPath("$[1].name", is("Registrations")))
+        .andExpect(jsonPath("$[1].chartType", is("bar")))
         .andExpect(jsonPath("$[1].rows", notNullValue()))
         .andExpect(jsonPath("$[1].rows", hasSize(3)))
         .andExpect(jsonPath("$[1].rows[0].label", is("2016-06-04")))
@@ -192,8 +192,8 @@ class CandidateStatAdminApiTest extends ApiTestBase {
         .andExpect(jsonPath("$", hasSize(46)))
 
         // Registrations by Occupation
-        .andExpect(jsonPath("$[0].name", is("Gender")))
-        .andExpect(jsonPath("$[0].chartType", is("bar")))
+        .andExpect(jsonPath("$[2].name", is("Registrations (by occupations)")))
+        .andExpect(jsonPath("$[2].chartType", is("doughnut")))
         .andExpect(jsonPath("$[2].rows", notNullValue()))
         .andExpect(jsonPath("$[2].rows", hasSize(3)))
         .andExpect(jsonPath("$[2].rows[0].label", is("undefined")))

--- a/server/src/test/java/org/tctalent/server/api/admin/CandidateStatAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/CandidateStatAdminApiTest.java
@@ -33,6 +33,7 @@ import static org.tctalent.server.api.admin.StatsApiTestUtil.getBirthYearStats;
 import static org.tctalent.server.api.admin.StatsApiTestUtil.getGenderStats;
 import static org.tctalent.server.api.admin.StatsApiTestUtil.getLinkedInByRegistrationDateStats;
 import static org.tctalent.server.api.admin.StatsApiTestUtil.getLinkedInExistsStats;
+import static org.tctalent.server.api.admin.StatsApiTestUtil.getMaxEducationStats;
 import static org.tctalent.server.api.admin.StatsApiTestUtil.getNationalityStats;
 import static org.tctalent.server.api.admin.StatsApiTestUtil.getOccupationStats;
 import static org.tctalent.server.api.admin.StatsApiTestUtil.getRegistrationByOccupationStats;
@@ -551,7 +552,42 @@ class CandidateStatAdminApiTest extends ApiTestBase {
     verify(candidateService, times(3)).computeMostCommonOccupationStats(any(), any(), any(), any());
   }
 
-  // max education level
+  @Test
+  @DisplayName("get all stats - most max education level report succeeds")
+  void getAllStatsMaxEducationLevelReportSucceeds() throws Exception {
+    CandidateStatsRequest request = new CandidateStatsRequest();
+
+    given(candidateService
+        .computeMaxEducationStats(any(), any(), any(), any()))
+        .willReturn(getMaxEducationStats());
+
+    mockMvc.perform(post(BASE_PATH + ALL_STATS_PATH)
+            .header("Authorization", "Bearer " + "jwt-token")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request))
+            .accept(MediaType.APPLICATION_JSON))
+
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$", notNullValue()))
+        .andExpect(jsonPath("$", hasSize(46)))
+
+        // max education level
+        .andExpect(jsonPath("$[26].name", is("Max Education Level")))
+        .andExpect(jsonPath("$[26].chartType", is("doughnut")))
+        .andExpect(jsonPath("$[26].rows", notNullValue()))
+        .andExpect(jsonPath("$[26].rows", hasSize(3)))
+        .andExpect(jsonPath("$[26].rows[0].label", is("Bachelor's Degree")))
+        .andExpect(jsonPath("$[26].rows[0].value", is(1000)))
+        .andExpect(jsonPath("$[26].rows[1].label", is("Primary School")))
+        .andExpect(jsonPath("$[26].rows[1].value", is(2000)))
+        .andExpect(jsonPath("$[26].rows[2].label", is("Doctoral Degree")))
+        .andExpect(jsonPath("$[26].rows[2].value", is(3000)));
+
+    verify(authService).getLoggedInUser();
+    verify(candidateService, times(3)).computeMaxEducationStats(any(), any(), any(), any());
+  }
 
   // languages
 

--- a/server/src/test/java/org/tctalent/server/api/admin/CandidateStatAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/CandidateStatAdminApiTest.java
@@ -36,6 +36,7 @@ import static org.tctalent.server.api.admin.StatsApiTestUtil.getLinkedInExistsSt
 import static org.tctalent.server.api.admin.StatsApiTestUtil.getNationalityStats;
 import static org.tctalent.server.api.admin.StatsApiTestUtil.getRegistrationByOccupationStats;
 import static org.tctalent.server.api.admin.StatsApiTestUtil.getRegistrationStats;
+import static org.tctalent.server.api.admin.StatsApiTestUtil.getStatusStats;
 import static org.tctalent.server.api.admin.StatsApiTestUtil.getUnhcrRegistrationStats;
 import static org.tctalent.server.api.admin.StatsApiTestUtil.getUnhcrStatusStats;
 
@@ -432,5 +433,46 @@ class CandidateStatAdminApiTest extends ApiTestBase {
 
     verify(authService).getLoggedInUser();
     verify(candidateService, times(5)).computeNationalityStats(any(), any(), any(), any(), any());
+  }
+
+  @Test
+  @DisplayName("get all stats - status report succeeds")
+  void getAllStatsStatusReportSucceeds() throws Exception {
+    CandidateStatsRequest request = new CandidateStatsRequest();
+
+    given(candidateService
+        .computeStatusStats(any(), any(), any(), any(), any()))
+        .willReturn(getStatusStats());
+
+    mockMvc.perform(post(BASE_PATH + ALL_STATS_PATH)
+            .header("Authorization", "Bearer " + "jwt-token")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request))
+            .accept(MediaType.APPLICATION_JSON))
+
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$", notNullValue()))
+        .andExpect(jsonPath("$", hasSize(46)))
+
+        // Statuses
+        .andExpect(jsonPath("$[15].name", is("Statuses")))
+        .andExpect(jsonPath("$[15].chartType", is("doughnut")))
+        .andExpect(jsonPath("$[15].rows", notNullValue()))
+        .andExpect(jsonPath("$[15].rows", hasSize(5)))
+        .andExpect(jsonPath("$[15].rows[0].label", is("pending")))
+        .andExpect(jsonPath("$[15].rows[0].value", is(1000)))
+        .andExpect(jsonPath("$[15].rows[1].label", is("incomplete")))
+        .andExpect(jsonPath("$[15].rows[1].value", is(2000)))
+        .andExpect(jsonPath("$[15].rows[2].label", is("active")))
+        .andExpect(jsonPath("$[15].rows[2].value", is(3000)))
+        .andExpect(jsonPath("$[15].rows[3].label", is("employed")))
+        .andExpect(jsonPath("$[15].rows[3].value", is(4000)))
+        .andExpect(jsonPath("$[15].rows[4].label", is("autonomousEmployment")))
+        .andExpect(jsonPath("$[15].rows[4].value", is(5000)));
+
+    verify(authService).getLoggedInUser();
+    verify(candidateService, times(5)).computeStatusStats(any(), any(), any(), any(), any());
   }
 }

--- a/server/src/test/java/org/tctalent/server/api/admin/CandidateStatAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/CandidateStatAdminApiTest.java
@@ -29,6 +29,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.tctalent.server.api.admin.StatsApiTestUtil.getGenderStats;
+import static org.tctalent.server.api.admin.StatsApiTestUtil.getRegistrationByOccupationStats;
+import static org.tctalent.server.api.admin.StatsApiTestUtil.getRegistrationStats;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Optional;
@@ -129,6 +131,80 @@ class CandidateStatAdminApiTest extends ApiTestBase {
 
     verify(authService).getLoggedInUser();
     verify(candidateService).computeGenderStats(any(), any(), any());
+  }
+
+  @Test
+  @DisplayName("get all stats - registration report succeeds")
+  void getAllStatsRegistrationReportSucceeds() throws Exception {
+    CandidateStatsRequest request = new CandidateStatsRequest();
+
+    given(candidateService
+        .computeRegistrationStats(any(), any(), any()))
+        .willReturn(getRegistrationStats());
+
+    mockMvc.perform(post(BASE_PATH + ALL_STATS_PATH)
+            .header("Authorization", "Bearer " + "jwt-token")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request))
+            .accept(MediaType.APPLICATION_JSON))
+
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$", notNullValue()))
+        .andExpect(jsonPath("$", hasSize(46)))
+
+        // Registrations
+        .andExpect(jsonPath("$[0].name", is("Gender")))
+        .andExpect(jsonPath("$[0].chartType", is("bar")))
+        .andExpect(jsonPath("$[1].rows", notNullValue()))
+        .andExpect(jsonPath("$[1].rows", hasSize(3)))
+        .andExpect(jsonPath("$[1].rows[0].label", is("2016-06-04")))
+        .andExpect(jsonPath("$[1].rows[0].value", is(4)))
+        .andExpect(jsonPath("$[1].rows[1].label", is("2016-06-10")))
+        .andExpect(jsonPath("$[1].rows[1].value", is(1)))
+        .andExpect(jsonPath("$[1].rows[2].label", is("2016-06-14")))
+        .andExpect(jsonPath("$[1].rows[2].value", is(1)));
+
+    verify(authService).getLoggedInUser();
+    verify(candidateService).computeRegistrationStats(any(), any(), any());
+  }
+
+  @Test
+  @DisplayName("get all stats - registration by occupation report succeeds")
+  void getAllStatsRegistrationByOccupationReportSucceeds() throws Exception {
+    CandidateStatsRequest request = new CandidateStatsRequest();
+
+    given(candidateService
+        .computeRegistrationOccupationStats(any(), any(), any()))
+        .willReturn(getRegistrationByOccupationStats());
+
+    mockMvc.perform(post(BASE_PATH + ALL_STATS_PATH)
+            .header("Authorization", "Bearer " + "jwt-token")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request))
+            .accept(MediaType.APPLICATION_JSON))
+
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$", notNullValue()))
+        .andExpect(jsonPath("$", hasSize(46)))
+
+        // Registrations by Occupation
+        .andExpect(jsonPath("$[0].name", is("Gender")))
+        .andExpect(jsonPath("$[0].chartType", is("bar")))
+        .andExpect(jsonPath("$[2].rows", notNullValue()))
+        .andExpect(jsonPath("$[2].rows", hasSize(3)))
+        .andExpect(jsonPath("$[2].rows[0].label", is("undefined")))
+        .andExpect(jsonPath("$[2].rows[0].value", is(11414)))
+        .andExpect(jsonPath("$[2].rows[1].label", is("Unknown")))
+        .andExpect(jsonPath("$[2].rows[1].value", is(1652)))
+        .andExpect(jsonPath("$[2].rows[2].label", is("Teacher")))
+        .andExpect(jsonPath("$[2].rows[2].value", is(777)));
+
+    verify(authService).getLoggedInUser();
+    verify(candidateService).computeRegistrationOccupationStats(any(), any(), any());
   }
 
 }

--- a/server/src/test/java/org/tctalent/server/api/admin/CandidateStatAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/CandidateStatAdminApiTest.java
@@ -40,6 +40,7 @@ import static org.tctalent.server.api.admin.StatsApiTestUtil.getOccupationStats;
 import static org.tctalent.server.api.admin.StatsApiTestUtil.getReferrerStats;
 import static org.tctalent.server.api.admin.StatsApiTestUtil.getRegistrationByOccupationStats;
 import static org.tctalent.server.api.admin.StatsApiTestUtil.getRegistrationStats;
+import static org.tctalent.server.api.admin.StatsApiTestUtil.getSpokenLanguageLevelStats;
 import static org.tctalent.server.api.admin.StatsApiTestUtil.getStatusStats;
 import static org.tctalent.server.api.admin.StatsApiTestUtil.getSurveyStats;
 import static org.tctalent.server.api.admin.StatsApiTestUtil.getUnhcrRegistrationStats;
@@ -701,7 +702,41 @@ class CandidateStatAdminApiTest extends ApiTestBase {
     verify(candidateService, times(5)).computeSurveyStats(any(), any(), any(), any(), any());
   }
 
-  // english
+  @Test
+  @DisplayName("get all stats - spoken language report succeeds")
+  void getAllStatsSpokenLanguageReportSucceeds() throws Exception {
+    CandidateStatsRequest request = new CandidateStatsRequest();
 
-  // french
+    given(candidateService
+        .computeSpokenLanguageLevelStats(any(), any(), any(), any(), any()))
+        .willReturn(getSpokenLanguageLevelStats());
+
+    mockMvc.perform(post(BASE_PATH + ALL_STATS_PATH)
+            .header("Authorization", "Bearer " + "jwt-token")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request))
+            .accept(MediaType.APPLICATION_JSON))
+
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$", notNullValue()))
+        .andExpect(jsonPath("$", hasSize(46)))
+
+        // spoken language
+        .andExpect(jsonPath("$[40].name", is("Spoken English Language Level")))
+        .andExpect(jsonPath("$[40].chartType", is("doughnut")))
+        .andExpect(jsonPath("$[40].rows", notNullValue()))
+        .andExpect(jsonPath("$[40].rows", hasSize(3)))
+        .andExpect(jsonPath("$[40].rows[0].label", is("Intermediate Proficiency")))
+        .andExpect(jsonPath("$[40].rows[0].value", is(1000)))
+        .andExpect(jsonPath("$[40].rows[1].label", is("Full Professional Proficiency")))
+        .andExpect(jsonPath("$[40].rows[1].value", is(2000)))
+        .andExpect(jsonPath("$[40].rows[2].label", is("Elementary Proficiency")))
+        .andExpect(jsonPath("$[40].rows[2].value", is(3000)));
+
+    verify(authService).getLoggedInUser();
+    verify(candidateService, times(6)).computeSpokenLanguageLevelStats(any(), any(), any(), any(), any());
+  }
+
 }

--- a/server/src/test/java/org/tctalent/server/api/admin/CandidateStatAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/CandidateStatAdminApiTest.java
@@ -41,6 +41,7 @@ import static org.tctalent.server.api.admin.StatsApiTestUtil.getReferrerStats;
 import static org.tctalent.server.api.admin.StatsApiTestUtil.getRegistrationByOccupationStats;
 import static org.tctalent.server.api.admin.StatsApiTestUtil.getRegistrationStats;
 import static org.tctalent.server.api.admin.StatsApiTestUtil.getStatusStats;
+import static org.tctalent.server.api.admin.StatsApiTestUtil.getSurveyStats;
 import static org.tctalent.server.api.admin.StatsApiTestUtil.getUnhcrRegistrationStats;
 import static org.tctalent.server.api.admin.StatsApiTestUtil.getUnhcrStatusStats;
 
@@ -663,7 +664,42 @@ class CandidateStatAdminApiTest extends ApiTestBase {
     verify(candidateService, times(3)).computeReferrerStats(any(), any(), any(), any(), any());
   }
 
-  // survey
+  @Test
+  @DisplayName("get all stats - survey report succeeds")
+  void getAllStatsSurveyReportSucceeds() throws Exception {
+    CandidateStatsRequest request = new CandidateStatsRequest();
+
+    given(candidateService
+        .computeSurveyStats(any(), any(), any(), any(), any()))
+        .willReturn(getSurveyStats());
+
+    mockMvc.perform(post(BASE_PATH + ALL_STATS_PATH)
+            .header("Authorization", "Bearer " + "jwt-token")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request))
+            .accept(MediaType.APPLICATION_JSON))
+
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$", notNullValue()))
+        .andExpect(jsonPath("$", hasSize(46)))
+
+        // survey
+        .andExpect(jsonPath("$[35].name", is("Survey")))
+        .andExpect(jsonPath("$[35].chartType", is("doughnut")))
+        .andExpect(jsonPath("$[35].rows", notNullValue()))
+        .andExpect(jsonPath("$[35].rows", hasSize(3)))
+        .andExpect(jsonPath("$[35].rows[0].label", is("Facebook")))
+        .andExpect(jsonPath("$[35].rows[0].value", is(1000)))
+        .andExpect(jsonPath("$[35].rows[1].label", is("From a friend")))
+        .andExpect(jsonPath("$[35].rows[1].value", is(2000)))
+        .andExpect(jsonPath("$[35].rows[2].label", is("NGO")))
+        .andExpect(jsonPath("$[35].rows[2].value", is(3000)));
+
+    verify(authService).getLoggedInUser();
+    verify(candidateService, times(5)).computeSurveyStats(any(), any(), any(), any(), any());
+  }
 
   // english
 

--- a/server/src/test/java/org/tctalent/server/api/admin/CandidateStatAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/CandidateStatAdminApiTest.java
@@ -33,6 +33,7 @@ import static org.tctalent.server.api.admin.StatsApiTestUtil.getBirthYearStats;
 import static org.tctalent.server.api.admin.StatsApiTestUtil.getGenderStats;
 import static org.tctalent.server.api.admin.StatsApiTestUtil.getLinkedInByRegistrationDateStats;
 import static org.tctalent.server.api.admin.StatsApiTestUtil.getLinkedInExistsStats;
+import static org.tctalent.server.api.admin.StatsApiTestUtil.getNationalityStats;
 import static org.tctalent.server.api.admin.StatsApiTestUtil.getRegistrationByOccupationStats;
 import static org.tctalent.server.api.admin.StatsApiTestUtil.getRegistrationStats;
 import static org.tctalent.server.api.admin.StatsApiTestUtil.getUnhcrRegistrationStats;
@@ -396,5 +397,40 @@ class CandidateStatAdminApiTest extends ApiTestBase {
 
     verify(authService).getLoggedInUser();
     verify(candidateService).computeUnhcrStatusStats(any(), any(), any());
+  }
+
+  @Test
+  @DisplayName("get all stats - nationalities report succeeds")
+  void getAllStatsNationalityReportSucceeds() throws Exception {
+    CandidateStatsRequest request = new CandidateStatsRequest();
+
+    given(candidateService
+        .computeNationalityStats(any(), any(), any(), any(), any()))
+        .willReturn(getNationalityStats());
+
+    mockMvc.perform(post(BASE_PATH + ALL_STATS_PATH)
+            .header("Authorization", "Bearer " + "jwt-token")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request))
+            .accept(MediaType.APPLICATION_JSON))
+
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$", notNullValue()))
+        .andExpect(jsonPath("$", hasSize(46)))
+
+        // Nationality
+        .andExpect(jsonPath("$[10].name", is("Nationalities by Country")))
+        .andExpect(jsonPath("$[10].chartType", is("doughnut")))
+        .andExpect(jsonPath("$[10].rows", notNullValue()))
+        .andExpect(jsonPath("$[10].rows", hasSize(2)))
+        .andExpect(jsonPath("$[10].rows[0].label", is("Palestinian Territories")))
+        .andExpect(jsonPath("$[10].rows[0].value", is(1073)))
+        .andExpect(jsonPath("$[10].rows[1].label", is("Syria")))
+        .andExpect(jsonPath("$[10].rows[1].value", is(14852)));
+
+    verify(authService).getLoggedInUser();
+    verify(candidateService, times(5)).computeNationalityStats(any(), any(), any(), any(), any());
   }
 }

--- a/server/src/test/java/org/tctalent/server/api/admin/CandidateStatAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/CandidateStatAdminApiTest.java
@@ -514,4 +514,52 @@ class CandidateStatAdminApiTest extends ApiTestBase {
     verify(candidateService, times(3)).computeOccupationStats(any(), any(), any(), any());
   }
 
+  @Test
+  @DisplayName("get all stats - most common occupations report succeeds")
+  void getAllStatsMostCommonOccupationsReportSucceeds() throws Exception {
+    CandidateStatsRequest request = new CandidateStatsRequest();
+
+    given(candidateService
+        .computeMostCommonOccupationStats(any(), any(), any(), any()))
+        .willReturn(getOccupationStats());
+
+    mockMvc.perform(post(BASE_PATH + ALL_STATS_PATH)
+            .header("Authorization", "Bearer " + "jwt-token")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request))
+            .accept(MediaType.APPLICATION_JSON))
+
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$", notNullValue()))
+        .andExpect(jsonPath("$", hasSize(46)))
+
+        // most common occupation
+        .andExpect(jsonPath("$[23].name", is("Most Common Occupations")))
+        .andExpect(jsonPath("$[23].chartType", is("doughnut")))
+        .andExpect(jsonPath("$[23].rows", notNullValue()))
+        .andExpect(jsonPath("$[23].rows", hasSize(3)))
+        .andExpect(jsonPath("$[23].rows[0].label", is("undefined")))
+        .andExpect(jsonPath("$[23].rows[0].value", is(1000)))
+        .andExpect(jsonPath("$[23].rows[1].label", is("Teacher")))
+        .andExpect(jsonPath("$[23].rows[1].value", is(2000)))
+        .andExpect(jsonPath("$[23].rows[2].label", is("Accountant")))
+        .andExpect(jsonPath("$[23].rows[2].value", is(3000)));
+
+    verify(authService).getLoggedInUser();
+    verify(candidateService, times(3)).computeMostCommonOccupationStats(any(), any(), any(), any());
+  }
+
+  // max education level
+
+  // languages
+
+  // referrers
+
+  // survey
+
+  // english
+
+  // french
 }

--- a/server/src/test/java/org/tctalent/server/api/admin/CandidateStatAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/CandidateStatAdminApiTest.java
@@ -37,6 +37,7 @@ import static org.tctalent.server.api.admin.StatsApiTestUtil.getLinkedInExistsSt
 import static org.tctalent.server.api.admin.StatsApiTestUtil.getMaxEducationStats;
 import static org.tctalent.server.api.admin.StatsApiTestUtil.getNationalityStats;
 import static org.tctalent.server.api.admin.StatsApiTestUtil.getOccupationStats;
+import static org.tctalent.server.api.admin.StatsApiTestUtil.getReferrerStats;
 import static org.tctalent.server.api.admin.StatsApiTestUtil.getRegistrationByOccupationStats;
 import static org.tctalent.server.api.admin.StatsApiTestUtil.getRegistrationStats;
 import static org.tctalent.server.api.admin.StatsApiTestUtil.getStatusStats;
@@ -590,9 +591,8 @@ class CandidateStatAdminApiTest extends ApiTestBase {
     verify(candidateService, times(3)).computeMaxEducationStats(any(), any(), any(), any());
   }
 
-  // languages
   @Test
-  @DisplayName("get all stats - most languages report succeeds")
+  @DisplayName("get all stats - languages report succeeds")
   void getAllStatsLanguagesReportSucceeds() throws Exception {
     CandidateStatsRequest request = new CandidateStatsRequest();
 
@@ -612,7 +612,7 @@ class CandidateStatAdminApiTest extends ApiTestBase {
         .andExpect(jsonPath("$", notNullValue()))
         .andExpect(jsonPath("$", hasSize(46)))
 
-        // max education level
+        // languages
         .andExpect(jsonPath("$[29].name", is("Languages")))
         .andExpect(jsonPath("$[29].chartType", is("doughnut")))
         .andExpect(jsonPath("$[29].rows", notNullValue()))
@@ -628,7 +628,40 @@ class CandidateStatAdminApiTest extends ApiTestBase {
     verify(candidateService, times(3)).computeLanguageStats(any(), any(), any(), any());
   }
 
-  // referrers
+  @Test
+  @DisplayName("get all stats - referrers report succeeds")
+  void getAllStatsReferrersReportSucceeds() throws Exception {
+    CandidateStatsRequest request = new CandidateStatsRequest();
+
+    given(candidateService
+        .computeReferrerStats(any(), any(), any(), any(), any()))
+        .willReturn(getReferrerStats());
+
+    mockMvc.perform(post(BASE_PATH + ALL_STATS_PATH)
+            .header("Authorization", "Bearer " + "jwt-token")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request))
+            .accept(MediaType.APPLICATION_JSON))
+
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$", notNullValue()))
+        .andExpect(jsonPath("$", hasSize(46)))
+
+        // referrers
+        .andExpect(jsonPath("$[32].name", is("Referrers")))
+        .andExpect(jsonPath("$[32].chartType", is("bar")))
+        .andExpect(jsonPath("$[32].rows", notNullValue()))
+        .andExpect(jsonPath("$[32].rows", hasSize(2)))
+        .andExpect(jsonPath("$[32].rows[0].label", is("auntie rene")))
+        .andExpect(jsonPath("$[32].rows[0].value", is(1000)))
+        .andExpect(jsonPath("$[32].rows[1].label", is("uncle fred")))
+        .andExpect(jsonPath("$[32].rows[1].value", is(2000)));
+
+    verify(authService).getLoggedInUser();
+    verify(candidateService, times(3)).computeReferrerStats(any(), any(), any(), any(), any());
+  }
 
   // survey
 

--- a/server/src/test/java/org/tctalent/server/api/admin/CandidateStatAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/CandidateStatAdminApiTest.java
@@ -31,6 +31,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.tctalent.server.api.admin.StatsApiTestUtil.getBirthYearStats;
 import static org.tctalent.server.api.admin.StatsApiTestUtil.getGenderStats;
+import static org.tctalent.server.api.admin.StatsApiTestUtil.getLanguageStats;
 import static org.tctalent.server.api.admin.StatsApiTestUtil.getLinkedInByRegistrationDateStats;
 import static org.tctalent.server.api.admin.StatsApiTestUtil.getLinkedInExistsStats;
 import static org.tctalent.server.api.admin.StatsApiTestUtil.getMaxEducationStats;
@@ -590,6 +591,42 @@ class CandidateStatAdminApiTest extends ApiTestBase {
   }
 
   // languages
+  @Test
+  @DisplayName("get all stats - most languages report succeeds")
+  void getAllStatsLanguagesReportSucceeds() throws Exception {
+    CandidateStatsRequest request = new CandidateStatsRequest();
+
+    given(candidateService
+        .computeLanguageStats(any(), any(), any(), any()))
+        .willReturn(getLanguageStats());
+
+    mockMvc.perform(post(BASE_PATH + ALL_STATS_PATH)
+            .header("Authorization", "Bearer " + "jwt-token")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request))
+            .accept(MediaType.APPLICATION_JSON))
+
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$", notNullValue()))
+        .andExpect(jsonPath("$", hasSize(46)))
+
+        // max education level
+        .andExpect(jsonPath("$[29].name", is("Languages")))
+        .andExpect(jsonPath("$[29].chartType", is("doughnut")))
+        .andExpect(jsonPath("$[29].rows", notNullValue()))
+        .andExpect(jsonPath("$[29].rows", hasSize(3)))
+        .andExpect(jsonPath("$[29].rows[0].label", is("English")))
+        .andExpect(jsonPath("$[29].rows[0].value", is(1000)))
+        .andExpect(jsonPath("$[29].rows[1].label", is("Arabic")))
+        .andExpect(jsonPath("$[29].rows[1].value", is(2000)))
+        .andExpect(jsonPath("$[29].rows[2].label", is("French")))
+        .andExpect(jsonPath("$[29].rows[2].value", is(3000)));
+
+    verify(authService).getLoggedInUser();
+    verify(candidateService, times(3)).computeLanguageStats(any(), any(), any(), any());
+  }
 
   // referrers
 

--- a/server/src/test/java/org/tctalent/server/api/admin/CandidateStatAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/CandidateStatAdminApiTest.java
@@ -35,6 +35,8 @@ import static org.tctalent.server.api.admin.StatsApiTestUtil.getLinkedInByRegist
 import static org.tctalent.server.api.admin.StatsApiTestUtil.getLinkedInExistsStats;
 import static org.tctalent.server.api.admin.StatsApiTestUtil.getRegistrationByOccupationStats;
 import static org.tctalent.server.api.admin.StatsApiTestUtil.getRegistrationStats;
+import static org.tctalent.server.api.admin.StatsApiTestUtil.getUnhcrRegistrationStats;
+import static org.tctalent.server.api.admin.StatsApiTestUtil.getUnhcrStatusStats;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Optional;
@@ -318,5 +320,81 @@ class CandidateStatAdminApiTest extends ApiTestBase {
 
     verify(authService).getLoggedInUser();
     verify(candidateService).computeLinkedInStats(any(), any(), any());
+  }
+
+  @Test
+  @DisplayName("get all stats - Unhcr registration date report succeeds")
+  void getAllStatsUnhcrRegistrationReportSucceeds() throws Exception {
+    CandidateStatsRequest request = new CandidateStatsRequest();
+
+    given(candidateService
+        .computeUnhcrRegisteredStats(any(), any(), any()))
+        .willReturn(getUnhcrRegistrationStats());
+
+    mockMvc.perform(post(BASE_PATH + ALL_STATS_PATH)
+            .header("Authorization", "Bearer " + "jwt-token")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request))
+            .accept(MediaType.APPLICATION_JSON))
+
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$", notNullValue()))
+        .andExpect(jsonPath("$", hasSize(46)))
+
+        // Unhcr registration date
+        .andExpect(jsonPath("$[8].name", is("UNHCR Registered")))
+        .andExpect(jsonPath("$[8].chartType", is("bar")))
+        .andExpect(jsonPath("$[8].rows", notNullValue()))
+        .andExpect(jsonPath("$[8].rows", hasSize(3)))
+        .andExpect(jsonPath("$[8].rows[0].label", is("NoResponse")))
+        .andExpect(jsonPath("$[8].rows[0].value", is(3)))
+        .andExpect(jsonPath("$[8].rows[1].label", is("Yes")))
+        .andExpect(jsonPath("$[8].rows[1].value", is(2)))
+        .andExpect(jsonPath("$[8].rows[2].label", is("No")))
+        .andExpect(jsonPath("$[8].rows[2].value", is(1)));
+
+    verify(authService).getLoggedInUser();
+    verify(candidateService).computeUnhcrRegisteredStats(any(), any(), any());
+  }
+
+  @Test
+  @DisplayName("get all stats - Unhcr status report succeeds")
+  void getAllStatsUnhcrStatusReportSucceeds() throws Exception {
+    CandidateStatsRequest request = new CandidateStatsRequest();
+
+    given(candidateService
+        .computeUnhcrStatusStats(any(), any(), any()))
+        .willReturn(getUnhcrStatusStats());
+
+    mockMvc.perform(post(BASE_PATH + ALL_STATS_PATH)
+            .header("Authorization", "Bearer " + "jwt-token")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request))
+            .accept(MediaType.APPLICATION_JSON))
+
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$", notNullValue()))
+        .andExpect(jsonPath("$", hasSize(46)))
+
+        // Unhcr status
+        .andExpect(jsonPath("$[9].name", is("UNHCR Status")))
+        .andExpect(jsonPath("$[9].chartType", is("bar")))
+        .andExpect(jsonPath("$[9].rows", notNullValue()))
+        .andExpect(jsonPath("$[9].rows", hasSize(4)))
+        .andExpect(jsonPath("$[9].rows[0].label", is("NoResponse")))
+        .andExpect(jsonPath("$[9].rows[0].value", is(4)))
+        .andExpect(jsonPath("$[9].rows[1].label", is("RegisteredAsylum")))
+        .andExpect(jsonPath("$[9].rows[1].value", is(3)))
+        .andExpect(jsonPath("$[9].rows[2].label", is("NotRegistered")))
+        .andExpect(jsonPath("$[9].rows[2].value", is(2)))
+        .andExpect(jsonPath("$[9].rows[3].label", is("RegisteredStatusUnknown")))
+        .andExpect(jsonPath("$[9].rows[3].value", is(1)));
+
+    verify(authService).getLoggedInUser();
+    verify(candidateService).computeUnhcrStatusStats(any(), any(), any());
   }
 }

--- a/server/src/test/java/org/tctalent/server/api/admin/CandidateStatAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/CandidateStatAdminApiTest.java
@@ -31,6 +31,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.tctalent.server.api.admin.StatsApiTestUtil.getBirthYearStats;
 import static org.tctalent.server.api.admin.StatsApiTestUtil.getGenderStats;
+import static org.tctalent.server.api.admin.StatsApiTestUtil.getLinkedInByRegistrationDateStats;
+import static org.tctalent.server.api.admin.StatsApiTestUtil.getLinkedInExistsStats;
 import static org.tctalent.server.api.admin.StatsApiTestUtil.getRegistrationByOccupationStats;
 import static org.tctalent.server.api.admin.StatsApiTestUtil.getRegistrationStats;
 
@@ -162,9 +164,9 @@ class CandidateStatAdminApiTest extends ApiTestBase {
         .andExpect(jsonPath("$[1].rows", notNullValue()))
         .andExpect(jsonPath("$[1].rows", hasSize(3)))
         .andExpect(jsonPath("$[1].rows[0].label", is("2016-06-04")))
-        .andExpect(jsonPath("$[1].rows[0].value", is(4)))
+        .andExpect(jsonPath("$[1].rows[0].value", is(3)))
         .andExpect(jsonPath("$[1].rows[1].label", is("2016-06-10")))
-        .andExpect(jsonPath("$[1].rows[1].value", is(1)))
+        .andExpect(jsonPath("$[1].rows[1].value", is(2)))
         .andExpect(jsonPath("$[1].rows[2].label", is("2016-06-14")))
         .andExpect(jsonPath("$[1].rows[2].value", is(1)));
 
@@ -230,19 +232,91 @@ class CandidateStatAdminApiTest extends ApiTestBase {
         .andExpect(jsonPath("$", notNullValue()))
         .andExpect(jsonPath("$", hasSize(46)))
 
-        // Registrations by Occupation
+        // Birth year
         .andExpect(jsonPath("$[3].name", is("Birth years")))
         .andExpect(jsonPath("$[3].chartType", is("bar")))
         .andExpect(jsonPath("$[3].rows", notNullValue()))
         .andExpect(jsonPath("$[3].rows", hasSize(3)))
         .andExpect(jsonPath("$[3].rows[0].label", is("1948")))
-        .andExpect(jsonPath("$[3].rows[0].value", is(1)))
+        .andExpect(jsonPath("$[3].rows[0].value", is(3)))
         .andExpect(jsonPath("$[3].rows[1].label", is("1950")))
         .andExpect(jsonPath("$[3].rows[1].value", is(2)))
         .andExpect(jsonPath("$[3].rows[2].label", is("1951")))
-        .andExpect(jsonPath("$[3].rows[2].value", is(2)));
+        .andExpect(jsonPath("$[3].rows[2].value", is(1)));
 
     verify(authService).getLoggedInUser();
     verify(candidateService, times(3)).computeBirthYearStats(any(), any(), any(), any());
+  }
+
+  @Test
+  @DisplayName("get all stats - linked in links report succeeds")
+  void getAllStatsLinkedInLinksReportSucceeds() throws Exception {
+    CandidateStatsRequest request = new CandidateStatsRequest();
+
+    given(candidateService
+        .computeLinkedInExistsStats(any(), any(), any()))
+        .willReturn(getLinkedInExistsStats());
+
+    mockMvc.perform(post(BASE_PATH + ALL_STATS_PATH)
+            .header("Authorization", "Bearer " + "jwt-token")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request))
+            .accept(MediaType.APPLICATION_JSON))
+
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$", notNullValue()))
+        .andExpect(jsonPath("$", hasSize(46)))
+
+        // Linkedin links
+        .andExpect(jsonPath("$[6].name", is("LinkedIn links")))
+        .andExpect(jsonPath("$[6].chartType", is("bar")))
+        .andExpect(jsonPath("$[6].rows", notNullValue()))
+        .andExpect(jsonPath("$[6].rows", hasSize(2)))
+        .andExpect(jsonPath("$[6].rows[0].label", is("No link")))
+        .andExpect(jsonPath("$[6].rows[0].value", is(2)))
+        .andExpect(jsonPath("$[6].rows[1].label", is("Has link")))
+        .andExpect(jsonPath("$[6].rows[1].value", is(10)));
+
+    verify(authService).getLoggedInUser();
+    verify(candidateService).computeLinkedInExistsStats(any(), any(), any());
+  }
+
+  @Test
+  @DisplayName("get all stats - linked in links by registration date report succeeds")
+  void getAllStatsLinkedInLinksByRegistrationDateReportSucceeds() throws Exception {
+    CandidateStatsRequest request = new CandidateStatsRequest();
+
+    given(candidateService
+        .computeLinkedInStats(any(), any(), any()))
+        .willReturn(getLinkedInByRegistrationDateStats());
+
+    mockMvc.perform(post(BASE_PATH + ALL_STATS_PATH)
+            .header("Authorization", "Bearer " + "jwt-token")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request))
+            .accept(MediaType.APPLICATION_JSON))
+
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$", notNullValue()))
+        .andExpect(jsonPath("$", hasSize(46)))
+
+        // Linkedin links by registration date
+        .andExpect(jsonPath("$[7].name", is("LinkedIn links by candidate registration date")))
+        .andExpect(jsonPath("$[7].chartType", is("bar")))
+        .andExpect(jsonPath("$[7].rows", notNullValue()))
+        .andExpect(jsonPath("$[7].rows", hasSize(3)))
+        .andExpect(jsonPath("$[7].rows[0].label", is("2016-06-04")))
+        .andExpect(jsonPath("$[7].rows[0].value", is(3)))
+        .andExpect(jsonPath("$[7].rows[1].label", is("2016-06-10")))
+        .andExpect(jsonPath("$[7].rows[1].value", is(2)))
+        .andExpect(jsonPath("$[7].rows[2].label", is("2016-06-14")))
+        .andExpect(jsonPath("$[7].rows[2].value", is(1)));
+
+    verify(authService).getLoggedInUser();
+    verify(candidateService).computeLinkedInStats(any(), any(), any());
   }
 }

--- a/server/src/test/java/org/tctalent/server/api/admin/CandidateStatAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/CandidateStatAdminApiTest.java
@@ -34,6 +34,7 @@ import static org.tctalent.server.api.admin.StatsApiTestUtil.getGenderStats;
 import static org.tctalent.server.api.admin.StatsApiTestUtil.getLinkedInByRegistrationDateStats;
 import static org.tctalent.server.api.admin.StatsApiTestUtil.getLinkedInExistsStats;
 import static org.tctalent.server.api.admin.StatsApiTestUtil.getNationalityStats;
+import static org.tctalent.server.api.admin.StatsApiTestUtil.getOccupationStats;
 import static org.tctalent.server.api.admin.StatsApiTestUtil.getRegistrationByOccupationStats;
 import static org.tctalent.server.api.admin.StatsApiTestUtil.getRegistrationStats;
 import static org.tctalent.server.api.admin.StatsApiTestUtil.getStatusStats;
@@ -475,4 +476,42 @@ class CandidateStatAdminApiTest extends ApiTestBase {
     verify(authService).getLoggedInUser();
     verify(candidateService, times(5)).computeStatusStats(any(), any(), any(), any(), any());
   }
+
+  @Test
+  @DisplayName("get all stats - occupations report succeeds")
+  void getAllStatsOccupationsReportSucceeds() throws Exception {
+    CandidateStatsRequest request = new CandidateStatsRequest();
+
+    given(candidateService
+        .computeOccupationStats(any(), any(), any(), any()))
+        .willReturn(getOccupationStats());
+
+    mockMvc.perform(post(BASE_PATH + ALL_STATS_PATH)
+            .header("Authorization", "Bearer " + "jwt-token")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request))
+            .accept(MediaType.APPLICATION_JSON))
+
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$", notNullValue()))
+        .andExpect(jsonPath("$", hasSize(46)))
+
+        // Occupations
+        .andExpect(jsonPath("$[20].name", is("Occupations")))
+        .andExpect(jsonPath("$[20].chartType", is("doughnut")))
+        .andExpect(jsonPath("$[20].rows", notNullValue()))
+        .andExpect(jsonPath("$[20].rows", hasSize(3)))
+        .andExpect(jsonPath("$[20].rows[0].label", is("undefined")))
+        .andExpect(jsonPath("$[20].rows[0].value", is(1000)))
+        .andExpect(jsonPath("$[20].rows[1].label", is("Teacher")))
+        .andExpect(jsonPath("$[20].rows[1].value", is(2000)))
+        .andExpect(jsonPath("$[20].rows[2].label", is("Accountant")))
+        .andExpect(jsonPath("$[20].rows[2].value", is(3000)));
+
+    verify(authService).getLoggedInUser();
+    verify(candidateService, times(3)).computeOccupationStats(any(), any(), any(), any());
+  }
+
 }

--- a/server/src/test/java/org/tctalent/server/api/admin/StatsApiTestUtil.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/StatsApiTestUtil.java
@@ -83,4 +83,11 @@ public class StatsApiTestUtil {
     );
   }
 
+  static List<DataRow> getNationalityStats() {
+    return List.of(
+        new DataRow("Palestinian Territories", 1073L),
+        new DataRow("Syria", 14852L)
+    );
+  }
+
 }

--- a/server/src/test/java/org/tctalent/server/api/admin/StatsApiTestUtil.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/StatsApiTestUtil.java
@@ -139,4 +139,12 @@ public class StatsApiTestUtil {
     );
   }
 
+  static List<DataRow> getSpokenLanguageLevelStats() {
+    return List.of(
+        new DataRow("Intermediate Proficiency", 1000L),
+        new DataRow("Full Professional Proficiency", 2000L),
+        new DataRow("Elementary Proficiency", 3000L)
+    );
+  }
+
 }

--- a/server/src/test/java/org/tctalent/server/api/admin/StatsApiTestUtil.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/StatsApiTestUtil.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2023 Talent Beyond Boundaries.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.api.admin;
+
+import java.util.List;
+import org.tctalent.server.model.db.DataRow;
+
+public class StatsApiTestUtil {
+
+  static List<DataRow> getGenderStats() {
+    return List.of(
+        new DataRow("male", 15111L),
+        new DataRow("undefined", 3772L),
+        new DataRow("female", 2588L)
+    );
+  }
+}

--- a/server/src/test/java/org/tctalent/server/api/admin/StatsApiTestUtil.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/StatsApiTestUtil.java
@@ -45,4 +45,12 @@ public class StatsApiTestUtil {
     );
   }
 
+  static List<DataRow> getBirthYearStats() {
+    return List.of(
+        new DataRow("1948", 1L),
+        new DataRow("1950", 2L),
+        new DataRow("1951", 2L)
+    );
+  }
+
 }

--- a/server/src/test/java/org/tctalent/server/api/admin/StatsApiTestUtil.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/StatsApiTestUtil.java
@@ -124,4 +124,11 @@ public class StatsApiTestUtil {
     );
   }
 
+  static List<DataRow> getReferrerStats() {
+    return List.of(
+        new DataRow("auntie rene", 1000L),
+        new DataRow("uncle fred", 2000L)
+    );
+  }
+
 }

--- a/server/src/test/java/org/tctalent/server/api/admin/StatsApiTestUtil.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/StatsApiTestUtil.java
@@ -108,4 +108,12 @@ public class StatsApiTestUtil {
     );
   }
 
+  static List<DataRow> getMaxEducationStats() {
+    return List.of(
+        new DataRow("Bachelor's Degree", 1000L),
+        new DataRow("Primary School", 2000L),
+        new DataRow("Doctoral Degree", 3000L)
+    );
+  }
+
 }

--- a/server/src/test/java/org/tctalent/server/api/admin/StatsApiTestUtil.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/StatsApiTestUtil.java
@@ -66,4 +66,21 @@ public class StatsApiTestUtil {
     return dateRows;
   }
 
+  static List<DataRow> getUnhcrRegistrationStats() {
+    return List.of(
+        new DataRow("NoResponse", 3L),
+        new DataRow("Yes", 2L),
+        new DataRow("No", 1L)
+    );
+  }
+
+  static List<DataRow> getUnhcrStatusStats() {
+    return List.of(
+        new DataRow("NoResponse", 4L),
+        new DataRow("RegisteredAsylum", 3L),
+        new DataRow("NotRegistered", 2L),
+        new DataRow("RegisteredStatusUnknown", 1L)
+    );
+  }
+
 }

--- a/server/src/test/java/org/tctalent/server/api/admin/StatsApiTestUtil.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/StatsApiTestUtil.java
@@ -116,4 +116,12 @@ public class StatsApiTestUtil {
     );
   }
 
+  static List<DataRow> getLanguageStats() {
+    return List.of(
+        new DataRow("English", 1000L),
+        new DataRow("Arabic", 2000L),
+        new DataRow("French", 3000L)
+    );
+  }
+
 }

--- a/server/src/test/java/org/tctalent/server/api/admin/StatsApiTestUtil.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/StatsApiTestUtil.java
@@ -131,4 +131,12 @@ public class StatsApiTestUtil {
     );
   }
 
+  static List<DataRow> getSurveyStats() {
+    return List.of(
+        new DataRow("Facebook", 1000L),
+        new DataRow("From a friend", 2000L),
+        new DataRow("NGO", 3000L)
+    );
+  }
+
 }

--- a/server/src/test/java/org/tctalent/server/api/admin/StatsApiTestUtil.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/StatsApiTestUtil.java
@@ -90,4 +90,14 @@ public class StatsApiTestUtil {
     );
   }
 
+  static List<DataRow> getStatusStats() {
+    return List.of(
+        new DataRow("pending", 1000L),
+        new DataRow("incomplete", 2000L),
+        new DataRow("active", 3000L),
+        new DataRow("employed", 4000L),
+        new DataRow("autonomousEmployment", 5000L)
+    );
+  }
+
 }

--- a/server/src/test/java/org/tctalent/server/api/admin/StatsApiTestUtil.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/StatsApiTestUtil.java
@@ -28,4 +28,21 @@ public class StatsApiTestUtil {
         new DataRow("female", 2588L)
     );
   }
+
+  static List<DataRow> getRegistrationStats() {
+    return List.of(
+        new DataRow("2016-06-04", 4L),
+        new DataRow("2016-06-10", 1L),
+        new DataRow("2016-06-14", 1L)
+    );
+  }
+
+  static List<DataRow> getRegistrationByOccupationStats() {
+    return List.of(
+        new DataRow("undefined", 11414L),
+        new DataRow("Unknown", 1652L),
+        new DataRow("Teacher", 777L)
+    );
+  }
+
 }

--- a/server/src/test/java/org/tctalent/server/api/admin/StatsApiTestUtil.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/StatsApiTestUtil.java
@@ -21,6 +21,12 @@ import org.tctalent.server.model.db.DataRow;
 
 public class StatsApiTestUtil {
 
+  private static List<DataRow> dateRows = List.of(
+      new DataRow("2016-06-04", 3L),
+      new DataRow("2016-06-10", 2L),
+      new DataRow("2016-06-14", 1L)
+  );
+
   static List<DataRow> getGenderStats() {
     return List.of(
         new DataRow("male", 15111L),
@@ -30,11 +36,7 @@ public class StatsApiTestUtil {
   }
 
   static List<DataRow> getRegistrationStats() {
-    return List.of(
-        new DataRow("2016-06-04", 4L),
-        new DataRow("2016-06-10", 1L),
-        new DataRow("2016-06-14", 1L)
-    );
+    return dateRows;
   }
 
   static List<DataRow> getRegistrationByOccupationStats() {
@@ -47,10 +49,21 @@ public class StatsApiTestUtil {
 
   static List<DataRow> getBirthYearStats() {
     return List.of(
-        new DataRow("1948", 1L),
+        new DataRow("1948", 3L),
         new DataRow("1950", 2L),
-        new DataRow("1951", 2L)
+        new DataRow("1951", 1L)
     );
+  }
+
+  static List<DataRow> getLinkedInExistsStats() {
+    return List.of(
+        new DataRow("No link", 2L),
+        new DataRow("Has link", 10L)
+    );
+  }
+
+  static List<DataRow> getLinkedInByRegistrationDateStats() {
+    return dateRows;
   }
 
 }

--- a/server/src/test/java/org/tctalent/server/api/admin/StatsApiTestUtil.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/StatsApiTestUtil.java
@@ -21,7 +21,7 @@ import org.tctalent.server.model.db.DataRow;
 
 public class StatsApiTestUtil {
 
-  private static List<DataRow> dateRows = List.of(
+  private static final List<DataRow> dateRows = List.of(
       new DataRow("2016-06-04", 3L),
       new DataRow("2016-06-10", 2L),
       new DataRow("2016-06-14", 1L)

--- a/server/src/test/java/org/tctalent/server/api/admin/StatsApiTestUtil.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/StatsApiTestUtil.java
@@ -100,4 +100,12 @@ public class StatsApiTestUtil {
     );
   }
 
+  static List<DataRow> getOccupationStats() {
+    return List.of(
+        new DataRow("undefined", 1000L),
+        new DataRow("Teacher", 2000L),
+        new DataRow("Accountant", 3000L)
+    );
+  }
+
 }


### PR DESCRIPTION
This PR contians:

- Unit tests for CandidateStatAdminApi
- Uses RequiredArgsConstructor and removes unnecessary 'this' references for CandidateStatAdminApi
- Resolves all IntelliJ warnings for CandidateStatAdminApi

