### PR TITLE
Unit tests for CandidateSavedListAdminApi

### DIFF
--- a/server/src/main/java/org/tctalent/server/api/admin/CandidateSavedListAdminApi.java
+++ b/server/src/main/java/org/tctalent/server/api/admin/CandidateSavedListAdminApi.java
@@ -18,11 +18,9 @@ package org.tctalent.server.api.admin;
 
 import java.util.List;
 import java.util.Map;
-
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
-
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.tctalent.server.exception.NoSuchObjectException;
@@ -30,7 +28,6 @@ import org.tctalent.server.model.db.SavedList;
 import org.tctalent.server.request.candidate.HasSetOfSavedListsImpl;
 import org.tctalent.server.request.list.SearchSavedListRequest;
 import org.tctalent.server.service.db.CandidateSavedListService;
-import org.tctalent.server.service.db.CandidateService;
 import org.tctalent.server.service.db.SavedListService;
 import org.tctalent.server.util.dto.DtoBuilder;
 
@@ -55,22 +52,12 @@ import org.tctalent.server.util.dto.DtoBuilder;
  */
 @RestController()
 @RequestMapping("/api/admin/candidate-saved-list")
+@RequiredArgsConstructor
 public class CandidateSavedListAdminApi implements IManyToManyApi<SearchSavedListRequest, HasSetOfSavedListsImpl> {
 
-    private final CandidateService candidateService;
     private final CandidateSavedListService candidateSavedListService;
     private final SavedListService savedListService;
     private final SavedListBuilderSelector builderSelector = new SavedListBuilderSelector();
-
-    @Autowired
-    public CandidateSavedListAdminApi(
-        CandidateService candidateService,
-        CandidateSavedListService candidateSavedListService,
-        SavedListService savedListService) {
-        this.candidateService = candidateService;
-        this.candidateSavedListService = candidateSavedListService;
-        this.savedListService = savedListService;
-    }
 
     @Override
     public void replace(long candidateId, @Valid HasSetOfSavedListsImpl request)

--- a/server/src/main/java/org/tctalent/server/model/db/SavedList.java
+++ b/server/src/main/java/org/tctalent/server/model/db/SavedList.java
@@ -31,6 +31,8 @@ import javax.persistence.OrderBy;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 import javax.persistence.Transient;
+import lombok.Getter;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.lang.NonNull;
 import org.springframework.lang.Nullable;
@@ -58,6 +60,8 @@ import org.tctalent.server.service.db.CandidateSavedListService;
 @Entity
 @Table(name = "saved_list")
 @SequenceGenerator(name = "seq_gen", sequenceName = "saved_list_id_seq", allocationSize = 1)
+@Getter
+@Setter
 @Slf4j
 public class SavedList extends AbstractCandidateSource {
 
@@ -140,6 +144,7 @@ public class SavedList extends AbstractCandidateSource {
      * item. A link to the job record on Salesforce is in {@link #getSfJobOpp()}.
      * There should only be one list registered to a particular job, as defined by its sfJobOpp.
      */
+    @NonNull
     private Boolean registeredJob = false;
 
     /**
@@ -203,89 +208,12 @@ public class SavedList extends AbstractCandidateSource {
 
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "savedList", cascade = CascadeType.ALL)
     @OrderBy("index ASC")
-    private List<ExportColumn> exportColumns;
-
     @Nullable
-    public List<ExportColumn> getExportColumns() {
-        return exportColumns;
-    }
+    private List<ExportColumn> exportColumns;
 
     public void setExportColumns(@Nullable List<ExportColumn> exportColumns) {
         modifyColumnIndices(exportColumns);
         this.exportColumns = exportColumns;
-    }
-
-    @Nullable
-    public String getFileJdLink() {
-        return fileJdLink;
-    }
-
-    public void setFileJdLink(@Nullable String fileJdLink) {
-        this.fileJdLink = fileJdLink;
-    }
-
-    @Nullable
-    public String getFileJdName() {
-        return fileJdName;
-    }
-
-    public void setFileJdName(@Nullable String fileJdName) {
-        this.fileJdName = fileJdName;
-    }
-
-    @Nullable
-    public String getFileJoiLink() {
-        return fileJoiLink;
-    }
-
-    public void setFileJoiLink(@Nullable String fileJoiLink) {
-        this.fileJoiLink = fileJoiLink;
-    }
-
-    @Nullable
-    public String getFileJoiName() {
-        return fileJoiName;
-    }
-
-    public void setFileJoiName(@Nullable String fileJoiName) {
-        this.fileJoiName = fileJoiName;
-    }
-
-    @Nullable
-    public String getFolderlink() {
-        return folderlink;
-    }
-
-    public void setFolderlink(@Nullable String folderlink) {
-        this.folderlink = folderlink;
-    }
-
-    @Nullable
-    public String getFolderjdlink() {
-        return folderjdlink;
-    }
-
-    public void setFolderjdlink(@Nullable String folderjdlink) {
-        this.folderjdlink = folderjdlink;
-    }
-
-    @Nullable
-    public String getPublishedDocLink() {
-        return publishedDocLink;
-    }
-
-    public void setPublishedDocLink(@Nullable String publishedDocLink) {
-        this.publishedDocLink = publishedDocLink;
-    }
-
-    @Nullable
-    public String getTbbShortName() {return tbbShortName;}
-
-    public void setTbbShortName(@Nullable String tbbShortName) {this.tbbShortName = tbbShortName;}
-
-    @NonNull
-    public Boolean getRegisteredJob() {
-        return registeredJob;
     }
 
     public void setRegisteredJob(Boolean registeredJob) {
@@ -324,32 +252,6 @@ public class SavedList extends AbstractCandidateSource {
         return sfJobOpp == null ? false : sfJobOpp.isClosed();
     }
 
-    @Nullable
-    public SavedSearch getSavedSearch() {
-        return savedSearch;
-    }
-
-    public void setSavedSearch(@Nullable SavedSearch savedSearch) {
-        this.savedSearch = savedSearch;
-    }
-
-    @Nullable
-    public SavedSearch getSavedSearchSource() {
-        return savedSearchSource;
-    }
-
-    public void setSavedSearchSource(@Nullable SavedSearch savedSearchSource) {
-        this.savedSearchSource = savedSearchSource;
-    }
-
-    public Set<CandidateSavedList> getCandidateSavedLists() {
-        return candidateSavedLists;
-    }
-
-    public void setCandidateSavedLists(Set<CandidateSavedList> candidateSavedLists) {
-        this.candidateSavedLists = candidateSavedLists;
-    }
-
     /**
      * Get all candidates in this list.
      * @return Set of candidates in this list (a candidate cannot appear more
@@ -365,20 +267,7 @@ public class SavedList extends AbstractCandidateSource {
     }
 
     @Override
-    public Set<User> getUsers() {
-        return users;
-    }
-
-    @Override
     public Set<SavedList> getUsersCollection(User user) {
         return user.getSharedLists();
-    }
-
-    public Set<TaskImpl> getTasks() {
-        return tasks;
-    }
-
-    public void setTasks(Set<TaskImpl> tasks) {
-        this.tasks = tasks;
     }
 }

--- a/server/src/main/java/org/tctalent/server/model/db/SavedList.java
+++ b/server/src/main/java/org/tctalent/server/model/db/SavedList.java
@@ -31,8 +31,7 @@ import javax.persistence.OrderBy;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 import javax.persistence.Transient;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.lang.NonNull;
 import org.springframework.lang.Nullable;
 import org.tctalent.server.service.db.CandidateSavedListService;
@@ -59,8 +58,8 @@ import org.tctalent.server.service.db.CandidateSavedListService;
 @Entity
 @Table(name = "saved_list")
 @SequenceGenerator(name = "seq_gen", sequenceName = "saved_list_id_seq", allocationSize = 1)
+@Slf4j
 public class SavedList extends AbstractCandidateSource {
-    private static final Logger log = LoggerFactory.getLogger(SavedList.class);
 
     /**
      * Tasks associated with this list.

--- a/server/src/test/java/org/tctalent/server/api/admin/AdminApiTestUtil.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/AdminApiTestUtil.java
@@ -17,6 +17,10 @@
 package org.tctalent.server.api.admin;
 
 
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Set;
 import org.tctalent.server.model.db.Candidate;
 import org.tctalent.server.model.db.CandidateCertification;
 import org.tctalent.server.model.db.CandidateCitizenship;
@@ -40,6 +44,7 @@ import org.tctalent.server.model.db.DocumentStatus;
 import org.tctalent.server.model.db.EducationMajor;
 import org.tctalent.server.model.db.EducationType;
 import org.tctalent.server.model.db.Exam;
+import org.tctalent.server.model.db.ExportColumn;
 import org.tctalent.server.model.db.FamilyRelations;
 import org.tctalent.server.model.db.Gender;
 import org.tctalent.server.model.db.HasPassport;
@@ -53,16 +58,16 @@ import org.tctalent.server.model.db.ReviewStatus;
 import org.tctalent.server.model.db.RiskLevel;
 import org.tctalent.server.model.db.Role;
 import org.tctalent.server.model.db.SalesforceJobOpp;
+import org.tctalent.server.model.db.SavedList;
 import org.tctalent.server.model.db.SavedSearch;
 import org.tctalent.server.model.db.Status;
 import org.tctalent.server.model.db.TBBEligibilityAssessment;
+import org.tctalent.server.model.db.TaskImpl;
 import org.tctalent.server.model.db.User;
 import org.tctalent.server.model.db.VisaEligibility;
 import org.tctalent.server.model.db.YesNo;
 import org.tctalent.server.model.db.YesNoUnsure;
-
-import java.time.LocalDate;
-import java.util.List;
+import org.tctalent.server.request.candidate.PublishedDocColumnProps;
 
 /**
  * @author sadatmalik
@@ -258,7 +263,10 @@ public class AdminApiTestUtil {
     }
 
     static SalesforceJobOpp getSalesforceJobOpp() {
-        return new SalesforceJobOpp();
+        SalesforceJobOpp salesforceJobOpp = new SalesforceJobOpp();
+        salesforceJobOpp.setId(135L);
+        salesforceJobOpp.setSfId("sales-force-job-opp-id");
+        return salesforceJobOpp;
     }
 
     static CandidateReviewStatusItem getCandidateReviewStatusItem() {
@@ -344,5 +352,74 @@ public class AdminApiTestUtil {
         candidateSkill.setSkill("Adobe Photoshop");
         candidateSkill.setTimePeriod("3-5 years");
         return candidateSkill;
+    }
+
+    static PublishedDocColumnProps getPublishedDocColumnProps() {
+        PublishedDocColumnProps publishedDocColumnProps = new PublishedDocColumnProps();
+        publishedDocColumnProps.setHeader("non default column header");
+        publishedDocColumnProps.setConstant("non default constant column value");
+        return publishedDocColumnProps;
+    }
+
+    static ExportColumn getExportColumn() {
+        ExportColumn exportColumn = new ExportColumn();
+        exportColumn.setKey("key");
+        exportColumn.setProperties(getPublishedDocColumnProps());
+        return exportColumn;
+    }
+
+    static SavedSearch getSavedSearch() {
+        SavedSearch savedSearch = new SavedSearch();
+        savedSearch.setId(123L);
+        return savedSearch;
+    }
+
+    static TaskImpl getTask() {
+        TaskImpl task = new TaskImpl();
+        task.setId(148L);
+        task.setName("a test task");
+        task.setDaysToComplete(7);
+        task.setDescription("a test task description");
+        task.setDisplayName("task display name");
+        task.setOptional(false);
+        task.setHelpLink("http://help.link");
+        return task;
+    }
+
+    static SavedList getSavedList() {
+        SavedList savedList = new SavedList();
+        savedList.setId(1L);
+        savedList.setDescription("Saved list description");
+        savedList.setDisplayedFieldsLong(List.of("user.firstName", "user.lastName"));
+        savedList.setExportColumns(List.of(getExportColumn()));
+        savedList.setStatus(Status.active);
+        savedList.setName("Saved list name");
+        savedList.setFixed(true);
+        savedList.setGlobal(false);
+        savedList.setSavedSearchSource(getSavedSearch());
+        savedList.setSfJobOpp(getSalesforceJobOpp());
+        savedList.setFileJdLink("http://file.jd.link");
+        savedList.setFileJdName("JobDescriptionFileName");
+        savedList.setFileJoiLink("http://file.joi.link");
+        savedList.setFileJoiName("JoiFileName");
+        savedList.setFolderlink("http://folder.link");
+        savedList.setFolderjdlink("http://folder.jd.link");
+        savedList.setPublishedDocLink("http://published.doc.link");
+        savedList.setRegisteredJob(true);
+        savedList.setTbbShortName("Saved list Tbb short name");
+        savedList.setCreatedBy(caller);
+        savedList.setCreatedDate(OffsetDateTime.parse("2023-10-30T12:30:00+02:00"));
+        savedList.setUpdatedBy(caller);
+        savedList.setUpdatedDate(OffsetDateTime.parse("2023-10-30T12:30:00+02:00"));
+        savedList.setUsers(Set.of(caller));
+        savedList.setTasks(Set.of(getTask()));
+
+        return savedList;
+    }
+
+    static List<SavedList> getSavedLists() {
+        return List.of(
+            getSavedList()
+        );
     }
 }

--- a/server/src/test/java/org/tctalent/server/api/admin/CandidateSavedListAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/CandidateSavedListAdminApiTest.java
@@ -17,8 +17,12 @@
 package org.tctalent.server.api.admin;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -26,6 +30,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.tctalent.server.api.admin.AdminApiTestUtil.getSavedLists;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
@@ -80,7 +85,68 @@ class CandidateSavedListAdminApiTest extends ApiTestBase {
 
   // replace
 
-  // search
+  @Test
+  @DisplayName("search succeeds")
+  void searchSucceeds() throws Exception {
+    SearchSavedListRequest request = new SearchSavedListRequest();
+
+    given(savedListService
+        .search(anyLong(), any(SearchSavedListRequest.class)))
+        .willReturn(getSavedLists());
+
+    mockMvc.perform(post(BASE_PATH + SEARCH_PATH.replace("{id}", "1"))
+            .header("Authorization", "Bearer " + "jwt-token")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request))
+            .accept(MediaType.APPLICATION_JSON))
+
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$", notNullValue()))
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$", hasSize(1)))
+        .andExpect(jsonPath("$[0].id", is(1)))
+        .andExpect(jsonPath("$.[0].description", is("Saved list description")))
+        .andExpect(jsonPath("$.[0].displayedFieldsLong[0]", is("user.firstName")))
+        .andExpect(jsonPath("$.[0].displayedFieldsLong[1]", is("user.lastName")))
+        .andExpect(jsonPath("$.[0].exportColumns").isArray())
+        .andExpect(jsonPath("$.[0].exportColumns[0].key", is("key")))
+        .andExpect(jsonPath("$.[0].exportColumns[0].properties.constant", is("non default constant column value")))
+        .andExpect(jsonPath("$.[0].exportColumns[0].properties.header", is("non default column header")))
+        .andExpect(jsonPath("$.[0].status", is("active")))
+        .andExpect(jsonPath("$.[0].name", is("Saved list name")))
+        .andExpect(jsonPath("$.[0].fixed", is(true)))
+        .andExpect(jsonPath("$.[0].global", is(false)))
+        .andExpect(jsonPath("$.[0].savedSearchSource.id", is(123)))
+        .andExpect(jsonPath("$.[0].sfJobOpp.id", is(135)))
+        .andExpect(jsonPath("$.[0].sfJobOpp.sfId", is("sales-force-job-opp-id")))
+        .andExpect(jsonPath("$.[0].fileJdLink", is("http://file.jd.link")))
+        .andExpect(jsonPath("$.[0].fileJdName", is("JobDescriptionFileName")))
+        .andExpect(jsonPath("$.[0].fileJoiLink", is("http://file.joi.link")))
+        .andExpect(jsonPath("$.[0].fileJoiName", is("JoiFileName")))
+        .andExpect(jsonPath("$.[0].folderlink", is("http://folder.link")))
+        .andExpect(jsonPath("$.[0].folderjdlink", is("http://folder.jd.link")))
+        .andExpect(jsonPath("$.[0].publishedDocLink", is("http://published.doc.link")))
+        .andExpect(jsonPath("$.[0].registeredJob", is(true)))
+        .andExpect(jsonPath("$.[0].tbbShortName", is("Saved list Tbb short name")))
+        .andExpect(jsonPath("$.[0].createdBy.firstName", is("test")))
+        .andExpect(jsonPath("$.[0].createdBy.lastName", is("user")))
+        .andExpect(jsonPath("$.[0].createdDate", is("2023-10-30T12:30:00+02:00")))
+        .andExpect(jsonPath("$.[0].updatedBy.firstName", is("test")))
+        .andExpect(jsonPath("$.[0].updatedBy.lastName", is("user")))
+        .andExpect(jsonPath("$.[0].updatedDate", is("2023-10-30T12:30:00+02:00")))
+        .andExpect(jsonPath("$.[0].users[0].firstName", is("test")))
+        .andExpect(jsonPath("$.[0].users[0].lastName", is("user")))
+        .andExpect(jsonPath("$.[0].tasks[0].id", is(148)))
+        .andExpect(jsonPath("$.[0].tasks[0].helpLink", is("http://help.link")))
+        .andExpect(jsonPath("$.[0].tasks[0].taskType", is("Simple")))
+        .andExpect(jsonPath("$.[0].tasks[0].displayName", is("task display name")))
+        .andExpect(jsonPath("$.[0].tasks[0].name", is("a test task")))
+        .andExpect(jsonPath("$.[0].tasks[0].description", is("a test task description")))
+        .andExpect(jsonPath("$.[0].tasks[0].optional", is(false)))
+        .andExpect(jsonPath("$.[0].tasks[0].daysToComplete", is(7)));
+  }
 
   @Test
   @DisplayName("list fails - not implemented")

--- a/server/src/test/java/org/tctalent/server/api/admin/CandidateSavedListAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/CandidateSavedListAdminApiTest.java
@@ -83,7 +83,24 @@ class CandidateSavedListAdminApiTest extends ApiTestBase {
 
   // list
 
-  // merge
+  @Test
+  @DisplayName("merge fails - not implemented")
+  void mergeFailsNotImplemented() throws Exception {
+    HasSetOfSavedListsImpl request = new HasSetOfSavedListsImpl();
+
+    mockMvc.perform(put(BASE_PATH + MERGE_PATH.replace("{id}", "1"))
+            .header("Authorization", "Bearer " + "jwt-token")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request))
+            .accept(MediaType.APPLICATION_JSON))
+
+        .andDo(print())
+        .andExpect(status().isBadRequest())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$", notNullValue()))
+        .andExpect(jsonPath("$.code", is("not_implemented")))
+        .andExpect(jsonPath("$.message", is("Method 'merge' of CandidateSavedListAdminApi is not implemented.")));
+  }
 
   @Test
   @DisplayName("remove fails - not implemented")

--- a/server/src/test/java/org/tctalent/server/api/admin/CandidateSavedListAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/CandidateSavedListAdminApiTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -35,6 +36,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.tctalent.server.request.candidate.HasSetOfSavedListsImpl;
 import org.tctalent.server.request.list.SearchSavedListRequest;
 import org.tctalent.server.service.db.CandidateSavedListService;
 import org.tctalent.server.service.db.SavedListService;
@@ -83,9 +85,25 @@ class CandidateSavedListAdminApiTest extends ApiTestBase {
 
   // merge
 
-  // remove
+  @Test
+  @DisplayName("remove fails - not implemented")
+  void removeFailsNotImplemented() throws Exception {
+    HasSetOfSavedListsImpl request = new HasSetOfSavedListsImpl();
 
-  // search-paged
+    mockMvc.perform(put(BASE_PATH + REMOVE_PATH.replace("{id}", "1"))
+            .header("Authorization", "Bearer " + "jwt-token")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request))
+            .accept(MediaType.APPLICATION_JSON))
+
+        .andDo(print())
+        .andExpect(status().isBadRequest())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$", notNullValue()))
+        .andExpect(jsonPath("$.code", is("not_implemented")))
+        .andExpect(jsonPath("$.message", is("Method 'remove' of CandidateSavedListAdminApi is not implemented.")));
+  }
+
   @Test
   @DisplayName("search paged fails - not implemented")
   void searchPagedFailsNotImplemented() throws Exception {

--- a/server/src/test/java/org/tctalent/server/api/admin/CandidateSavedListAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/CandidateSavedListAdminApiTest.java
@@ -19,6 +19,7 @@ package org.tctalent.server.api.admin;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -81,7 +82,22 @@ class CandidateSavedListAdminApiTest extends ApiTestBase {
 
   // search
 
-  // list
+  @Test
+  @DisplayName("list fails - not implemented")
+  void listFailsNotImplemented() throws Exception {
+    HasSetOfSavedListsImpl request = new HasSetOfSavedListsImpl();
+
+    mockMvc.perform(get(BASE_PATH + LIST_PATH.replace("{id}", "1"))
+            .header("Authorization", "Bearer " + "jwt-token")
+            .accept(MediaType.APPLICATION_JSON))
+
+        .andDo(print())
+        .andExpect(status().isBadRequest())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$", notNullValue()))
+        .andExpect(jsonPath("$.code", is("not_implemented")))
+        .andExpect(jsonPath("$.message", is("Method 'list' of CandidateSavedListAdminApi is not implemented.")));
+  }
 
   @Test
   @DisplayName("merge fails - not implemented")

--- a/server/src/test/java/org/tctalent/server/api/admin/CandidateSavedListAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/CandidateSavedListAdminApiTest.java
@@ -27,7 +27,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.tctalent.server.service.db.CandidateSavedListService;
-import org.tctalent.server.service.db.CandidateService;
 import org.tctalent.server.service.db.SavedListService;
 
 /**
@@ -39,7 +38,6 @@ import org.tctalent.server.service.db.SavedListService;
 @AutoConfigureMockMvc
 class CandidateSavedListAdminApiTest extends ApiTestBase {
 
-  @MockBean CandidateService candidateService;
   @MockBean CandidateSavedListService candidateSavedListService;
   @MockBean SavedListService savedListService;
 

--- a/server/src/test/java/org/tctalent/server/api/admin/CandidateSavedListAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/CandidateSavedListAdminApiTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2023 Talent Beyond Boundaries.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.api.admin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.tctalent.server.service.db.CandidateSavedListService;
+import org.tctalent.server.service.db.CandidateService;
+import org.tctalent.server.service.db.SavedListService;
+
+/**
+ * Unit tests for Candidate Saved List Admin Api endpoints.
+ *
+ * @author sadatmalik
+ */
+@WebMvcTest(CandidateSavedListAdminApi.class)
+@AutoConfigureMockMvc
+class CandidateSavedListAdminApiTest extends ApiTestBase {
+
+  @MockBean CandidateService candidateService;
+  @MockBean CandidateSavedListService candidateSavedListService;
+  @MockBean SavedListService savedListService;
+
+  @Autowired MockMvc mockMvc;
+  @Autowired ObjectMapper objectMapper;
+  @Autowired CandidateSavedListAdminApi candidateSavedListAdminApi;
+
+  @BeforeEach
+  void setUp() {
+    configureAuthentication();
+  }
+
+  @Test
+  public void testWebOnlyContextLoads() {
+    assertThat(candidateSavedListAdminApi).isNotNull();
+  }
+
+
+
+}

--- a/server/src/test/java/org/tctalent/server/api/admin/CandidateSavedListAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/CandidateSavedListAdminApiTest.java
@@ -17,15 +17,25 @@
 package org.tctalent.server.api.admin;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.tctalent.server.request.list.SearchSavedListRequest;
 import org.tctalent.server.service.db.CandidateSavedListService;
 import org.tctalent.server.service.db.SavedListService;
 
@@ -37,6 +47,16 @@ import org.tctalent.server.service.db.SavedListService;
 @WebMvcTest(CandidateSavedListAdminApi.class)
 @AutoConfigureMockMvc
 class CandidateSavedListAdminApiTest extends ApiTestBase {
+
+  private static final String BASE_PATH = "/api/admin/candidate-saved-list";
+
+  private static final String REPLACE_PATH = "/{id}/replace";
+  private static final String SEARCH_PATH = "/{id}/search";
+  private static final String LIST_PATH = "/{id}/list";
+  private static final String MERGE_PATH = "/{id}/merge";
+  private static final String REMOVE_PATH = "/{id}/remove";
+  private static final String SEARCH_PAGED_PATH = "/{id}/search-paged";
+
 
   @MockBean CandidateSavedListService candidateSavedListService;
   @MockBean SavedListService savedListService;
@@ -55,6 +75,34 @@ class CandidateSavedListAdminApiTest extends ApiTestBase {
     assertThat(candidateSavedListAdminApi).isNotNull();
   }
 
+  // replace
 
+  // search
+
+  // list
+
+  // merge
+
+  // remove
+
+  // search-paged
+  @Test
+  @DisplayName("search paged fails - not implemented")
+  void searchPagedFailsNotImplemented() throws Exception {
+    SearchSavedListRequest request = new SearchSavedListRequest();
+
+    mockMvc.perform(post(BASE_PATH + SEARCH_PAGED_PATH.replace("{id}", "1"))
+            .header("Authorization", "Bearer " + "jwt-token")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request))
+            .accept(MediaType.APPLICATION_JSON))
+
+        .andDo(print())
+        .andExpect(status().isBadRequest())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$", notNullValue()))
+        .andExpect(jsonPath("$.code", is("not_implemented")))
+        .andExpect(jsonPath("$.message", is("Method 'searchPaged' of CandidateSavedListAdminApi is not implemented.")));
+  }
 
 }

--- a/server/src/test/java/org/tctalent/server/api/admin/CandidateSavedListAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/CandidateSavedListAdminApiTest.java
@@ -169,7 +169,6 @@ class CandidateSavedListAdminApiTest extends ApiTestBase {
   @Test
   @DisplayName("list fails - not implemented")
   void listFailsNotImplemented() throws Exception {
-    HasSetOfSavedListsImpl request = new HasSetOfSavedListsImpl();
 
     mockMvc.perform(get(BASE_PATH + LIST_PATH.replace("{id}", "1"))
             .header("Authorization", "Bearer " + "jwt-token")

--- a/server/src/test/java/org/tctalent/server/api/admin/CandidateSavedListAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/CandidateSavedListAdminApiTest.java
@@ -23,6 +23,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -65,6 +66,7 @@ class CandidateSavedListAdminApiTest extends ApiTestBase {
   private static final String REMOVE_PATH = "/{id}/remove";
   private static final String SEARCH_PAGED_PATH = "/{id}/search-paged";
 
+  private static final long CANDIDATE_ID = 99L;
 
   @MockBean CandidateSavedListService candidateSavedListService;
   @MockBean SavedListService savedListService;
@@ -82,8 +84,6 @@ class CandidateSavedListAdminApiTest extends ApiTestBase {
   public void testWebOnlyContextLoads() {
     assertThat(candidateSavedListAdminApi).isNotNull();
   }
-
-  // replace
 
   @Test
   @DisplayName("search succeeds")
@@ -146,6 +146,24 @@ class CandidateSavedListAdminApiTest extends ApiTestBase {
         .andExpect(jsonPath("$.[0].tasks[0].description", is("a test task description")))
         .andExpect(jsonPath("$.[0].tasks[0].optional", is(false)))
         .andExpect(jsonPath("$.[0].tasks[0].daysToComplete", is(7)));
+  }
+
+  @Test
+  @DisplayName("replace succeeds")
+  void replaceSucceeds() throws Exception {
+    HasSetOfSavedListsImpl request = new HasSetOfSavedListsImpl();
+
+    mockMvc.perform(put(BASE_PATH + REPLACE_PATH.replace("{id}", String.valueOf(CANDIDATE_ID)))
+            .header("Authorization", "Bearer " + "jwt-token")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request))
+            .accept(MediaType.APPLICATION_JSON))
+
+        .andDo(print())
+        .andExpect(status().isOk());
+
+    verify(candidateSavedListService).clearCandidateSavedLists(CANDIDATE_ID);
+    verify(candidateSavedListService).mergeCandidateSavedLists(anyLong(), any(HasSetOfSavedListsImpl.class));
   }
 
   @Test


### PR DESCRIPTION
This PR:

- contains unit tests for CandidateSavedListAdminApi endpoints
- removes unused property in CandidateSavedListAdminApi
- uses required arg constructor in CandidateSavedListAdminApi
- uses Slf4j, getter and setter lombok annotations in SavedList entity