### PR TITLE
Renaming db name from tbbtalent to tctalent

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,19 +145,19 @@ Then you can run `init` (only need to do this once), and then `plan` or `apply`,
    
 Now you will see the command line prompt =#
 
-    CREATE DATABASE tbbtalent;
-    CREATE USER tbbtalent WITH SUPERUSER PASSWORD 'tbbtalent';
+    CREATE DATABASE tctalent;
+    CREATE USER tctalent WITH SUPERUSER PASSWORD 'tctalent';
     \q
 
 Ask another developer for a recent `pg_dump` of their test database - 
 matching the latest version of the code.
     
-    pg_dump --file=path/to/file.sql --create --username=tbbtalent --host=localhost --port=5432
+    pg_dump --file=path/to/file.sql --create --username=tctalent --host=localhost --port=5432
 
 
 Use `psql` to import that dump file into your newly created database.
 
-    psql -h localhost -d tbbtalent -U tbbtalent -f path/to/file.sql
+    psql -h localhost -d tctalent -U tctalent -f path/to/file.sql
 
 ### Download and edit the code ###
 

--- a/performance-tests/src/test/resources/application.conf
+++ b/performance-tests/src/test/resources/application.conf
@@ -1,7 +1,7 @@
 db {
-  username = "tbbtalent"
-  password = "tbbtalent"
-  url = "localhost:5432/tbbtalent"
+  username = "tctalent"
+  password = "tctalent"
+  url = "localhost:5432/tctalent"
   maximumPoolSize = 23
   connectionTimeout = "3 minutes"
 }

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -19,7 +19,7 @@ logging:
         boot:
           internal:
             #Gets rid of DuplicateSeqGen errors at start up.
-            #Caused by Entity inheritance from org/tbbtalent/server/model/db/AbstractDomainObject.java
+            #Caused by Entity inheritance from org/tctalent/server/model/db/AbstractDomainObject.java
             #See notes in that class
             InFlightMetadataCollectorImpl: ERROR
       springframework:
@@ -60,9 +60,9 @@ spring:
 
   datasource:
     driverClassName: org.postgresql.Driver
-    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/tbbtalent}
-    username: tbbtalent
-    password: ${SPRING_DATASOURCE_PASSWORD:tbbtalent}
+    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/tctalent}
+    username: tctalent
+    password: ${SPRING_DATASOURCE_PASSWORD:tctalent}
     hikari:
       maximum-pool-size: ${SPRING_DBPOOL_MAX:10}
       minimum-idle:  ${SPRING_DBPOOL_MIN:10}


### PR DESCRIPTION
This PR:

- updates the relevant configuration properties to point to the renamed tctalent database
- updates the project Readme

Notes 

- you will have to take steps to rename your local DB - details can be found in the issue [comments](https://app.zenhub.com/workspaces/tc-engineering-646c91f0c3176e1ce584ec28/issues/gh/talent-catalog/talentcatalog/176)
- when the PR is merged with staging - the staging DB will need to be renamed and the staging service restarted
- the production DB will need to be renamed prior to the v2.2.0 service release
