### PR TITLE
372 widen colour palette on admin portal tc lacking strong accent colour very bluesgreys

### DIFF
--- a/ui/admin-portal/src/app/components/candidate-opp/candidate-opps-with-detail/candidate-opps-with-detail.component.html
+++ b/ui/admin-portal/src/app/components/candidate-opp/candidate-opps-with-detail/candidate-opps-with-detail.component.html
@@ -1,32 +1,34 @@
-<div class="row">
-  <div class="col-sm-{{mainPanelColWidth}}">
+<div class="container-fluid mt-4">
+  <div class="row">
+    <div class="col-sm-{{mainPanelColWidth}}">
 
-    <app-candidate-opps
-      [searchBy]="searchBy"
-      (oppSelection)="onOppSelected($event)"
-    >
-    </app-candidate-opps>
+      <app-candidate-opps
+        [searchBy]="searchBy"
+        (oppSelection)="onOppSelected($event)"
+      >
+      </app-candidate-opps>
 
-  </div>
+    </div>
 
-  <div class="col-sm-{{sidePanelColWidth}} detail-panel">
-    <div class="w-100">
-      <div *ngIf="canToggleSizes()" class="float-end">
-        <button class="btn btn-sm btn-outline-secondary" (click)="resizeSidePanel()"><i
-          class="fas fa-arrow-{{sidePanelIsMax ? 'right' : 'left'}}"></i></button>
-      </div>
-
-      <div *ngIf="selectedOpp">
-        <div class="alert alert-danger" *ngIf="error">
-          {{error}}
+    <div class="col-sm-{{sidePanelColWidth}} detail-panel side-panel-color">
+      <div class="w-100">
+        <div *ngIf="canToggleSizes()" class="float-end">
+          <button class="btn btn-sm btn-outline-secondary" (click)="resizeSidePanel()"><i
+            class="fas fa-arrow-{{sidePanelIsMax ? 'right' : 'left'}}"></i></button>
         </div>
 
-        <app-view-candidate-opp
-          [opp]="selectedOpp"
-          [showBreadcrumb]="false"
-          (candidateOppUpdated)="onCandidateOppUpdated($event)"
-        >
-        </app-view-candidate-opp>
+        <div *ngIf="selectedOpp">
+          <div class="alert alert-danger" *ngIf="error">
+            {{error}}
+          </div>
+
+          <app-view-candidate-opp
+            [opp]="selectedOpp"
+            [showBreadcrumb]="false"
+            (candidateOppUpdated)="onCandidateOppUpdated($event)"
+          >
+          </app-view-candidate-opp>
+        </div>
       </div>
     </div>
   </div>

--- a/ui/admin-portal/src/app/components/candidate-opp/candidate-opps-with-detail/candidate-opps-with-detail.component.scss
+++ b/ui/admin-portal/src/app/components/candidate-opp/candidate-opps-with-detail/candidate-opps-with-detail.component.scss
@@ -1,5 +1,5 @@
-.detail-panel {
-  position: fixed;
-  top: 150px;
-  right: 0;
-}
+//.detail-panel {
+//  position: fixed;
+//  top: 150px;
+//  right: 0;
+//}

--- a/ui/admin-portal/src/app/components/candidate-opp/candidate-opps-with-detail/candidate-opps-with-detail.component.scss
+++ b/ui/admin-portal/src/app/components/candidate-opp/candidate-opps-with-detail/candidate-opps-with-detail.component.scss
@@ -1,5 +1,1 @@
-//.detail-panel {
-//  position: fixed;
-//  top: 150px;
-//  right: 0;
-//}
+

--- a/ui/admin-portal/src/app/components/candidate-opp/candidate-opps/candidate-opps.component.html
+++ b/ui/admin-portal/src/app/components/candidate-opp/candidate-opps/candidate-opps.component.html
@@ -55,7 +55,7 @@
     <div class="table-responsive">
       <table class="table table-hover">
         <!--          Header-->
-        <thead class="table-light">
+        <thead class="table-primary">
         <tr>
           <th *ngIf="!showJobOppName" (click)="toggleSort('name')">
             <app-sorted-by [column]="'name'" [sortColumn]="sortField" [sortDirection]="sortDirection"

--- a/ui/admin-portal/src/app/components/candidate-opp/view-candidate-opp/view-candidate-opp.component.html
+++ b/ui/admin-portal/src/app/components/candidate-opp/view-candidate-opp/view-candidate-opp.component.html
@@ -1,4 +1,4 @@
-<div *ngIf="opp">
+<div *ngIf="opp" [ngClass]="{'detail-panel' : !showBreadcrumb}">
 
   <nav aria-label="breadcrumb" [hidden]="!showBreadcrumb">
     <ol class="breadcrumb align-items-center">
@@ -8,32 +8,31 @@
 
   </nav>
 
-  <div class="d-flex justify-content-between align-items-center">
-    <h1>{{opp.name}}
-      <span class="small text-muted">
+  <div class="py-2">
+    <div class="d-flex justify-content-between align-items-center">
+      <h1 class="mb-4">{{opp.name}}
+        <span class="small text-muted">
         <a [routerLink]="['/opp',opp.id]">
           <i class="fas fa-expand" title="Open"></i>
         </a>
         <a *ngIf="opp.sfId && canAccessSalesforce()" [href]="getOppSfLink(opp.sfId)" target="_blank">
-          <i class="fab fa-salesforce" title="Show opp in Salesforce"></i>
+          <i class="fab fa-salesforce link-info ms-2" title="Show opp in Salesforce"></i>
         </a>
         <a [routerLink]="['/candidate',opp.candidate?.candidateNumber]">
-          <i class="fas fa-user" title="Candidate"></i>
+          <i class="fas fa-user link-info" title="Candidate"></i>
         </a>
         <a [routerLink]="['/job',opp.jobOpp.id]">
-          <i class="fa-solid fa-briefcase" title="Job"></i>
+          <i class="fa-solid fa-briefcase link-info" title="Job"></i>
         </a>
       </span>
-    </h1>
+      </h1>
+    </div>
+    <p class="text-accent-1 fst-italic" [ngClass]="{'fs-5' : showBreadcrumb, 'fs-6' : !showBreadcrumb}">
+      Candidate Opportunity Case Number {{opp.id}}
+    </p>
   </div>
 
-  <div>
-    Candidate Opportunity Case Number {{opp.id}}
-  </div>
-  <hr/>
-
-
-  <div>
+  <div class="pt-2">
     <!-- TABS -->
     <nav ngbNav #nav="ngbNav" class="nav-tabs" [activeId]="activeTabId" (navChange)="onTabChanged($event)">
 
@@ -47,7 +46,7 @@
               Case details
               <div class="float-end" *ngIf="editable">
                 <i class="fas fa-spinner fa-spin" *ngIf=updating></i>
-                <button class="btn btn-sm btn-outline-secondary" title="Update progress" (click)="editOppProgress()">
+                <button class="btn btn-sm btn-secondary" title="Update progress" (click)="editOppProgress()">
                   <i class="fas fa-edit"></i>
                 </button>
               </div>

--- a/ui/admin-portal/src/app/components/candidate-opp/view-candidate-opp/view-candidate-opp.component.html
+++ b/ui/admin-portal/src/app/components/candidate-opp/view-candidate-opp/view-candidate-opp.component.html
@@ -1,4 +1,4 @@
-<div *ngIf="opp" [ngClass]="{'detail-panel' : !showBreadcrumb}">
+<div *ngIf="opp">
 
   <nav aria-label="breadcrumb" [hidden]="!showBreadcrumb">
     <ol class="breadcrumb align-items-center">

--- a/ui/admin-portal/src/app/components/candidate-opp/view-candidate-opp/view-candidate-opp.component.scss
+++ b/ui/admin-portal/src/app/components/candidate-opp/view-candidate-opp/view-candidate-opp.component.scss
@@ -1,0 +1,11 @@
+@import "~src/scss/variables";
+
+.detail-panel {
+  background-color: fade-out($accent3, 0.7);
+  border-radius: 5px;
+  padding: 1rem;
+  h1 {
+    font-size: 1.5rem;
+  }
+}
+

--- a/ui/admin-portal/src/app/components/candidate-opp/view-candidate-opp/view-candidate-opp.component.scss
+++ b/ui/admin-portal/src/app/components/candidate-opp/view-candidate-opp/view-candidate-opp.component.scss
@@ -1,11 +1,9 @@
 @import "~src/scss/variables";
 
 .detail-panel {
-  background-color: fade-out($accent3, 0.7);
-  border-radius: 5px;
-  padding: 1rem;
   h1 {
     font-size: 1.5rem;
   }
 }
+
 

--- a/ui/admin-portal/src/app/components/candidates/show/browse/browse-candidate-sources.component.scss
+++ b/ui/admin-portal/src/app/components/candidates/show/browse/browse-candidate-sources.component.scss
@@ -39,21 +39,22 @@
   position: relative;
   left: 0;
   background-color: $accent3;
+  color: $dark;
   margin: .5em;
   margin-left: 0;
   padding: 0.1em .4em;
   border-radius: 4px;
 }
 .searches li:hover {;
-  background-color: $accent2;
-  color: $accent1;
+  background-color: $accent1;
+  color: $light;
   left: .1em;
 }
 .searches li.selected {
-  background-color: $secondary;
+  background-color: $accent1;
   color: white;
 }
 .searches li.selected:hover {
-  background-color: $accent2;
-  color: white;
+  background-color: $accent1;
+  color: $light;
 }

--- a/ui/admin-portal/src/app/components/candidates/show/browse/browse-candidate-sources.component.scss
+++ b/ui/admin-portal/src/app/components/candidates/show/browse/browse-candidate-sources.component.scss
@@ -18,8 +18,7 @@
 
 .admin-panel {
   justify-content: space-between;
-  //align-items: flex-end;
-  //background-color: #efefef;
+  align-items: flex-end;
   padding: 1em;
   max-width: 700px;
 }
@@ -39,21 +38,22 @@
   cursor: pointer;
   position: relative;
   left: 0;
-  background-color: $color-secondary-lighter;
+  background-color: $accent3;
   margin: .5em;
   margin-left: 0;
   padding: 0.1em .4em;
   border-radius: 4px;
 }
 .searches li:hover {;
-  background-color: $color-primary-dark;
+  background-color: $accent2;
+  color: $accent1;
   left: .1em;
 }
 .searches li.selected {
-  background-color: $color-secondary-light;
+  background-color: $secondary;
   color: white;
 }
 .searches li.selected:hover {
-  background-color: $color-primary-darker;
+  background-color: $accent2;
   color: white;
 }

--- a/ui/admin-portal/src/app/components/candidates/show/returns/candidate-source-results.component.html
+++ b/ui/admin-portal/src/app/components/candidates/show/returns/candidate-source-results.component.html
@@ -79,7 +79,7 @@
 
       <tr *ngFor="let candidate of results?.content">
         <td>
-          <a class="fw-500" [routerLink]="['/candidate',candidate.candidateNumber]">
+          <a class="fw-bold" [routerLink]="['/candidate',candidate.candidateNumber]">
             {{candidate.candidateNumber}}
           </a>
           <a target="_blank" [href]="candidate.user.partner.websiteUrl">

--- a/ui/admin-portal/src/app/components/candidates/show/returns/candidate-source-results.component.html
+++ b/ui/admin-portal/src/app/components/candidates/show/returns/candidate-source-results.component.html
@@ -61,7 +61,7 @@
   <div class="table-responsive">
     <table class="table">
 
-      <thead>
+      <thead class="table-primary">
       <tr>
         <th class="candidate-number-row" (click)="toggleSort('id')">
           <app-sorted-by [column]="'id'" [sortColumn]="sortField" [sortDirection]="sortDirection"></app-sorted-by>
@@ -79,7 +79,7 @@
 
       <tr *ngFor="let candidate of results?.content">
         <td>
-          <a [routerLink]="['/candidate',candidate.candidateNumber]">
+          <a class="fw-500" [routerLink]="['/candidate',candidate.candidateNumber]">
             {{candidate.candidateNumber}}
           </a>
           <a target="_blank" [href]="candidate.user.partner.websiteUrl">

--- a/ui/admin-portal/src/app/components/candidates/show/returns/candidate-source-results.component.html
+++ b/ui/admin-portal/src/app/components/candidates/show/returns/candidate-source-results.component.html
@@ -82,11 +82,11 @@
           <a class="fw-bold" [routerLink]="['/candidate',candidate.candidateNumber]">
             {{candidate.candidateNumber}}
           </a>
+          <a target="_blank" [routerLink]="['/candidate',candidate.candidateNumber]">
+            <i class="fas fa-external-link-alt link-primary me-2" title="Show candidate in new tab"></i>
+          </a>
           <a target="_blank" [href]="candidate.user.partner.websiteUrl">
             <i class="fas fa-hands-helping" [title]="'Partner: ' + candidate.user.partner.name"></i>
-          </a>
-          <a target="_blank" [routerLink]="['/candidate',candidate.candidateNumber]">
-            <i class="fas fa-external-link-alt" title="Show candidate in new tab"></i>
           </a>
           <a *ngIf="candidate.sflink && canAccessSalesforce()" [href]="candidate.sflink" target="_blank">
             <i class="fab fa-salesforce" title="Show candidate in Salesforce"></i>

--- a/ui/admin-portal/src/app/components/candidates/show/returns/candidate-source-results.component.html
+++ b/ui/admin-portal/src/app/components/candidates/show/returns/candidate-source-results.component.html
@@ -83,7 +83,7 @@
             {{candidate.candidateNumber}}
           </a>
           <a target="_blank" [routerLink]="['/candidate',candidate.candidateNumber]">
-            <i class="fas fa-external-link-alt link-primary me-2" title="Show candidate in new tab"></i>
+            <i class="fas fa-external-link-alt is-link me-2" title="Show candidate in new tab"></i>
           </a>
           <a target="_blank" [href]="candidate.user.partner.websiteUrl">
             <i class="fas fa-hands-helping" [title]="'Partner: ' + candidate.user.partner.name"></i>

--- a/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.html
+++ b/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.html
@@ -57,48 +57,47 @@
 
 <!--      Icons -->
       <div class="d-flex flex-grow-1 space-evenly">
-        <button class="btn" *ngIf="!isDefaultSavedSearch()" (click)="doCopyLink()">
+        <button class="btn btn-link" *ngIf="!isDefaultSavedSearch()" (click)="doCopyLink()">
           <i class="fas fa-link" title="Copy shareable link"></i>
         </button>
-        <button class="btn" (click)="doToggleStarred()">
+        <button class="btn btn-link" (click)="doToggleStarred()">
           <i *ngIf="isStarred()" class="fas fa-star starred" title="Unstar"></i>
           <i *ngIf="!isStarred()" class="far fa-star notstarred" title="Star"></i>
         </button>
-        <button class="btn" *ngIf="isSavedList()" (click)="doCopySource()">
+        <button class="btn btn-link" *ngIf="isSavedList()" (click)="doCopySource()">
           <i class="fas fa-clone" title="Copy"></i>
         </button>
-        <button class="btn" *ngIf="hasSavedSearchSource()" (click)="doShowSearch()">
+        <button class="btn btn-link" *ngIf="hasSavedSearchSource()" (click)="doShowSearch()">
           <i class="fas fa-search" title="Show Search"></i>
         </button>
-        <button class="btn" *ngIf="isEditable() && !isDefaultSavedSearch()" (click)="doEditSource()">
+        <button class="btn btn-link" *ngIf="isEditable() && !isDefaultSavedSearch()" (click)="doEditSource()">
           <i class="fas fa-edit" title="Rename"></i>
         </button>
-        <button class="btn" (click)="doSelectColumns()">
+        <button class="btn btn-link" (click)="doSelectColumns()">
           <i class="fas fa-columns" title="Select columns to display"></i>
         </button>
-        <button class="btn" *ngIf="canAssignTasks()" (click)="assignTasks()">
+        <button class="btn btn-link" *ngIf="canAssignTasks()" (click)="assignTasks()">
           <i class="fas fa-tasks" title="Assign/show tasks"></i>
         </button>
-        <button class="btn" *ngIf="!isDefaultSavedSearch()" (click)="doRunStats()">
+        <button class="btn btn-link" *ngIf="!isDefaultSavedSearch()" (click)="doRunStats()">
           <i class="fas fa-chart-bar" title="Run stats"></i>
         </button>
-        <button class="btn" *ngIf="candidateSource?.sfJobOpp"
+        <button class="btn btn-link" *ngIf="candidateSource?.sfJobOpp"
            [routerLink]="['/job',candidateSource.sfJobOpp.id]">
           <i class="fa-solid fa-briefcase" title="Associated Job"></i>
         </button>
-        <button class="btn" *ngIf="salesforceService.joblink(candidateSource) && canAccessSalesforce()">
-          <a target="_blank"
-             [href]="salesforceService.joblink(candidateSource)">
+        <button class="btn btn-link"
+                *ngIf="salesforceService.joblink(candidateSource) && canAccessSalesforce()"
+                (click)="doShowSalesforceLink()">
             <i class="fab fa-salesforce" title="Associated Job Opportunity on Salesforce"></i>
-          </a>
         </button>
-        <button class="btn" *ngIf="isSavedList()" (click)="doShowListFolder()">
+        <button class="btn btn-link" *ngIf="isSavedList()" (click)="doShowListFolder()">
           <i class="fab fa-google-drive" title="Create/show Google folder"></i>
         </button>
-        <button class="btn" *ngIf="hasPublishedDoc()" (click)="doShowPublishedDoc()">
+        <button class="btn btn-link" *ngIf="hasPublishedDoc()" (click)="doShowPublishedDoc()">
           <i class="fas fa-globe" title="Show published sheet"></i>
         </button>
-        <button class="btn" *ngIf="timestamp" (click)="doSearch(true)">
+        <button class="btn btn-link" *ngIf="timestamp" (click)="doSearch(true)">
           <i class="fas fa-sync" title="Refresh data"></i>
         </button>
       </div>
@@ -111,10 +110,10 @@
     </div>
 
 <!--    Buttons -->
-    <div class="d-flex">
+    <div class="d-flex justify-content-between">
 
-      <div class="d-flex flex-wrap buttons-spacing flex-fill">
-        <button class="btn btn-sm btn-secondary" [disabled]="!isSelection()"
+      <div class="d-flex flex-wrap buttons-spacing flex-fill align-content-between">
+        <button class="btn btn-sm btn-success" [disabled]="!isSelection()"
                 (click)="saveSelection()" title="Save Selection">
           <i class="fas fa-spinner fa-spin" *ngIf=savingSelection></i>
           <i class="fas fa-user-check"></i> to
@@ -193,20 +192,7 @@
       </div>
 
       <div class="d-flex">
-        <div *ngIf="isSavedList()" class="flex-fill w-50 me-2">
-          <form [formGroup]="searchForm">
-            <div class="mb-3 mb-0 flex-fill">
-              <input type="text" class="form-control" placeholder="Search (name or #)..." aria-label="Search (name/number)..." formControlName="keyword"
-                     id="keyword" autofocus>
-            </div>
-            <div *ngIf="isJobList()">
-              <label class="form-label" [title]="showClosedOppsTip" for="showClosedOpps">Show closed cases</label>
-              <input [title]="showClosedOppsTip" type="checkbox" formControlName="showClosedOpps" id="showClosedOpps">
-            </div>
-          </form>
-        </div>
-
-        <div *ngIf="isContentModifiable()" class="flex-fill w-50 ms-2">
+        <div *ngIf="isContentModifiable()" class="flex-fill w-50 me-2">
           <input id="quickNumberOrNameSearch"
                  type="text" class="form-control" #input
                  [ngbTypeahead]="doNumberOrNameSearch"
@@ -218,6 +204,19 @@
           <ng-template #rt let-r="result" let-t="term">
             <ngb-highlight [result]="renderCandidateRow(r)" [term]="t"></ngb-highlight>
           </ng-template>
+        </div>
+
+        <div *ngIf="isSavedList()" class="flex-fill w-50 mx-2">
+          <form [formGroup]="searchForm">
+            <div class="mb-3 mb-0 flex-fill">
+              <input type="text" class="form-control" placeholder="Search (name or #)..." aria-label="Search (name/number)..." formControlName="keyword"
+                     id="keyword" autofocus>
+            </div>
+            <div *ngIf="isJobList()" class="form-check-reverse">
+              <input [title]="showClosedOppsTip" type="checkbox" formControlName="showClosedOpps" id="showClosedOpps" class="form-check-input">
+              <label class="form-check-label" [title]="showClosedOppsTip" for="showClosedOpps">Show closed cases</label>
+            </div>
+          </form>
         </div>
       </div>
 

--- a/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.html
+++ b/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.html
@@ -113,7 +113,7 @@
     <div class="d-flex justify-content-between">
 
       <div class="d-flex flex-wrap buttons-spacing flex-fill align-content-between">
-        <button class="btn btn-sm btn-success" [disabled]="!isSelection()"
+        <button class="btn btn-sm btn-secondary" [disabled]="!isSelection()"
                 (click)="saveSelection()" title="Save Selection">
           <i class="fas fa-spinner fa-spin" *ngIf=savingSelection></i>
           <i class="fas fa-user-check"></i> to
@@ -372,22 +372,22 @@
                   {{candidate.candidateNumber}}
                 </a>
                 <a target="_blank" [routerLink]="['/candidate',candidate.candidateNumber]">
-                  <i class="fas fa-external-link-alt is-link link-primary me-2" title="Show candidate in new tab"></i>
+                  <i class="fas fa-external-link-alt is-link me-2" title="Show candidate in new tab"></i>
                 </a>
                 <a target="_blank" [href]="candidate.user.partner.websiteUrl">
-                  <i class="fas fa-hands-helping is-link" [title]="'Partner: ' + candidate.user.partner.name"></i>
+                  <i class="fas fa-hands-helping" [title]="'Partner: ' + candidate.user.partner.name"></i>
                 </a>
                 <a *ngIf="candidate.sflink && canAccessSalesforce()" [href]="candidate.sflink" target="_blank">
-                  <i class="fab fa-salesforce is-link" title="Show candidate in Salesforce"></i>
+                  <i class="fab fa-salesforce" title="Show candidate in Salesforce"></i>
                 </a>
                 <a *ngIf="candidate.folderlink" [href]="candidate.folderlink" target="_blank">
-                  <i class="fab fa-google-drive is-link" title="Show candidate's Google Doc folder"></i>
+                  <i class="fab fa-google-drive" title="Show candidate's Google Doc folder"></i>
                 </a>
                 <a *ngIf="candidate.videolink" [href]="candidate.videolink" target="_blank">
-                  <i class="fas fa-video is-link" title="Show candidate's one way video"></i>
+                  <i class="fas fa-video" title="Show candidate's one way video"></i>
                 </a>
                 <a *ngIf="candidate.linkedInLink" [href]="candidate.linkedInLink" target="_blank">
-                  <i class="fab fa-linkedin is-link" title="Show candidate's LinkedIn page"></i>
+                  <i class="fab fa-linkedin" title="Show candidate's LinkedIn page"></i>
                 </a>
                 <app-cv-icon
                   *ngIf="isCandidateNameViewable()"

--- a/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.html
+++ b/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.html
@@ -372,11 +372,11 @@
                 <a class="fw-bold" [routerLink]="['/candidate',candidate.candidateNumber]">
                   {{candidate.candidateNumber}}
                 </a>
+                <a target="_blank" [routerLink]="['/candidate',candidate.candidateNumber]">
+                  <i class="fas fa-external-link-alt is-link link-primary me-2" title="Show candidate in new tab"></i>
+                </a>
                 <a target="_blank" [href]="candidate.user.partner.websiteUrl">
                   <i class="fas fa-hands-helping is-link" [title]="'Partner: ' + candidate.user.partner.name"></i>
-                </a>
-                <a target="_blank" [routerLink]="['/candidate',candidate.candidateNumber]">
-                  <i class="fas fa-external-link-alt is-link" title="Show candidate in new tab"></i>
                 </a>
                 <a *ngIf="candidate.sflink && canAccessSalesforce()" [href]="candidate.sflink" target="_blank">
                   <i class="fab fa-salesforce is-link" title="Show candidate in Salesforce"></i>

--- a/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.html
+++ b/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.html
@@ -417,7 +417,7 @@
                 <span [title]="field.getTooltip(candidate)" [ngClass]="{
                 'text-danger': field.getValue(candidate) === 'Overdue',
                 'text-success' : field.getValue(candidate) == 'Completed',
-                'text-alert' : field.getValue(candidate) == 'Abandoned'}">
+                'text-warning' : field.getValue(candidate) == 'Abandoned'}">
 <!--                  todo Have switch on display of arrays vs non arrays.
 Non arrays or single value arrays, just display value
 

--- a/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.html
+++ b/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.html
@@ -293,7 +293,7 @@
         <table class="table table-hover">
 
 <!--          Header-->
-          <thead class="table-light">
+          <thead class="table-primary">
           <tr>
             <th></th>
             <th *ngIf="isReviewable()">
@@ -369,26 +369,26 @@
                 </div>
               </td>
               <td>
-                <a [routerLink]="['/candidate',candidate.candidateNumber]">
+                <a class="fw-bold" [routerLink]="['/candidate',candidate.candidateNumber]">
                   {{candidate.candidateNumber}}
                 </a>
                 <a target="_blank" [href]="candidate.user.partner.websiteUrl">
-                  <i class="fas fa-hands-helping" [title]="'Partner: ' + candidate.user.partner.name"></i>
+                  <i class="fas fa-hands-helping is-link" [title]="'Partner: ' + candidate.user.partner.name"></i>
                 </a>
                 <a target="_blank" [routerLink]="['/candidate',candidate.candidateNumber]">
-                  <i class="fas fa-external-link-alt" title="Show candidate in new tab"></i>
+                  <i class="fas fa-external-link-alt is-link" title="Show candidate in new tab"></i>
                 </a>
                 <a *ngIf="candidate.sflink && canAccessSalesforce()" [href]="candidate.sflink" target="_blank">
-                  <i class="fab fa-salesforce" title="Show candidate in Salesforce"></i>
+                  <i class="fab fa-salesforce is-link" title="Show candidate in Salesforce"></i>
                 </a>
                 <a *ngIf="candidate.folderlink" [href]="candidate.folderlink" target="_blank">
-                  <i class="fab fa-google-drive" title="Show candidate's Google Doc folder"></i>
+                  <i class="fab fa-google-drive is-link" title="Show candidate's Google Doc folder"></i>
                 </a>
                 <a *ngIf="candidate.videolink" [href]="candidate.videolink" target="_blank">
-                  <i class="fas fa-video" title="Show candidate's one way video"></i>
+                  <i class="fas fa-video is-link" title="Show candidate's one way video"></i>
                 </a>
                 <a *ngIf="candidate.linkedInLink" [href]="candidate.linkedInLink" target="_blank">
-                  <i class="fab fa-linkedin" title="Show candidate's LinkedIn page"></i>
+                  <i class="fab fa-linkedin is-link" title="Show candidate's LinkedIn page"></i>
                 </a>
                 <app-cv-icon
                   *ngIf="isCandidateNameViewable()"
@@ -403,7 +403,7 @@
               </td>
               <td *ngIf="isShowStage()">
                 <a *ngIf="getStage(candidate)" [routerLink]="getCandidateOpportunityLink(candidate)"
-                   title="Stage that this candidate is at - linking to their candidate opportunity">
+                   title="Stage that this candidate is at - linking to their candidate opportunity" class="text-secondary">
                   {{getStage(candidate)}}
                 </a>
               </td>

--- a/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.scss
+++ b/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.scss
@@ -44,7 +44,7 @@ label {
 }
 
 .starred {
-  color: red;
+  color: $info;
 }
 
 .notstarred {

--- a/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.scss
+++ b/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.scss
@@ -151,7 +151,6 @@ $candidate-card-width: 40vw;
     bottom: 0;
     z-index: 10;
     overflow-y: auto;
-    background-color: white;
 
     @media (max-width: 768px) {
       width: auto;

--- a/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.scss
+++ b/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.scss
@@ -47,10 +47,6 @@ label {
   color: $warning;
 }
 
-.notstarred {
-  color: grey;
-}
-
 
 .filter-form {
   //background-color: #efefef;

--- a/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.scss
+++ b/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.scss
@@ -44,7 +44,7 @@ label {
 }
 
 .starred {
-  color: $info;
+  color: $warning;
 }
 
 .notstarred {

--- a/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.ts
+++ b/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.ts
@@ -35,7 +35,10 @@ import {
 import {CandidateService} from '../../../services/candidate.service';
 import {SearchResults} from '../../../model/search-results';
 import {NgbModal, NgbOffcanvas, NgbOffcanvasRef} from '@ng-bootstrap/ng-bootstrap';
-import {CreateFromDefaultSavedSearchRequest, SavedSearchService} from '../../../services/saved-search.service';
+import {
+  CreateFromDefaultSavedSearchRequest,
+  SavedSearchService
+} from '../../../services/saved-search.service';
 import {Observable, of, Subscription} from 'rxjs';
 import {CandidateReviewStatusItem} from '../../../model/candidate-review-status-item';
 import {HttpClient} from '@angular/common/http';
@@ -85,7 +88,9 @@ import {
   SavedListGetRequest,
   UpdateExplicitSavedListContentsRequest
 } from '../../../model/saved-list';
-import {CandidateSourceCandidateService} from '../../../services/candidate-source-candidate.service';
+import {
+  CandidateSourceCandidateService
+} from '../../../services/candidate-source-candidate.service';
 import {LocalStorageService} from 'angular-2-local-storage';
 import {
   EditCandidateReviewStatusItemComponent
@@ -104,7 +109,9 @@ import {
 import {CandidateFieldInfo} from '../../../model/candidate-field-info';
 import {CandidateFieldService} from '../../../services/candidate-field.service';
 import {EditCandidateStatusComponent} from "../view/status/edit-candidate-status.component";
-import {EditCandidateOppComponent} from "../../candidate-opp/edit-candidate-opp/edit-candidate-opp.component";
+import {
+  EditCandidateOppComponent
+} from "../../candidate-opp/edit-candidate-opp/edit-candidate-opp.component";
 import {FileSelectorComponent} from "../../util/file-selector/file-selector.component";
 import {PublishedDocColumnService} from "../../../services/published-doc-column.service";
 import {
@@ -1475,6 +1482,14 @@ export class ShowCandidatesComponent implements OnInit, OnChanges, OnDestroy {
         //Open link in new window
         window.open(folderlink, "_blank");
       }
+    }
+  }
+
+  doShowSalesforceLink() {
+    const joblink = this.salesforceService.joblink(this.candidateSource);
+    if (joblink != null) {
+        //Open link in new window
+        window.open(joblink, "_blank");
     }
   }
 

--- a/ui/admin-portal/src/app/components/candidates/view/additional-info/view-candidate-additional-info.component.html
+++ b/ui/admin-portal/src/app/components/candidates/view/additional-info/view-candidate-additional-info.component.html
@@ -19,7 +19,7 @@
   <div class="card-header">
     Anything else we should know?
     <div class="float-end" *ngIf="editable">
-      <button class="btn btn-sm btn-outline-secondary" (click)="editAdditionalInfo()">
+      <button class="btn btn-sm btn-secondary" (click)="editAdditionalInfo()">
         <i class="fas fa-edit"></i></button>
     </div>
   </div>

--- a/ui/admin-portal/src/app/components/candidates/view/attachment/view-candidate-attachment.component.html
+++ b/ui/admin-portal/src/app/components/candidates/view/attachment/view-candidate-attachment.component.html
@@ -98,7 +98,7 @@
         <!-- EDIT -->
         <div class="col-2 col-sm-auto" *ngIf="editable">
           <div class="float-end">
-            <button class="btn btn-sm btn-outline-primary me-2" (click)="editCandidateAttachment(attachment)">
+            <button class="btn btn-sm btn-outline-secondary me-2" (click)="editCandidateAttachment(attachment)">
               <i class="fas fa-edit"></i>
             </button>
 

--- a/ui/admin-portal/src/app/components/candidates/view/attachment/view-candidate-attachment.component.html
+++ b/ui/admin-portal/src/app/components/candidates/view/attachment/view-candidate-attachment.component.html
@@ -67,7 +67,7 @@
           <!-- Non Google files - ie links and AWS files -
            we can just follow their urls-->
           <a *ngIf="attachment.type!==AttachmentType.googlefile"
-             target="_blank" [href]="attachment.url">
+             target="_blank" [href]="attachment.url" class="link-info">
             {{attachment.name}}
           </a>
           <!-- With Google files we can't link to the Google Shared Drive
@@ -76,7 +76,7 @@
            and show that-->
           <a *ngIf="attachment.type===AttachmentType.googlefile"
              (click)="downloadCandidateAttachment(attachment)"
-             target="_blank" class="is-link">
+             target="_blank" class="link-info">
             {{attachment.name}}
           </a>
           <span class="small text-dark"> - {{attachment.type}}</span>

--- a/ui/admin-portal/src/app/components/candidates/view/contact/view-candidate-contact.component.html
+++ b/ui/admin-portal/src/app/components/candidates/view/contact/view-candidate-contact.component.html
@@ -25,7 +25,7 @@
   <div class="card-header">
     Contact Information
     <div class="float-end" *ngIf="editable">
-      <button class="btn btn-sm btn-outline-secondary" (click)="editContactDetails()">
+      <button class="btn btn-sm btn-secondary" (click)="editContactDetails()">
         <i class="fas fa-edit"></i></button>
     </div>
   </div>

--- a/ui/admin-portal/src/app/components/candidates/view/education/view-candidate-education.component.html
+++ b/ui/admin-portal/src/app/components/candidates/view/education/view-candidate-education.component.html
@@ -26,7 +26,7 @@
   <div class="card-header">
 
     <span>Education</span>
-    <small class="space-before text-muted" *ngIf="candidate.maxEducationLevel">
+    <small class="space-before" *ngIf="candidate.maxEducationLevel">
       (Max Level: {{candidate.maxEducationLevel?.name}})
     </small>
 

--- a/ui/admin-portal/src/app/components/candidates/view/media/view-candidate-media-willingness.component.html
+++ b/ui/admin-portal/src/app/components/candidates/view/media/view-candidate-media-willingness.component.html
@@ -3,7 +3,7 @@
   <div class="card-header">
     Is candidate open to media?
     <div class="float-end" *ngIf="editable">
-      <button class="btn btn-sm btn-outline-secondary" (click)="editMediaWillingness()">
+      <button class="btn btn-sm btn-secondary" (click)="editMediaWillingness()">
         <i class="fas fa-edit"></i></button>
     </div>
   </div>

--- a/ui/admin-portal/src/app/components/candidates/view/registration/view-candidate-registration.component.html
+++ b/ui/admin-portal/src/app/components/candidates/view/registration/view-candidate-registration.component.html
@@ -25,7 +25,7 @@
   <div class="card-header">
     Registration
     <div class="float-end" *ngIf="editable">
-      <button class="btn btn-sm btn-outline-secondary" (click)="editRegistrationDetails()">
+      <button class="btn btn-sm btn-secondary" (click)="editRegistrationDetails()">
         <i class="fas fa-edit"></i></button>
     </div>
   </div>

--- a/ui/admin-portal/src/app/components/candidates/view/special-links/view-candidate-special-links.component.html
+++ b/ui/admin-portal/src/app/components/candidates/view/special-links/view-candidate-special-links.component.html
@@ -25,15 +25,15 @@
         <i class="fas fa-spinner fa-spin"></i>
     </span>
     <div class="float-end" *ngIf="editable">
-      <button *ngIf="canAccessSalesforce()" class="btn btn-outline-secondary me-2"
+      <button *ngIf="canAccessSalesforce()" class="btn btn-primary me-2"
               (click)="createUpdateSalesforce()">
         <i class="fab fa-salesforce"></i> Create/update Salesforce
       </button>
-      <button *ngIf="!candidate.folderlink" class="btn btn-outline-secondary me-2"
+      <button *ngIf="!candidate.folderlink" class="btn btn-primary me-2"
               (click)="createCandidateFolder()">
         <i class="fab fa-google-drive"></i> Create Google Docs Folder
       </button>
-      <button class="btn btn-sm btn-outline-secondary" (click)="editSpecialLinks()">
+      <button class="btn btn-sm btn-secondary" (click)="editSpecialLinks()">
         <i class="fas fa-edit"></i>
       </button>
     </div>

--- a/ui/admin-portal/src/app/components/candidates/view/status/edit-candidate-status.component.html
+++ b/ui/admin-portal/src/app/components/candidates/view/status/edit-candidate-status.component.html
@@ -32,7 +32,7 @@
   </div>
 </div>
 <div class="modal-footer">
-  <button type="button" class="btn btn-primary"
+  <button type="button" class="btn btn-success"
           (click)="onSave()">Save</button>
   <button type="button" class="btn btn-secondary"
           (click)="cancel()">Cancel</button>

--- a/ui/admin-portal/src/app/components/candidates/view/survey/view-candidate-survey.component.html
+++ b/ui/admin-portal/src/app/components/candidates/view/survey/view-candidate-survey.component.html
@@ -19,7 +19,7 @@
   <div class="card-header">
     How did you hear about us?
     <div class="float-end" *ngIf="editable">
-      <button class="btn btn-sm btn-outline-secondary" (click)="editSurvey()">
+      <button class="btn btn-sm btn-secondary" (click)="editSurvey()">
       <i class="fas fa-edit"></i></button>
     </div>
   </div>

--- a/ui/admin-portal/src/app/components/candidates/view/tab/candidate-visa-tab/candidate-visa-tab.component.html
+++ b/ui/admin-portal/src/app/components/candidates/view/tab/candidate-visa-tab/candidate-visa-tab.component.html
@@ -44,7 +44,7 @@
             <input class="form-check-input" type="radio" [value]="i" name="visaCountry" [id]="'radio'+i"
                    [formControlName]="'visaCountry'" (change)="reloadAndSelectVisaCheck(i)">
             <label class="form-check-label fw-light" [for]="'radio'+i">{{visaCheck?.country?.name}}</label>
-            <a *ngIf="canDeleteVisa()" class="link-secondary float-end" (click)="deleteRecord(i)"><i class="fas fa-trash"></i></a>
+            <a *ngIf="canDeleteVisa()" class="link-danger float-end" (click)="deleteRecord(i)"><i class="fas fa-trash"></i></a>
           </div>
         </div>
       </form>

--- a/ui/admin-portal/src/app/components/candidates/view/tab/candidate-visa-tab/job/candidate-visa-job.component.html
+++ b/ui/admin-portal/src/app/components/candidates/view/tab/candidate-visa-tab/job/candidate-visa-job.component.html
@@ -16,7 +16,7 @@
           <label class="form-check-label fw-light" [for]="'radio'+i">
             <a [routerLink]="visaJob?.jobOpp ? ['/job',visaJob.jobOpp.id] : null" target="_blank">{{visaJob?.jobOpp ? visaJob?.jobOpp?.name : visaJob.name}} <i *ngIf="visaJob?.jobOpp" class="fas fa-external-link-alt" title="Show in new tab"></i></a>
           </label>
-          <a *ngIf="canDeleteVisaJob()" class="link-secondary float-end" (click)="deleteJob(i)"><i class="fas fa-trash"></i></a>
+          <a *ngIf="canDeleteVisaJob()" class="link-danger float-end" (click)="deleteJob(i)"><i class="fas fa-trash"></i></a>
         </div>
       </div>
     </form>

--- a/ui/admin-portal/src/app/components/candidates/view/tab/candidate-visa-tab/nz/visa-check-nz.component.html
+++ b/ui/admin-portal/src/app/components/candidates/view/tab/candidate-visa-tab/nz/visa-check-nz.component.html
@@ -23,7 +23,7 @@
 <div *ngIf="!loading" id="VisaNewZealand">
   <div class="d-flex justify-content-between align-items-center mb-2">
     <h5>Visa New Zealand</h5>
-    <button class="btn btn-primary" (click)="exportAsPdf('VisaNewZealand')" [disabled]="saving">
+    <button class="btn btn-secondary" (click)="exportAsPdf('VisaNewZealand')" [disabled]="saving">
       <i *ngIf="saving" class="fas fa-spinner fa-spin" ></i>
       Export PDF
     </button>

--- a/ui/admin-portal/src/app/components/candidates/view/tab/candidate-visa-tab/uk/visa-check-uk.component.html
+++ b/ui/admin-portal/src/app/components/candidates/view/tab/candidate-visa-tab/uk/visa-check-uk.component.html
@@ -23,7 +23,7 @@
 <div *ngIf="!loading" id="VisaUK">
   <div class="d-flex justify-content-between align-items-center mb-2">
     <h5>Visa UK</h5>
-    <button class="btn btn-primary" (click)="exportAsPdf('VisaUK')" [disabled]="saving">
+    <button class="btn btn-secondary" (click)="exportAsPdf('VisaUK')" [disabled]="saving">
       <i *ngIf="saving" class="fas fa-spinner fa-spin" ></i>
       Export PDF
     </button>

--- a/ui/admin-portal/src/app/components/candidates/view/tasks/view-candidate-tasks.component.html
+++ b/ui/admin-portal/src/app/components/candidates/view/tasks/view-candidate-tasks.component.html
@@ -95,9 +95,9 @@
             </span>
           </div>
           <div *ngIf="ta.completedDate && !ta.abandonedDate" class="text-success font-r80">Completed: {{ta.completedDate | date}}</div>
-          <div *ngIf="ta.abandonedDate && !ta.completedDate" class="text-alert font-r80">Abandoned: {{ta.abandonedDate | date}}</div>
-          <div *ngIf="ta.abandonedDate < ta.completedDate" class="text-alert font-r80">Abandoned: {{ta.abandonedDate | date}}</div>
-          <div *ngIf="ta.completedDate && ta.abandonedDate" class="text-tbb-primary font-r80">Resolved by partner: {{ta.completedDate | date}}</div>
+          <div *ngIf="ta.abandonedDate && !ta.completedDate" class="text-warning font-r80">Abandoned: {{ta.abandonedDate | date}}</div>
+          <div *ngIf="ta.abandonedDate < ta.completedDate" class="text-warning font-r80">Abandoned: {{ta.abandonedDate | date}}</div>
+          <div *ngIf="ta.completedDate && ta.abandonedDate" class="text-secondary font-r80">Resolved by partner: {{ta.completedDate | date}}</div>
         </div>
 
         <!-- IF EDITABLE SHOW FULL RESULTS (COMMENTS, ANSWERS AND EDIT BUTTONS) -->

--- a/ui/admin-portal/src/app/components/candidates/view/view-candidate.component.html
+++ b/ui/admin-portal/src/app/components/candidates/view/view-candidate.component.html
@@ -43,32 +43,32 @@
       <h1>{{candidate.user.firstName}} {{candidate.user.lastName}}
         <span class="small text-muted">
         {{candidate.candidateNumber}} -
-          <a target="_blank" (click)="downloadCV()">
-              <i class="fas fa-file-download is-link" title="Download CV"></i>
+          <a target="_blank" (click)="downloadCV()" class="link-secondary">
+              <i class="fas fa-file-download" title="Download CV"></i>
           </a>
-          <a target="_blank" [routerLink]="['/candidate',candidate.candidateNumber]">
+          <a target="_blank" [routerLink]="['/candidate',candidate.candidateNumber]" class="link-secondary">
             <i class="fas fa-external-link-alt" title="Show candidate in new tab"></i>
           </a>
-          <a *ngIf="candidate.sflink && canAccessSalesforce()" [href]="candidate.sflink" target="_blank">
+          <a *ngIf="candidate.sflink && canAccessSalesforce()" [href]="candidate.sflink" target="_blank" class="link-secondary">
             <i class="fab fa-salesforce" title="Show candidate in Salesforce"></i>
           </a>
-          <a *ngIf="candidate.folderlink" [href]="candidate.folderlink" target="_blank">
+          <a *ngIf="candidate.folderlink" [href]="candidate.folderlink" target="_blank" class="link-secondary">
             <i class="fab fa-google-drive" title="Show candidate's Google Doc folder"></i>
           </a>
-          <a *ngIf="candidate.videolink" [href]="candidate.videolink" target="_blank">
+          <a *ngIf="candidate.videolink" [href]="candidate.videolink" target="_blank" class="link-secondary">
             <i class="fas fa-video" title="Show candidate's one way video"></i>
           </a>
-          <a *ngIf="candidate.linkedInLink" [href]="candidate.linkedInLink" target="_blank">
+          <a *ngIf="candidate.linkedInLink" [href]="candidate.linkedInLink" target="_blank" class="link-secondary" >
             <i class="fab fa-linkedin" title="Show candidate's linkedIn"></i>
           </a>
           <app-cv-icon
             *ngIf="isCVViewable()"
             [candidate]="candidate">
           </app-cv-icon>
-          <a [href]="publicCvUrl()" target="_blank">
+          <a [href]="publicCvUrl()" target="_blank" class="link-secondary">
             <i class="fas fa-users" title="View candidate's public CV"></i>
           </a>
-          <a class="btn-link" (click)="createTailoredCv()">
+          <a (click)="createTailoredCv()" class="link-secondary">
             <i class="fas fa-users-gear"  title="View tailored candidate's public CV"></i>
           </a>
       </span>

--- a/ui/admin-portal/src/app/components/candidates/view/view-candidate.component.html
+++ b/ui/admin-portal/src/app/components/candidates/view/view-candidate.component.html
@@ -43,32 +43,32 @@
       <h1>{{candidate.user.firstName}} {{candidate.user.lastName}}
         <span class="small text-muted">
         {{candidate.candidateNumber}} -
-          <a target="_blank" (click)="downloadCV()" class="link-secondary">
+          <a target="_blank" (click)="downloadCV()" class="link-info">
               <i class="fas fa-file-download" title="Download CV"></i>
           </a>
-          <a target="_blank" [routerLink]="['/candidate',candidate.candidateNumber]" class="link-secondary">
+          <a target="_blank" [routerLink]="['/candidate',candidate.candidateNumber]" class="link-info">
             <i class="fas fa-external-link-alt" title="Show candidate in new tab"></i>
           </a>
-          <a *ngIf="candidate.sflink && canAccessSalesforce()" [href]="candidate.sflink" target="_blank" class="link-secondary">
+          <a *ngIf="candidate.sflink && canAccessSalesforce()" [href]="candidate.sflink" target="_blank" class="link-info">
             <i class="fab fa-salesforce" title="Show candidate in Salesforce"></i>
           </a>
-          <a *ngIf="candidate.folderlink" [href]="candidate.folderlink" target="_blank" class="link-secondary">
+          <a *ngIf="candidate.folderlink" [href]="candidate.folderlink" target="_blank" class="link-info">
             <i class="fab fa-google-drive" title="Show candidate's Google Doc folder"></i>
           </a>
-          <a *ngIf="candidate.videolink" [href]="candidate.videolink" target="_blank" class="link-secondary">
+          <a *ngIf="candidate.videolink" [href]="candidate.videolink" target="_blank" class="link-info">
             <i class="fas fa-video" title="Show candidate's one way video"></i>
           </a>
-          <a *ngIf="candidate.linkedInLink" [href]="candidate.linkedInLink" target="_blank" class="link-secondary" >
+          <a *ngIf="candidate.linkedInLink" [href]="candidate.linkedInLink" target="_blank" class="link-info" >
             <i class="fab fa-linkedin" title="Show candidate's linkedIn"></i>
           </a>
           <app-cv-icon
             *ngIf="isCVViewable()"
             [candidate]="candidate">
           </app-cv-icon>
-          <a [href]="publicCvUrl()" target="_blank" class="link-secondary">
+          <a [href]="publicCvUrl()" target="_blank" class="link-info">
             <i class="fas fa-users" title="View candidate's public CV"></i>
           </a>
-          <a (click)="createTailoredCv()" class="link-secondary">
+          <a (click)="createTailoredCv()" class="link-info">
             <i class="fas fa-users-gear"  title="View tailored candidate's public CV"></i>
           </a>
       </span>

--- a/ui/admin-portal/src/app/components/candidates/view/view-candidate.component.html
+++ b/ui/admin-portal/src/app/components/candidates/view/view-candidate.component.html
@@ -42,12 +42,13 @@
 
       <h1>{{candidate.user.firstName}} {{candidate.user.lastName}}
         <span class="small text-muted">
-        {{candidate.candidateNumber}} -
+        {{candidate.candidateNumber}}
+          <a target="_blank" [routerLink]="['/candidate',candidate.candidateNumber]" class="link-primary">
+            <i class="fas fa-external-link-alt link-primary" title="Show candidate in new tab"></i>
+          </a>
+           -
           <a target="_blank" (click)="downloadCV()" class="link-info">
               <i class="fas fa-file-download" title="Download CV"></i>
-          </a>
-          <a target="_blank" [routerLink]="['/candidate',candidate.candidateNumber]" class="link-info">
-            <i class="fas fa-external-link-alt" title="Show candidate in new tab"></i>
           </a>
           <a *ngIf="candidate.sflink && canAccessSalesforce()" [href]="candidate.sflink" target="_blank" class="link-info">
             <i class="fab fa-salesforce" title="Show candidate in Salesforce"></i>
@@ -124,7 +125,7 @@
     </div>
 
     <div *ngIf="isEditable()" class="ps-2 flex-shrink-0">
-      <button class="btn btn-sm btn-secondary" type="button"
+      <button class="btn btn-sm btn-primary" type="button"
               (click)="onNewList()">+ New List
       </button>
     </div>

--- a/ui/admin-portal/src/app/components/candidates/view/view-candidate.component.html
+++ b/ui/admin-portal/src/app/components/candidates/view/view-candidate.component.html
@@ -44,7 +44,7 @@
         <span class="small text-muted">
         {{candidate.candidateNumber}}
           <a target="_blank" [routerLink]="['/candidate',candidate.candidateNumber]" class="link-primary">
-            <i class="fas fa-external-link-alt link-primary" title="Show candidate in new tab"></i>
+            <i class="fas fa-external-link-alt is-link" title="Show candidate in new tab"></i>
           </a>
            -
           <a target="_blank" (click)="downloadCV()" class="link-info">

--- a/ui/admin-portal/src/app/components/candidates/view/view-candidate.component.scss
+++ b/ui/admin-portal/src/app/components/candidates/view/view-candidate.component.scss
@@ -20,7 +20,7 @@
   display: flex;
   justify-content: space-between;
   //align-items: flex-end;
-  background-color: #efefef;
+  background-color: fade-out($accent3, 0.7);
   padding: 1em;
   border-radius: 0.25rem;
 }
@@ -32,4 +32,8 @@
 #status {
   background-color: #ffffff;
   font-size: 13px;
+}
+
+.card-header {
+  font-size: 17px;
 }

--- a/ui/admin-portal/src/app/components/chat/chats-with-posts/chats-with-posts.component.html
+++ b/ui/admin-portal/src/app/components/chat/chats-with-posts/chats-with-posts.component.html
@@ -7,7 +7,7 @@
     </app-chats>
   </div>
 
-  <div class="col-sm-{{sidePanelColWidth}} admin-panel detail-panel">
+  <div class="col-sm-{{sidePanelColWidth}} admin-panel detail-panel side-panel-color">
     <div class="w-100">
       <div *ngIf="canToggleSizes()" class="float-end">
         <button class="btn btn-sm btn-outline-secondary" (click)="resizeSidePanel()"><i

--- a/ui/admin-portal/src/app/components/header/header.component.html
+++ b/ui/admin-portal/src/app/components/header/header.component.html
@@ -14,13 +14,14 @@
   ~ along with this program. If not, see https://www.gnu.org/licenses/.
   -->
 
-<nav class="navbar navbar-expand-md navbar-dark fixed-top" [ngClass]="{'navbar-staging': isStagingEnv(), 'navbar-local': isLocalEnv()}">
+<nav class="navbar navbar-expand-md navbar-dark fixed-top" [ngClass]="{'navbar-staging': isStagingEnv()}">
   <div class="container-fluid">
 
     <!-- LOGO -->
     <a class="navbar-brand" [href]="websiteUrl" target="_blank">
-      <img id="logo" *ngIf="logo && !isStagingEnv()" class="logo" [src]="logo" alt="Logo">
+      <img id="logo" *ngIf="logo && !isStagingEnv() && !isLocalEnv()" class="logo" [src]="logo" alt="Logo">
       <div *ngIf="isStagingEnv()" class="px-3">PREVIEW</div>
+      <div *ngIf="isLocalEnv()" class="px-3">LOCAL</div>
     </a>
 
     <button class="navbar-toggler hidden-sm-up" type="button"

--- a/ui/admin-portal/src/app/components/header/header.component.scss
+++ b/ui/admin-portal/src/app/components/header/header.component.scss
@@ -22,7 +22,7 @@
 }
 
 .navbar {
-  background-color: $color-primary-darker;
+  background-color: $dark;
   width: 100%;
 
   .logo {
@@ -38,14 +38,14 @@
   }
 }
 
-.navbar-staging {
-  background-color: #e16a0c;
-  height: 80px;
-  #logo {
-    visibility: hidden;
-  }
-}
-
-.navbar-local {
-  background-color: #4f3d77;
-}
+//.navbar-staging {
+//  background-color: #e16a0c;
+//  height: 80px;
+//  #logo {
+//    visibility: hidden;
+//  }
+//}
+//
+//.navbar-local {
+//  background-color: #4f3d77;
+//}

--- a/ui/admin-portal/src/app/components/header/header.component.scss
+++ b/ui/admin-portal/src/app/components/header/header.component.scss
@@ -24,6 +24,7 @@
 .navbar {
   background-color: $dark;
   width: 100%;
+  height: 85px;
 
   .logo {
     max-height: 60px;
@@ -38,14 +39,18 @@
   }
 }
 
-//.navbar-staging {
-//  background-color: #e16a0c;
-//  height: 80px;
-//  #logo {
-//    visibility: hidden;
-//  }
-//}
-//
-//.navbar-local {
-//  background-color: #4f3d77;
-//}
+.navbar-staging {
+  background-color: #145243;
+  height: 80px;
+  #logo {
+    visibility: hidden;
+  }
+}
+
+.navbar-local {
+  background-color: #231c4d;
+  height: 80px;
+  #logo {
+    visibility: hidden;
+  }
+}

--- a/ui/admin-portal/src/app/components/infographics/infographic.component.html
+++ b/ui/admin-portal/src/app/components/infographics/infographic.component.html
@@ -90,23 +90,32 @@
   <!--Loop through reports data, displaying each report-->
   <div *ngIf="statReports">
 
-    <nav class="navbar sticky-top navbar-expand-md navbar-light bg-light second-nav">
+    <nav class="navbar sticky-top navbar-expand-md second-nav">
       <span class="navbar-brand">Stats for {{statsName}}</span>
         <ul class="navbar-nav ms-auto">
-          <button class="btn btn-outline-secondary float-end" [disabled]="!dataLoaded" (click)="exportStats()">
-            <i class="fas fa-file-excel"></i> Export
-          </button>
-
-          <li class="nav-item" ngbDropdown display="dynamic" placement="bottom-right">
-            <a class="nav-link" tabindex="0" ngbDropdownToggle id="navbarDropdown3" role="button">
-              Jump to stats report
-            </a>
-            <div ngbDropdownMenu aria-labelledby="navbarDropdown3" class="dropdown-menu scroll-dropdown">
+          <div ngbDropdown display="dynamic" placement="bottom-end">
+            <button type="button" class="btn btn-info float-end" id="jumpToStats" ngbDropdownToggle>Go to stat <i class="fa-solid fa-hand-point-down"></i></button>
+            <div ngbDropdownMenu aria-labelledby="jumpToStats">
               <ng-container *ngFor="let statReport of statReports; let i = index">
                 <a ngbDropdownItem (click)="scroll(i)">{{statReport.name}}</a>
               </ng-container>
             </div>
-          </li>
+          </div>
+
+          <button class="btn btn-secondary float-end  ms-2" [disabled]="!dataLoaded" (click)="exportStats()">
+            Export <i class="fas fa-file-excel"></i>
+          </button>
+
+<!--          <div class="nav-item" ngbDropdown display="dynamic" placement="bottom-right">-->
+<!--            <a class="btn btn-info" tabindex="0" ngbDropdownToggle id="navbarDropdown3" role="button">-->
+<!--              Jump to stats report-->
+<!--            </a>-->
+<!--            <div ngbDropdownMenu aria-labelledby="navbarDropdown3" class="dropdown-menu scroll-dropdown">-->
+<!--              <ng-container *ngFor="let statReport of statReports; let i = index">-->
+<!--                <a ngbDropdownItem (click)="scroll(i)">{{statReport.name}}</a>-->
+<!--              </ng-container>-->
+<!--            </div>-->
+<!--          </div>-->
         </ul>
     </nav>
 

--- a/ui/admin-portal/src/app/components/infographics/infographic.component.html
+++ b/ui/admin-portal/src/app/components/infographics/infographic.component.html
@@ -14,12 +14,6 @@
   ~ along with this program. If not, see https://www.gnu.org/licenses/.
   -->
 
-<!--<div class="row align-items-center d-flex justify-content-between">-->
-<!--  <div class="col-sm-12 col-md-6">-->
-<!--    <button class="btn btn-outline-secondary" [disabled]="!dataLoaded" (click)="exportStats()">-->
-<!--      <i class="fas fa-file-excel"></i> Export-->
-<!--    </button>-->
-<!--  </div>-->
 <nav aria-label="breadcrumb">
   <ol class="breadcrumb">
     <li class="breadcrumb-item"><a [routerLink]="['/']">Home</a></li>
@@ -106,16 +100,6 @@
             Export <i class="fas fa-file-excel"></i>
           </button>
 
-<!--          <div class="nav-item" ngbDropdown display="dynamic" placement="bottom-right">-->
-<!--            <a class="btn btn-info" tabindex="0" ngbDropdownToggle id="navbarDropdown3" role="button">-->
-<!--              Jump to stats report-->
-<!--            </a>-->
-<!--            <div ngbDropdownMenu aria-labelledby="navbarDropdown3" class="dropdown-menu scroll-dropdown">-->
-<!--              <ng-container *ngFor="let statReport of statReports; let i = index">-->
-<!--                <a ngbDropdownItem (click)="scroll(i)">{{statReport.name}}</a>-->
-<!--              </ng-container>-->
-<!--            </div>-->
-<!--          </div>-->
         </ul>
     </nav>
 

--- a/ui/admin-portal/src/app/components/infographics/infographic.component.scss
+++ b/ui/admin-portal/src/app/components/infographics/infographic.component.scss
@@ -14,6 +14,8 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
+@import "~src/scss/variables";
+
 section {
   margin: 20px;
 }
@@ -21,6 +23,10 @@ section {
 .second-nav {
   top: 76px;
   z-index: 1;
+  border-radius: 5px;
+  background-color: $accent3;
+  padding: 10px 30px;
+  display: flex;
   .scroll-dropdown {
     max-height: 70vh;
     overflow: auto;

--- a/ui/admin-portal/src/app/components/job/jobs-with-detail/jobs-with-detail.component.html
+++ b/ui/admin-portal/src/app/components/job/jobs-with-detail/jobs-with-detail.component.html
@@ -18,12 +18,12 @@
         </div>
 
         <div *ngIf="selectedJob">
-          <div class="d-flex align-items-center mb-3">
-            <span class="fs-5 fw-bold text-primary">{{selectedJob.name + ' (' + selectedJob.id + ')'}}</span>
-            <button class="btn" (click)="doOpenJob()"><i class="fa-solid fa-briefcase text-primary" title="Job"></i></button>
+          <div class="d-flex align-items-center mb-3 text-accent-1">
+            <span class="fs-5 fw-bold">{{selectedJob.name + ' (' + selectedJob.id + ')'}}</span>
+            <button class="btn" (click)="doOpenJob()"><i class="fa-solid fa-briefcase" title="Job"></i></button>
             <button class="btn" (click)="doToggleStarred()">
               <i *ngIf="isStarred()" class="fas fa-star starred" title="Unstar"></i>
-              <i *ngIf="!isStarred()" class="far fa-star notstarred text-primary" title="Star"></i>
+              <i *ngIf="!isStarred()" class="far fa-star notstarred" title="Star"></i>
             </button>
 
             <div class="alert alert-danger" *ngIf="error">

--- a/ui/admin-portal/src/app/components/job/jobs-with-detail/jobs-with-detail.component.html
+++ b/ui/admin-portal/src/app/components/job/jobs-with-detail/jobs-with-detail.component.html
@@ -10,7 +10,7 @@
 
     </div>
 
-    <div class="col-sm-{{sidePanelColWidth}} admin-panel detail-panel">
+    <div class="col-sm-{{sidePanelColWidth}} detail-panel side-panel-color">
       <div class="w-100">
         <div *ngIf="canToggleSizes()" class="float-end">
           <button class="btn btn-sm btn-outline-secondary" (click)="resizeSidePanel()"><i

--- a/ui/admin-portal/src/app/components/job/jobs-with-detail/jobs-with-detail.component.html
+++ b/ui/admin-portal/src/app/components/job/jobs-with-detail/jobs-with-detail.component.html
@@ -1,55 +1,60 @@
-<div class="row">
-  <div class="col-sm-{{mainPanelColWidth}}">
+<div class="container-fluid mt-4">
+  <div class="row">
+    <div class="col-sm-{{mainPanelColWidth}}">
 
-    <app-jobs
-      [searchBy]="searchBy"
-      (oppSelection)="onJobSelected($event)"
-    >
-    </app-jobs>
+      <app-jobs
+        [searchBy]="searchBy"
+        (oppSelection)="onJobSelected($event)"
+      >
+      </app-jobs>
 
-  </div>
+    </div>
 
-  <div class="col-sm-{{sidePanelColWidth}} admin-panel detail-panel">
-    <div class="w-100">
-      <div *ngIf="canToggleSizes()" class="float-end">
-        <button class="btn btn-sm btn-outline-secondary" (click)="resizeSidePanel()"><i
-          class="fas fa-arrow-{{sidePanelIsMax ? 'right' : 'left'}}"></i></button>
-      </div>
-
-      <div *ngIf="selectedJob">
-        <strong>{{selectedJob.name + ' (' + selectedJob.id + ')'}}</strong>
-        <button class="btn" (click)="doOpenJob()"><i class="fa-solid fa-briefcase" title="Job"></i></button>
-        <button class="btn" (click)="doToggleStarred()">
-          <i *ngIf="isStarred()" class="fas fa-star starred" title="Unstar"></i>
-          <i *ngIf="!isStarred()" class="far fa-star notstarred" title="Star"></i>
-        </button>
-
-        <div class="alert alert-danger" *ngIf="error">
-          {{error}}
+    <div class="col-sm-{{sidePanelColWidth}} admin-panel detail-panel">
+      <div class="w-100">
+        <div *ngIf="canToggleSizes()" class="float-end">
+          <button class="btn btn-sm btn-outline-secondary" (click)="resizeSidePanel()"><i
+            class="fas fa-arrow-{{sidePanelIsMax ? 'right' : 'left'}}"></i></button>
         </div>
 
-        <app-view-job-summary
-          [job]="selectedJob"
-        >
-        </app-view-job-summary>
+        <div *ngIf="selectedJob">
+          <div class="d-flex align-items-center mb-3">
+            <span class="fs-5 fw-bold text-primary">{{selectedJob.name + ' (' + selectedJob.id + ')'}}</span>
+            <button class="btn" (click)="doOpenJob()"><i class="fa-solid fa-briefcase text-primary" title="Job"></i></button>
+            <button class="btn" (click)="doToggleStarred()">
+              <i *ngIf="isStarred()" class="fas fa-star starred" title="Unstar"></i>
+              <i *ngIf="!isStarred()" class="far fa-star notstarred text-primary" title="Star"></i>
+            </button>
 
-        <hr/>
-        <div>
-          Submission List - Candidate opportunities ("cases") going for this job
+            <div class="alert alert-danger" *ngIf="error">
+              {{error}}
+            </div>
+          </div>
+
+          <app-view-job-summary
+            [job]="selectedJob"
+          >
+          </app-view-job-summary>
+
+
+          <div class="mt-4">
+            <h6>Submission List - <small class="fst-italic">Candidate opportunities ("cases") going for this job</small></h6>
+          </div>
+
+          <app-candidate-source-results *ngIf= "selectedJob.submissionList"
+                                        [candidateSource]="selectedJob.submissionList" >
+            <!--                                    (toggleStarred)="onToggleStarred($event)"-->
+            <!--                                    (toggleWatch)="onToggleWatch($event)"-->
+            <!--                                    (deleteSource)="onDeleteSource($event)"-->
+            <!--                                    (editSource)="onEditSource($event)"-->
+            <!--                                    (copySource)="onCopySource($event)"-->
+            >
+
+          </app-candidate-source-results>
         </div>
 
-        <app-candidate-source-results *ngIf= "selectedJob.submissionList"
-                                      [candidateSource]="selectedJob.submissionList" >
-  <!--                                    (toggleStarred)="onToggleStarred($event)"-->
-  <!--                                    (toggleWatch)="onToggleWatch($event)"-->
-  <!--                                    (deleteSource)="onDeleteSource($event)"-->
-  <!--                                    (editSource)="onEditSource($event)"-->
-  <!--                                    (copySource)="onCopySource($event)"-->
-        >
-
-        </app-candidate-source-results>
       </div>
-
     </div>
   </div>
 </div>
+

--- a/ui/admin-portal/src/app/components/job/jobs-with-detail/jobs-with-detail.component.html
+++ b/ui/admin-portal/src/app/components/job/jobs-with-detail/jobs-with-detail.component.html
@@ -20,7 +20,7 @@
         <div *ngIf="selectedJob">
           <div class="d-flex align-items-center mb-3 text-accent-1">
             <span class="fs-5 fw-bold">{{selectedJob.name + ' (' + selectedJob.id + ')'}}</span>
-            <button class="btn" (click)="doOpenJob()"><i class="fa-solid fa-briefcase" title="Job"></i></button>
+            <button class="btn" (click)="doOpenJob()"><i class="fa-solid fa-briefcase link-info" title="Job"></i></button>
             <button class="btn" (click)="doToggleStarred()">
               <i *ngIf="isStarred()" class="fas fa-star starred" title="Unstar"></i>
               <i *ngIf="!isStarred()" class="far fa-star notstarred" title="Star"></i>

--- a/ui/admin-portal/src/app/components/job/jobs-with-detail/jobs-with-detail.component.scss
+++ b/ui/admin-portal/src/app/components/job/jobs-with-detail/jobs-with-detail.component.scss
@@ -1,11 +1,11 @@
 @import "~src/scss/variables";
 
 .detail-panel {
-  background-color: fade-out($accent2, 0.9);
+  background-color: fade-out($accent3, 0.7);
   border-radius: 5px;
   padding: 1rem;
 }
 
 .starred {
-  color: $info;
+  color: $warning;
 }

--- a/ui/admin-portal/src/app/components/job/jobs-with-detail/jobs-with-detail.component.scss
+++ b/ui/admin-portal/src/app/components/job/jobs-with-detail/jobs-with-detail.component.scss
@@ -1,11 +1,5 @@
 @import "~src/scss/variables";
 
-.detail-panel {
-  background-color: fade-out($accent3, 0.7);
-  border-radius: 5px;
-  padding: 1rem;
-}
-
 .starred {
   color: $warning;
 }

--- a/ui/admin-portal/src/app/components/job/jobs-with-detail/jobs-with-detail.component.scss
+++ b/ui/admin-portal/src/app/components/job/jobs-with-detail/jobs-with-detail.component.scss
@@ -1,7 +1,7 @@
 @import "~src/scss/variables";
 
 .detail-panel {
-  background-color: fade-out($accent2, 0.8);
+  background-color: fade-out($accent2, 0.9);
   border-radius: 5px;
   padding: 1rem;
 }

--- a/ui/admin-portal/src/app/components/job/jobs-with-detail/jobs-with-detail.component.scss
+++ b/ui/admin-portal/src/app/components/job/jobs-with-detail/jobs-with-detail.component.scss
@@ -1,5 +1,11 @@
+@import "~src/scss/variables";
+
 .detail-panel {
-  position: fixed;
-  top: 150px;
-  right: 0;
+  background-color: fade-out($accent2, 0.8);
+  border-radius: 5px;
+  padding: 1rem;
+}
+
+.starred {
+  color: $info;
 }

--- a/ui/admin-portal/src/app/components/job/jobs/jobs.component.html
+++ b/ui/admin-portal/src/app/components/job/jobs/jobs.component.html
@@ -54,7 +54,7 @@
     <div class="table-responsive">
       <table class="table table-hover">
         <!--          Header-->
-        <thead class="table-light">
+        <thead class="table-primary">
         <tr>
           <th (click)="toggleSort('name')">
             <app-sorted-by [column]="'name'" [sortColumn]="sortField"

--- a/ui/admin-portal/src/app/components/job/view/info/view-job-info/view-job-info.component.html
+++ b/ui/admin-portal/src/app/components/job/view/info/view-job-info/view-job-info.component.html
@@ -3,7 +3,7 @@
   <div class="card-header">
     Job Information
     <div class="float-end" *ngIf="editable" [ngClass]="{'alert alert-danger': highlightSubmissionDate()}">
-      <button class="btn btn-sm btn-outline-secondary" (click)="editJobInfo()">
+      <button class="btn btn-sm btn-secondary" (click)="editJobInfo()">
         <i class="fas fa-edit"></i>
       </button>
     </div>

--- a/ui/admin-portal/src/app/components/job/view/source-contacts/job-source-contacts-with-chats/job-source-contacts-with-chats.component.html
+++ b/ui/admin-portal/src/app/components/job/view/source-contacts/job-source-contacts-with-chats/job-source-contacts-with-chats.component.html
@@ -9,7 +9,7 @@
     </app-view-job-source-contacts>
   </div>
 
-  <div class="col-sm-{{sidePanelColWidth}} admin-panel detail-panel">
+  <div class="col-sm-{{sidePanelColWidth}} admin-panel detail-panel side-panel-color">
     <div class="w-100">
       <div *ngIf="canToggleSizes()" class="float-end">
         <button class="btn btn-sm btn-outline-secondary" (click)="resizeSidePanel()"><i

--- a/ui/admin-portal/src/app/components/job/view/uploads/view-job-uploads/view-job-uploads.component.html
+++ b/ui/admin-portal/src/app/components/job/view/uploads/view-job-uploads/view-job-uploads.component.html
@@ -25,10 +25,10 @@
         </div>
       </div>
       <div class="col-2 col-sm-auto" *ngIf="editable">
-          <button title="Enter/change a link to the document" class="btn btn-sm btn-outline-primary me-2" (click)="editJDLink()">
+          <button title="Enter/change a link to the document" class="btn btn-sm btn-secondary me-2" (click)="editJDLink()">
             <i class="fas fa-edit"></i>
           </button>
-          <button title="Upload the document from your computer" class="btn btn-sm btn-outline-primary" (click)="uploadJD()">
+          <button title="Upload the document from your computer" class="btn btn-sm btn-primary" (click)="uploadJD()">
             <i class="fa-solid fa-upload"></i>
           </button>
         </div>

--- a/ui/admin-portal/src/app/components/job/view/view-job/view-job.component.html
+++ b/ui/admin-portal/src/app/components/job/view/view-job/view-job.component.html
@@ -22,8 +22,8 @@
           <a *ngIf="job.submissionList?.folderjdlink" [href]="job.submissionList.folderjdlink" target="_blank">
             <i class="fab fa-google-drive link-info" title="Show job's Google Doc folder"></i>
           </a>
-          <div class="btn btn-lg pt-0 ps-1" (click)="doToggleStarred()">
-            <i *ngIf="isStarred()" class="fas fa-star starred fa-lg" title="Unstar"></i>
+          <div class="btn btn-lg pt-0" (click)="doToggleStarred()">
+            <i *ngIf="isStarred()" class="fas fa-star starred text-warning fa-lg" title="Unstar"></i>
             <i *ngIf="!isStarred()" class="far fa-star notstarred fa-lg" title="Star"></i>
           </div>
         </span>

--- a/ui/admin-portal/src/app/components/job/view/view-job/view-job.component.html
+++ b/ui/admin-portal/src/app/components/job/view/view-job/view-job.component.html
@@ -12,22 +12,27 @@
     {{error}}
   </div>
 
-  <div class="d-flex justify-content-between align-items-center">
-    <h1>{{job.name}}
-      <span class="small text-muted">
-        <a *ngIf="job.sfId && canAccessSalesforce()" [href]="getSalesforceJobLink(job.sfId)" target="_blank">
-          <i class="fab fa-salesforce" title="Show job in Salesforce"></i>
-        </a>
-        <a *ngIf="job.submissionList?.folderjdlink" [href]="job.submissionList.folderjdlink" target="_blank">
-          <i class="fab fa-google-drive" title="Show job's Google Doc folder"></i>
-        </a>
-        <div class="btn" (click)="doToggleStarred()">
-          <i *ngIf="isStarred()" class="fas fa-star starred" title="Unstar"></i>
-          <i *ngIf="!isStarred()" class="far fa-star notstarred" title="Star"></i>
-        </div>
+  <div class="d-flex justify-content-between align-items-end">
+    <div>
+      <h1 class="my-3">{{job.name}}
+        <span class="ms-2">
+          <a *ngIf="job.sfId && canAccessSalesforce()" [href]="getSalesforceJobLink(job.sfId)" target="_blank">
+            <i class="fab fa-salesforce link-info" title="Show job in Salesforce"></i>
+          </a>
+          <a *ngIf="job.submissionList?.folderjdlink" [href]="job.submissionList.folderjdlink" target="_blank">
+            <i class="fab fa-google-drive link-info" title="Show job's Google Doc folder"></i>
+          </a>
+          <div class="btn btn-lg pt-0 ps-1" (click)="doToggleStarred()">
+            <i *ngIf="isStarred()" class="fas fa-star starred fa-lg" title="Unstar"></i>
+            <i *ngIf="!isStarred()" class="far fa-star notstarred fa-lg" title="Star"></i>
+          </div>
+        </span>
+      </h1>
+      <p class="text-accent-1 fst-italic fs-5">
+        Job Opportunity Number {{job.id}}
+      </p>
+    </div>
 
-      </span>
-    </h1>
 
     <div *ngIf="!job.publishedDate">
       <button type="button" class="btn btn-outline-dark me-2"
@@ -47,11 +52,6 @@
     </div>
 
   </div>
-
-  <div>
-    Job Opportunity Number {{job.id}}
-  </div>
-  <hr/>
 
   <app-view-job-preparation-items *ngIf="!job.publishedDate"
     [jobPrepItems]="jobPrepItems"

--- a/ui/admin-portal/src/app/components/list/create-update/create-update-list.component.html
+++ b/ui/admin-portal/src/app/components/list/create-update/create-update-list.component.html
@@ -60,7 +60,7 @@
 </div>
 
 <div class="modal-footer">
-  <button type="button" class="btn btn-primary" (click)="save()"
+  <button type="button" class="btn btn-success" (click)="save()"
           [disabled]="form?.invalid || saving">
     <i class="fas fa-spinner fa-spin" *ngIf="saving"></i>
     Save

--- a/ui/admin-portal/src/app/components/search/create-update/create-update-search.component.html
+++ b/ui/admin-portal/src/app/components/search/create-update/create-update-search.component.html
@@ -66,7 +66,7 @@
 </div>
 
 <div class="modal-footer">
-  <button type="button" class="btn btn-primary" (click)="save()"
+  <button type="button" class="btn btn-success" (click)="save()"
           [disabled]="form?.invalid || saving">
     <i class="fas fa-spinner fa-spin" *ngIf="saving"></i>
     Save

--- a/ui/admin-portal/src/app/components/search/define-search/define-search.component.html
+++ b/ui/admin-portal/src/app/components/search/define-search/define-search.component.html
@@ -512,7 +512,7 @@
         <div class="container-fluid">
           <div class="row">
             <div class="col text-center">
-              <button type="submit" class="btn btn-primary btn-lg" [disabled]="loading || searchForm.invalid"><i class="fa-solid fa-magnifying-glass fa-sm" style="color: #ffffff;"></i> Search</button>
+              <button type="submit" class="btn btn-success btn-lg" [disabled]="loading || searchForm.invalid"><i class="fa-solid fa-magnifying-glass fa-sm" style="color: #ffffff;"></i> Search</button>
             </div>
           </div>
         </div>

--- a/ui/admin-portal/src/app/components/search/define-search/define-search.component.html
+++ b/ui/admin-portal/src/app/components/search/define-search/define-search.component.html
@@ -25,7 +25,7 @@
     </ol>
   </nav>
 
-  <div [hidden]="!showSearchRequest" >
+  <div [hidden]="!showSearchRequest">
     <div>
       <a class="link" (click)="showSearchRequest = false">
         <ng-container>
@@ -38,32 +38,35 @@
       <div class="d-flex justify-content-between mb-4">
 
         <h3 class="m-0">Candidate Search</h3>
+        <div class="d-flex">
+          <div>
+            <button type="button" class="btn btn-warning me-2"
+                    [disabled]="loading"
+                    (click)="clearForm()">Clear Search</button>
+          </div>
+          <div>
+            <button type="button" class="ms-2 btn btn-secondary"
+                    [hidden]="savedSearch?.defaultSearch"
+                    [disabled]="!canChangeSearchRequest()"
+                    (click)="updateSavedSearchModal()">
+              <i *ngIf="!canChangeSearchRequest()" title="Fixed - can't change"
+                 class="fas fa-lock"></i>
+              Update Search</button>
+            <button type="button" class="ms-2 btn btn-danger"
+                    [hidden]="savedSearch?.defaultSearch"
+                    [disabled]="!canChangeSearchRequest()"
+                    (click)="deleteSavedSearchModal()">
+              <i *ngIf="!canChangeSearchRequest()" title="Fixed - can't change"
+                 class="fas fa-lock"></i>
+              Delete Search</button>
+            <button type="button" class="ms-2 btn btn-primary"
+                    [hidden]="!savedSearch?.defaultSearch"
+                    (click)="createNewSavedSearchModal()">
+              Save Search</button>
+          </div>
+        </div>
 
-        <div>
-          <button type="button" class="btn btn-outline-dark me-2"
-                  [disabled]="loading"
-                  (click)="clearForm()">Clear Search</button>
-        </div>
-        <div>
-          <button type="button" class="ms-2 btn btn-outline-primary"
-                  [hidden]="savedSearch?.defaultSearch"
-                  [disabled]="!canChangeSearchRequest()"
-                  (click)="updateSavedSearchModal()">
-            <i *ngIf="!canChangeSearchRequest()" title="Fixed - can't change"
-               class="fas fa-lock"></i>
-            Update Search</button>
-          <button type="button" class="ms-2 btn btn-outline-primary"
-                  [hidden]="savedSearch?.defaultSearch"
-                  [disabled]="!canChangeSearchRequest()"
-                  (click)="deleteSavedSearchModal()">
-            <i *ngIf="!canChangeSearchRequest()" title="Fixed - can't change"
-               class="fas fa-lock"></i>
-            Delete Search</button>
-          <button type="button" class="ms-2 btn btn-outline-primary"
-                  [hidden]="!savedSearch?.defaultSearch"
-                  (click)="createNewSavedSearchModal()">
-            Save Search</button>
-        </div>
+
 
       </div>
 
@@ -71,7 +74,7 @@
         {{getError()}}
       </div>
 
-      <form class="filter-form" [formGroup]="searchForm" (ngSubmit)="apply()" #formWrapper>
+      <form class="filter-form side-panel-color" [formGroup]="searchForm" (ngSubmit)="apply()" #formWrapper>
         <ng-template #keywordSearchTip>
           Search candidate CVs using these tips to create powerful queries:
           <ul id="keyword-search-tip-list">
@@ -493,17 +496,12 @@
         <hr class="w-100">
 
         <div class="container-fluid">
-          <div class="row">
-
-            <div class="col">
-              <app-join-saved-search
-                (addBaseSearch)="addBaseSearchJoin($event)"
-                (deleteBaseSearch)="deleteBaseSearchJoin()"
-                [baseSearch]= "selectedBaseJoin"
-                [readonly]="elastic()"
-              ></app-join-saved-search>
-            </div>
-          </div>
+          <app-join-saved-search
+            (addBaseSearch)="addBaseSearchJoin($event)"
+            (deleteBaseSearch)="deleteBaseSearchJoin()"
+            [baseSearch]= "selectedBaseJoin"
+            [readonly]="elastic()"
+          ></app-join-saved-search>
         </div>
 
 
@@ -534,7 +532,7 @@
                        (editSource)="updateSavedSearchModal()"
   >
     <!--Toggle search details-->
-    <div>
+    <div class="mb-3">
       <a class="link" (click)="showSearchRequest = !showSearchRequest">
         <ng-container *ngIf="!showSearchRequest">
           <i class="fas fa-caret-up"></i> Show search request

--- a/ui/admin-portal/src/app/components/search/define-search/define-search.component.scss
+++ b/ui/admin-portal/src/app/components/search/define-search/define-search.component.scss
@@ -96,6 +96,7 @@ $candidate-card-width: 375px;
 
     .candidate-number-row {
       max-width: 50px;
+      font-weight: 500;
     }
 
     tbody {

--- a/ui/admin-portal/src/app/components/search/define-search/define-search.component.scss
+++ b/ui/admin-portal/src/app/components/search/define-search/define-search.component.scss
@@ -149,7 +149,6 @@ $candidate-card-width: 375px;
     bottom: 0;
     z-index: 10;
     overflow-y: auto;
-    background-color: white;
 
     @media (max-width: 768px) {
       width: auto;

--- a/ui/admin-portal/src/app/components/search/define-search/define-search.component.scss
+++ b/ui/admin-portal/src/app/components/search/define-search/define-search.component.scss
@@ -14,6 +14,8 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
+@import "~src/scss/variables";
+
 :host {
   ::ng-deep .dropdown-btn {
     background-color: #fff;
@@ -36,8 +38,8 @@ label {
 }
 
 .filter-form {
-  background-color: #efefef;
   padding: 1em;
+  border-radius: 5px;
 
   ::ng-deep {
     .dropdown-btn {
@@ -130,7 +132,7 @@ $candidate-card-width: 375px;
   }
 
   .active {
-    color: black;
+    color: $info;
     font-weight: bold;
   }
 }
@@ -173,6 +175,8 @@ $candidate-card-width: 375px;
 // Making the search tip icon a button enables it to be keyboard-focusable, per Bootstrap doc advice https://getbootstrap.com/docs/5.0/components/tooltips/#markup - overriding the native button style fixes the visual aspect
 .search-tip-button {
   border: none;
+  background-color: inherit;
+  margin-left: 5px;
   padding: 0;
 }
 

--- a/ui/admin-portal/src/app/components/search/join-search/join-saved-search.component.html
+++ b/ui/admin-portal/src/app/components/search/join-search/join-saved-search.component.html
@@ -16,36 +16,42 @@
 
 <div class="row">
   <div class="col-12 col-md-4">
-    <label class="form-label" for="savedSearch">Base Search</label>
-    <input id="savedSearch"
-           type="text" class="form-control"
-           (selectItem)="selected($event.item.id)"
-           [ngbTypeahead]="doSavedSearchSearch"
-           [resultTemplate]="rt"
-           [inputFormatter]="renderSavedSearchRow"
-           [editable]="false"
-           [readOnly]="readonly"
-           placeholder="Type the name of a base search..."/>
-  </div>
-    <ng-template #rt let-r="result" let-t="term">
-      <ngb-highlight [result]="r.name" [term]="t"></ngb-highlight>
-    </ng-template>
+      <label class="form-label" for="savedSearch">Base Search</label>
+      <div class="input-group">
+        <input id="savedSearch"
+               type="text" class="form-control"
+               (selectItem)="selected($event.item.id)"
+               [ngbTypeahead]="doSavedSearchSearch"
+               [resultTemplate]="rt"
+               placement="bottom-left"
+               [value]="this.selectedBaseSearch?.name"
+               [inputFormatter]="renderSavedSearchRow"
+               [readOnly]="readonly"
+               placeholder="Type the name of a base search..."/>
+          <button *ngIf="this.selectedBaseSearch" type="button" class="btn btn-danger" (click)="deleteSearch()" >
+            Remove base search <i class="fas fa-xmark ms-2"></i>
+          </button>
+      </div>
+      <ng-template #rt let-r="result" let-t="term">
+        <ngb-highlight [result]="r.name" [term]="t"></ngb-highlight>
+      </ng-template>
+    </div>
 
-  <div *ngIf="this.selectedBaseSearch" class="d-flex">
-    <app-candidate-source
-      [candidateSource]="selectedBaseSearch"
-      [seeMore]="true"
-      [canLoad]="false"
-      [showWatch]="false"
-      [showOpen]="false"
-      [showSelect]="false"
-      [showLink]="false"
-      [showMore]="false"
-    >
-    </app-candidate-source>
-    <button type="button" class="btn btn-default" (click)="deleteSearch()" ><i
-      class="fas fa-trash"></i></button>
+
+
+  <div *ngIf="this.selectedBaseSearch" class="col-auto">
+      <app-candidate-source
+        [candidateSource]="selectedBaseSearch"
+        [seeMore]="true"
+        [canLoad]="false"
+        [showWatch]="false"
+        [showOpen]="false"
+        [showSelect]="false"
+        [showLink]="false"
+        [showMore]="false">
+      </app-candidate-source>
   </div>
+
 </div>
 
 

--- a/ui/admin-portal/src/app/components/search/join-search/join-saved-search.component.ts
+++ b/ui/admin-portal/src/app/components/search/join-search/join-saved-search.component.ts
@@ -25,14 +25,7 @@ import {
 } from '@angular/core';
 import {SearchResults} from '../../../model/search-results';
 import {FormBuilder, FormGroup} from "@angular/forms";
-import {
-  catchError,
-  debounceTime,
-  distinctUntilChanged,
-  map,
-  switchMap,
-  tap
-} from "rxjs/operators";
+import {catchError, debounceTime, distinctUntilChanged, map, switchMap, tap} from "rxjs/operators";
 import {SavedSearch} from '../../../model/saved-search';
 import {SavedSearchService} from "../../../services/saved-search.service";
 import {Router} from "@angular/router";
@@ -102,6 +95,8 @@ export class JoinSavedSearchComponent implements OnInit, OnChanges {
         tap(() => this.searching = false)
       );
 
+    this.renderSavedSearchRow(this.selectedBaseSearch)
+
   }
 
   ngOnChanges (changes: SimpleChanges) {
@@ -117,7 +112,7 @@ export class JoinSavedSearchComponent implements OnInit, OnChanges {
   }
 
   renderSavedSearchRow(savedSearch: SavedSearch) {
-    return '';
+    return savedSearch?.name;
   }
 
 

--- a/ui/admin-portal/src/app/components/settings/countries/search-countries.component.html
+++ b/ui/admin-portal/src/app/components/settings/countries/search-countries.component.html
@@ -62,7 +62,7 @@
 
   <table class="table">
 
-    <thead class="table-light">
+    <thead class="table-primary">
     <tr>
       <th>Name</th>
       <th>Status</th>

--- a/ui/admin-portal/src/app/components/settings/education-levels/search-education-levels.component.html
+++ b/ui/admin-portal/src/app/components/settings/education-levels/search-education-levels.component.html
@@ -74,7 +74,7 @@
 
   <table class="table align-middle">
 
-    <thead class="table-light">
+    <thead class="table-primary">
     <tr>
       <th>Level</th>
       <th>Name</th>

--- a/ui/admin-portal/src/app/components/settings/education-majors/search-education-majors.component.html
+++ b/ui/admin-portal/src/app/components/settings/education-majors/search-education-majors.component.html
@@ -74,7 +74,7 @@
 
   <table class="table align-middle">
 
-    <thead class="table-light">
+    <thead class="table-primary">
     <tr>
       <th>Name</th>
       <th>Status</th>

--- a/ui/admin-portal/src/app/components/settings/external-links/search-external-links.component.html
+++ b/ui/admin-portal/src/app/components/settings/external-links/search-external-links.component.html
@@ -46,7 +46,7 @@
 
   <table class="table align-middle">
 
-    <thead class="table-light">
+    <thead class="table-primary">
     <tr>
       <th>Saved List</th>
       <th>Published Document Link</th>

--- a/ui/admin-portal/src/app/components/settings/industries/search-industries.component.html
+++ b/ui/admin-portal/src/app/components/settings/industries/search-industries.component.html
@@ -62,7 +62,7 @@
 
   <table class="table">
 
-    <thead class="table-light">
+    <thead class="table-primary">
     <tr>
       <th>Name</th>
       <th>Status</th>

--- a/ui/admin-portal/src/app/components/settings/language-levels/search-language-levels.component.html
+++ b/ui/admin-portal/src/app/components/settings/language-levels/search-language-levels.component.html
@@ -75,7 +75,7 @@
 
   <table class="table align-middle">
 
-    <thead class="table-light">
+    <thead class="table-primary">
     <tr>
       <th>Level</th>
       <th>Name</th>

--- a/ui/admin-portal/src/app/components/settings/languages/search-languages.component.html
+++ b/ui/admin-portal/src/app/components/settings/languages/search-languages.component.html
@@ -39,7 +39,7 @@
 
   <table class="table">
 
-    <thead class="table-light">
+    <thead class="table-primary">
     <tr>
       <th>Name</th>
       <th>Language code</th>

--- a/ui/admin-portal/src/app/components/settings/occupations/search-occupations.component.html
+++ b/ui/admin-portal/src/app/components/settings/occupations/search-occupations.component.html
@@ -69,7 +69,7 @@
 
   <table class="table align-middle">
 
-    <thead class="table-light">
+    <thead class="table-primary">
     <tr>
       <th>Name (TC id-ISCO08 code)</th>
       <th>Status</th>

--- a/ui/admin-portal/src/app/components/settings/partners/search-partners/search-partners.component.html
+++ b/ui/admin-portal/src/app/components/settings/partners/search-partners/search-partners.component.html
@@ -48,7 +48,7 @@
 
     <table class="table align-middle">
 
-      <thead class="table-light">
+      <thead class="table-primary">
       <tr>
         <th *ngIf="!readOnly"></th>
         <th>Partner</th>

--- a/ui/admin-portal/src/app/components/settings/settings.component.scss
+++ b/ui/admin-portal/src/app/components/settings/settings.component.scss
@@ -28,7 +28,3 @@ label {
   font-size: 14px;
 }
 
-ng-multiselect-dropdown .multiselect-dropdown > .dropdown-btn{
-     font-size:12px;
-}
-

--- a/ui/admin-portal/src/app/components/settings/tasks/search-tasks.component.html
+++ b/ui/admin-portal/src/app/components/settings/tasks/search-tasks.component.html
@@ -55,7 +55,7 @@
 
   <table class="table align-middle">
 
-    <thead class="table-light">
+    <thead class="table-primary">
     <tr>
       <th class="col-1 text-center">Id</th>
       <th class="col-2">Task Name</th>

--- a/ui/admin-portal/src/app/components/settings/translations/dropdowns/dropdown-translations.component.html
+++ b/ui/admin-portal/src/app/components/settings/translations/dropdowns/dropdown-translations.component.html
@@ -70,7 +70,7 @@
       <div formArrayName="translations">
         <table class="table">
 
-          <thead class="table-light">
+          <thead class="table-primary">
           <tr>
             <th>Type</th>
             <th>Name</th>

--- a/ui/admin-portal/src/app/components/settings/translations/general/general-translations.component.html
+++ b/ui/admin-portal/src/app/components/settings/translations/general/general-translations.component.html
@@ -52,7 +52,7 @@
     </div>
 
     <table class="table table-bordered">
-      <thead class="table-light">
+      <thead class="table-primary">
       <tr>
         <th>Field</th>
         <th>Translation</th>

--- a/ui/admin-portal/src/app/components/settings/translations/general/general-translations.component.html
+++ b/ui/admin-portal/src/app/components/settings/translations/general/general-translations.component.html
@@ -20,7 +20,7 @@
     <div class="header">
       <h4>General Translations</h4>
       <div>
-        <button *ngIf="isAnAdmin() && !loggedInUser.readOnly" class="btn btn-primary" (click)="save()" [disabled]="saving">Save</button>
+        <button *ngIf="isAnAdmin() && !loggedInUser.readOnly" class="btn btn-success" (click)="save()" [disabled]="saving">Save</button>
       </div>
     </div>
 

--- a/ui/admin-portal/src/app/components/settings/users/search-users.component.html
+++ b/ui/admin-portal/src/app/components/settings/users/search-users.component.html
@@ -62,7 +62,7 @@
 
   <table class="table align-middle">
 
-    <thead class="table-light">
+    <thead class="table-primary">
     <tr>
       <th></th>
       <th>#</th>

--- a/ui/admin-portal/src/app/components/settings/users/search-users.component.scss
+++ b/ui/admin-portal/src/app/components/settings/users/search-users.component.scss
@@ -28,7 +28,3 @@ label {
   font-size: 14px;
 }
 
-ng-multiselect-dropdown .multiselect-dropdown > .dropdown-btn{
-     font-size:12px;
-}
-

--- a/ui/admin-portal/src/app/components/tasks/assign-tasks-candidate/assign-tasks-candidate.component.html
+++ b/ui/admin-portal/src/app/components/tasks/assign-tasks-candidate/assign-tasks-candidate.component.html
@@ -68,7 +68,7 @@
   </div>
 </div>
 <div class="modal-footer">
-  <button type="button" class="btn btn-primary" [disabled]="assignForm.invalid || loading || saving"
+  <button type="button" class="btn btn-success" [disabled]="assignForm.invalid || loading || saving"
           (click)="onSave()"><i class="fas fa-spinner fa-spin" *ngIf="saving"></i>Save
   </button>
   <button type="button" class="btn btn-secondary"

--- a/ui/admin-portal/src/app/components/tasks/assign-tasks-list/assign-tasks-list.component.html
+++ b/ui/admin-portal/src/app/components/tasks/assign-tasks-list/assign-tasks-list.component.html
@@ -88,7 +88,7 @@
   </div>
 </div>
 <div class="modal-footer">
-  <button type="button" class="btn btn-primary" [disabled]="assignForm.invalid || loading"
+  <button type="button" class="btn btn-success" [disabled]="assignForm.invalid || loading"
           (click)="onSave()">Save</button>
   <button type="button" class="btn btn-secondary"
           (click)="close()">Close</button>

--- a/ui/admin-portal/src/app/components/tasks/browse-tasks/browse-tasks.component.scss
+++ b/ui/admin-portal/src/app/components/tasks/browse-tasks/browse-tasks.component.scss
@@ -23,21 +23,21 @@
   cursor: pointer;
   position: relative;
   left: 0;
-  background-color: $color-secondary-lighter;
+  background-color: $accent3;
   margin: .5em;
   margin-left: 0;
   padding: 0.1em .4em;
   border-radius: 4px;
 }
 .searches li:hover {;
-  background-color: $color-primary-dark;
+  background-color: $accent1;
   left: .1em;
 }
 .searches li.selected {
-  background-color: $color-secondary-light;
+  background-color: $accent3;
   color: white;
 }
 .searches li.selected:hover {
-  background-color: $color-primary-darker;
+  background-color: $accent2;
   color: white;
 }

--- a/ui/admin-portal/src/app/components/util/candidate-column-selector/candidate-column-selector.component.scss
+++ b/ui/admin-portal/src/app/components/util/candidate-column-selector/candidate-column-selector.component.scss
@@ -23,10 +23,10 @@
 }
 
 .field {
-  background-color: $color-secondary-lighter;
+  background-color: $accent3;
   list-style: none;
   padding: 8px;
-  color: $color-text-primary;
+  color: $dark;
   margin-bottom: 0.5em;
   border-radius: 3px;
   text-align: center;
@@ -40,7 +40,7 @@
 }
 
 .gu-mirror {
-  background-color: $color-secondary-light;
+  background-color: $accent3;
 }
 
 .dragula-container {

--- a/ui/admin-portal/src/app/components/util/candidate-context-note/candidate-context-note.component.scss
+++ b/ui/admin-portal/src/app/components/util/candidate-context-note/candidate-context-note.component.scss
@@ -23,7 +23,7 @@ label {
 
 #contextNotes {
   font-size: 15px;
-  color: $color-text-secondary;
+  color: $info;
 }
 
 ::-webkit-input-placeholder {

--- a/ui/admin-portal/src/app/components/util/candidate-context-note/candidate-context-note.component.scss
+++ b/ui/admin-portal/src/app/components/util/candidate-context-note/candidate-context-note.component.scss
@@ -23,7 +23,7 @@ label {
 
 #contextNotes {
   font-size: 15px;
-  color: $info;
+  color: $accent1;
 }
 
 ::-webkit-input-placeholder {

--- a/ui/admin-portal/src/app/components/util/candidate-search-card/candidate-search-card.component.html
+++ b/ui/admin-portal/src/app/components/util/candidate-search-card/candidate-search-card.component.html
@@ -13,7 +13,7 @@
   ~ You should have received a copy of the GNU Affero General Public License
   ~ along with this program. If not, see https://www.gnu.org/licenses/.
   -->
-<div class="candidate-card" *ngIf="!!candidate">
+<div class="candidate-card side-panel-color" *ngIf="!!candidate">
   <div class="content">
   <button (click)="close()" type="button" class="btn-close text-reset float-end ms-4" aria-label="Close"></button>
 

--- a/ui/admin-portal/src/app/components/util/candidate-search-card/candidate-search-card.component.html
+++ b/ui/admin-portal/src/app/components/util/candidate-search-card/candidate-search-card.component.html
@@ -85,7 +85,7 @@
           <i class="fas fa-external-link-alt" title="Show candidate in new tab"></i>
         </a>
       </h3>
-      <button (click)="toggleNotes()" id="bt2" class="btn btn-sm btn-secondary-light me-1">
+      <button (click)="toggleNotes()" id="bt2" class="btn btn-sm btn-info me-1">
         General Notes
         <i *ngIf="!showNotes" class="fas fa-eye"></i>
         <i *ngIf="showNotes" class="fas fa-eye-slash"></i>

--- a/ui/admin-portal/src/app/components/util/candidate-search-card/candidate-search-card.component.scss
+++ b/ui/admin-portal/src/app/components/util/candidate-search-card/candidate-search-card.component.scss
@@ -18,6 +18,7 @@
 
 :host {
   font-size: 0.80rem;
+  background-color: $light;
 }
 
 .candidate-card {
@@ -27,7 +28,6 @@
   position: relative;
   display: flex;
   flex-direction: column;
-  background-color: fade-out($accent2, 0.9);
   height: 100%;
 }
 

--- a/ui/admin-portal/src/app/components/util/candidate-search-card/candidate-search-card.component.scss
+++ b/ui/admin-portal/src/app/components/util/candidate-search-card/candidate-search-card.component.scss
@@ -28,6 +28,7 @@
   display: flex;
   flex-direction: column;
   background-color: fade-out($accent2, 0.9);
+  height: 100%;
 }
 
 .candidate-header {

--- a/ui/admin-portal/src/app/components/util/candidate-search-card/candidate-search-card.component.scss
+++ b/ui/admin-portal/src/app/components/util/candidate-search-card/candidate-search-card.component.scss
@@ -14,6 +14,8 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
+@import "~src/scss/variables";
+
 :host {
   font-size: 0.80rem;
 }
@@ -25,6 +27,7 @@
   position: relative;
   display: flex;
   flex-direction: column;
+  background-color: fade-out($accent2, 0.9);
 }
 
 .candidate-header {

--- a/ui/admin-portal/src/app/components/util/candidate-shareable-notes/candidate-shareable-notes.component.scss
+++ b/ui/admin-portal/src/app/components/util/candidate-shareable-notes/candidate-shareable-notes.component.scss
@@ -6,7 +6,7 @@ span {
 
 #shareableNotes {
   font-size: 15px;
-  color: $color-text-secondary;
+  color: $info;
 }
 
 ::-webkit-input-placeholder {

--- a/ui/admin-portal/src/app/components/util/candidate-shareable-notes/candidate-shareable-notes.component.scss
+++ b/ui/admin-portal/src/app/components/util/candidate-shareable-notes/candidate-shareable-notes.component.scss
@@ -6,7 +6,7 @@ span {
 
 #shareableNotes {
   font-size: 15px;
-  color: $info;
+  color: $accent1;
 }
 
 ::-webkit-input-placeholder {

--- a/ui/admin-portal/src/app/components/util/candidate-source/candidate-source.component.scss
+++ b/ui/admin-portal/src/app/components/util/candidate-source/candidate-source.component.scss
@@ -20,7 +20,7 @@
 }
 
 .starred {
-  color: $info;
+  color: $warning;
 }
 
 .notstarred {

--- a/ui/admin-portal/src/app/components/util/candidate-source/candidate-source.component.scss
+++ b/ui/admin-portal/src/app/components/util/candidate-source/candidate-source.component.scss
@@ -13,13 +13,14 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
+@import "~src/scss/variables";
 
 .selected {
   background-color: lightgray;
 }
 
 .starred {
-  color: red;
+  color: $info;
 }
 
 .notstarred {
@@ -27,7 +28,7 @@
 }
 
 .watched {
-  color: red;
+  color: $success;
 }
 
 .notwatched {

--- a/ui/admin-portal/src/app/components/util/cv-icon/cv-icon.component.html
+++ b/ui/admin-portal/src/app/components/util/cv-icon/cv-icon.component.html
@@ -14,8 +14,8 @@
   ~ along with this program. If not, see https://www.gnu.org/licenses/.
   -->
 
-<a *ngIf="canOpen()" target="_blank" (click)="openCVs()">
-  <i class="fas fa-address-card is-link" title="Open candidate's CV(s)"></i>
+<a *ngIf="canOpen()" target="_blank" (click)="openCVs()" class="link-secondary">
+  <i class="fas fa-address-card" title="Open candidate's CV(s)"></i>
 </a>
 <span *ngIf="loading">
     <i class="fas fa-spinner fa-spin"></i>

--- a/ui/admin-portal/src/app/components/util/cv-icon/cv-icon.component.html
+++ b/ui/admin-portal/src/app/components/util/cv-icon/cv-icon.component.html
@@ -14,7 +14,7 @@
   ~ along with this program. If not, see https://www.gnu.org/licenses/.
   -->
 
-<a *ngIf="canOpen()" target="_blank" (click)="openCVs()" class="link-secondary">
+<a *ngIf="canOpen()" target="_blank" (click)="openCVs()" class="link-info">
   <i class="fas fa-address-card" title="Open candidate's CV(s)"></i>
 </a>
 <span *ngIf="loading">

--- a/ui/admin-portal/src/app/components/util/date-picker/date-picker.component.html
+++ b/ui/admin-portal/src/app/components/util/date-picker/date-picker.component.html
@@ -14,7 +14,7 @@
        (click)="picker.toggle()">
     <span>Choose</span>
   </div>
-  <div class="btn btn-secondary"
+  <div class="btn btn-danger"
        (click)="clear()">
     <span>Clear</span>
   </div>

--- a/ui/admin-portal/src/app/components/util/form/date-range-picker/date-range-picker.component.html
+++ b/ui/admin-portal/src/app/components/util/form/date-range-picker/date-range-picker.component.html
@@ -27,7 +27,7 @@
   <button class="btn btn-primary calendar" (click)="picker.toggle()">
     <span class="fas fa-calendar"></span>
   </button>
-    <button class="btn btn-danger calendar" (click)="clearDates()">
+    <button class="btn btn-accent-1 hover-color-red calendar" (click)="clearDates()">
       <span class="fas fa-times"></span>
     </button>
 

--- a/ui/admin-portal/src/app/components/util/form/date-range-picker/date-range-picker.component.html
+++ b/ui/admin-portal/src/app/components/util/form/date-range-picker/date-range-picker.component.html
@@ -24,13 +24,14 @@
          [value]="displayDate"
          [readOnly]="readonly"
          (dateSelect)="selectDate($event)">
-    <button class="btn btn-outline-secondary calendar" (click)="clearDates()">
+  <button class="btn btn-primary calendar" (click)="picker.toggle()">
+    <span class="fas fa-calendar"></span>
+  </button>
+    <button class="btn btn-danger calendar" (click)="clearDates()">
       <span class="fas fa-times"></span>
     </button>
 
-    <button class="btn btn-outline-secondary calendar" (click)="picker.toggle()">
-      <span class="fas fa-calendar"></span>
-    </button>
+
 </div>
 
 <ng-template #t let-date let-focused="focused">

--- a/ui/admin-portal/src/app/components/util/form/date-range-picker/date-range-picker.component.scss
+++ b/ui/admin-portal/src/app/components/util/form/date-range-picker/date-range-picker.component.scss
@@ -13,6 +13,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
+@import "~src/scss/variables";
 
 .custom-day {
   text-align: center;
@@ -30,4 +31,11 @@
 }
 .custom-day.faded {
   background-color: rgba(2, 117, 216, 0.5);
+}
+
+.hover-color-red {
+  &:hover {
+    background-color: $danger;
+    color: $white;
+  }
 }

--- a/ui/admin-portal/src/app/components/util/form/language-proficiency/language-level-form-control.component.scss
+++ b/ui/admin-portal/src/app/components/util/form/language-proficiency/language-level-form-control.component.scss
@@ -31,7 +31,7 @@
   padding: 1em;
   border-bottom-left-radius: 5px;
   border-bottom-right-radius: 5px;
-  border: 1px solid $color-secondary-lighter;
+  border: 1px solid $info;
   border-top: none;
   min-width: 100%;
 }

--- a/ui/admin-portal/src/app/components/util/intake/fixed-input/fixed-input.component.scss
+++ b/ui/admin-portal/src/app/components/util/intake/fixed-input/fixed-input.component.scss
@@ -17,8 +17,9 @@
 @import "~src/scss/variables";
 
 .answer {
-  color: $info;
+  color: $accent2;
   font-weight: 300;
+  margin-left: 5px;
 }
 
 .question {

--- a/ui/admin-portal/src/app/components/util/intake/fixed-input/fixed-input.component.scss
+++ b/ui/admin-portal/src/app/components/util/intake/fixed-input/fixed-input.component.scss
@@ -17,7 +17,7 @@
 @import "~src/scss/variables";
 
 .answer {
-  color: $color-text-primary;
+  color: $info;
   font-weight: 300;
 }
 

--- a/ui/admin-portal/src/app/components/util/opportunity-stage-next-step/opportunity-stage-next-step.component.html
+++ b/ui/admin-portal/src/app/components/util/opportunity-stage-next-step/opportunity-stage-next-step.component.html
@@ -5,7 +5,7 @@
       Progress
       <div class="float-end" *ngIf="editable">
         <i class="fas fa-spinner fa-spin" *ngIf=updating></i>
-        <button class="btn btn-sm btn-outline-secondary" title="Update progress" (click)="editOppProgress()">
+        <button class="btn btn-sm btn-secondary" title="Update progress" (click)="editOppProgress()">
           <i class="fas fa-edit"></i>
         </button>
       </div>

--- a/ui/admin-portal/src/app/components/util/published-doc-column-selector/published-doc-column-selector.component.scss
+++ b/ui/admin-portal/src/app/components/util/published-doc-column-selector/published-doc-column-selector.component.scss
@@ -1,10 +1,10 @@
 @import "src/scss/_variables.scss";
 
 .field {
-  background-color: $color-secondary-lighter;
+  background-color: $info;
   list-style: none;
   padding: 8px;
-  color: $color-text-primary;
+  color: $dark;
   margin-bottom: 0.5em;
   border-radius: 3px;
   text-align: center;
@@ -15,7 +15,7 @@
 }
 
 .gu-mirror {
-  background-color: $color-secondary-light;
+  background-color: $info;
 }
 
 .edit-btn {

--- a/ui/admin-portal/src/app/components/util/tasks-monitor-list/tasks-monitor-list.component.html
+++ b/ui/admin-portal/src/app/components/util/tasks-monitor-list/tasks-monitor-list.component.html
@@ -1,6 +1,6 @@
 <div class="row">
   <span class="col text-success fw-bold" [ngbTooltip]="this.completed?.length + ' completed'">{{this.completed?.length}}</span>
-  <span class="col text-alert fw-bold" [ngbTooltip]="this.abandoned?.length + ' abandoned'">{{this.abandoned?.length}}</span>
+  <span class="col text-warning fw-bold" [ngbTooltip]="this.abandoned?.length + ' abandoned'">{{this.abandoned?.length}}</span>
   <span class="col fw-bold" [ngbTooltip]="this.outstandingNotOverdue?.length + ' outstanding not overdue'">{{this.outstandingNotOverdue?.length}}</span>
   <span class="col text-danger fw-bold" [ngbTooltip]="this.outstandingOverdue?.length + ' outstanding overdue'">{{this.outstandingOverdue?.length}}</span>
 </div>

--- a/ui/admin-portal/src/app/components/util/tasks-monitor/tasks-monitor.component.html
+++ b/ui/admin-portal/src/app/components/util/tasks-monitor/tasks-monitor.component.html
@@ -1,5 +1,5 @@
 <div class="d-inline-block ms-2" *ngIf="!hasCompleted">
-  <sup class="fw-bold" [ngClass]="{'text-danger' : hasOverdue,'text-alert' : hasAbandoned}">
+  <sup class="fw-bold" [ngClass]="{'text-danger' : hasOverdue,'text-warning' : hasAbandoned}">
     {{this.completedTasks.length}}
   </sup>
   &frasl;

--- a/ui/admin-portal/src/scss/_btn.scss
+++ b/ui/admin-portal/src/scss/_btn.scss
@@ -19,16 +19,19 @@
 @import "~bootstrap/scss/mixins";
 @import "~bootstrap/scss/buttons";
 
-.btn-primary, .btn-secondary, .btn-danger, .btn-success, .btn-info {
+.btn-primary, .btn-secondary, .btn-danger, .btn-success, .btn-info, .btn-warning {
   color: $white;
+  &:hover {
+    color: $light;
+  }
 }
 
 .btn-link {
-  color: $primary;
+  color: $accent1;
   background-color: transparent;
 
   &:hover {
-    color: $secondary;
+    color: $primary;
     text-decoration: none;
     background-color: transparent;
     border-color: transparent;
@@ -64,6 +67,17 @@ a {
   &.disabled {
     color: $light;
     background-color: $accent2;
+  }
+}
+
+button {
+  a {
+    i {
+      color: $primary;
+      &:hover {
+        color: $secondary;
+      }
+    }
   }
 }
 

--- a/ui/admin-portal/src/scss/_btn.scss
+++ b/ui/admin-portal/src/scss/_btn.scss
@@ -53,7 +53,7 @@ a {
   text-decoration: none;
 
   &:hover {
-    color: $accent1;
+    color: $secondary;
     text-decoration: none;
     background-color: transparent;
     border-color: transparent;

--- a/ui/admin-portal/src/scss/_btn.scss
+++ b/ui/admin-portal/src/scss/_btn.scss
@@ -19,87 +19,87 @@
 @import "~bootstrap/scss/mixins";
 @import "~bootstrap/scss/buttons";
 
-.btn-primary {
-  @include button-variant(
-      // Regular button (background, border, color)
-      $color-primary, $color-primary, white,
-      // Hover
-      $color-primary-dark, $color-primary-dark, white,
-      // Active
-      $color-primary, $color-primary, white,
-      // Disabled
-      $color-secondary-lighter, $color-secondary-lighter, white);
-}
-
-.btn-outline-primary {
-  @include button-outline-variant($color-primary, white, $color-primary-dark, $color-primary-darker);
-
-  &:hover {
-    border-color: $color-primary;
-  }
-
-  &:not(:disabled):not(.disabled){
-    &:hover {
-      border-color: $color-primary-dark;
-      background: $color-primary-dark;
-    }
-
-    &:active {
-      background-color: $color-primary-darker;
-      border-color: $color-primary-darker;
-    }
-  }
-}
-
-.btn-link {
-  color: $color-primary;
-  background-color: transparent;
-
-  &:hover {
-    color: $color-primary-dark;
-    text-decoration: none;
-    background-color: transparent;
-    border-color: transparent;
-  }
-
-  &:active {
-    color: $color-primary-darker;
-  }
-
-  &:disabled,
-  &.disabled {
-    color: $color-text-light;
-  }
-}
-
-a {
-  color: $color-primary;
-  background-color: transparent;
-  text-decoration: none;
-
-  &:hover {
-    color: $color-primary-dark;
-    text-decoration: none;
-    background-color: transparent;
-    border-color: transparent;
-  }
-
-  &:active {
-    color: $color-primary-darker;
-  }
-
-  &:disabled,
-  &.disabled {
-    color: $color-text-light;
-    background-color: $color-secondary-light;
-  }
-}
-
-.link {
-  color: $color-primary;
-}
-
-button:focus {
-  box-shadow: none !important;
-  text-decoration: none !important;
-}
+//.btn-primary {
+//  @include button-variant(
+//      // Regular button (background, border, color)
+//      $color-primary, $color-primary, white,
+//      // Hover
+//      $color-primary-dark, $color-primary-dark, white,
+//      // Active
+//      $color-primary, $color-primary, white,
+//      // Disabled
+//      $color-secondary-lighter, $color-secondary-lighter, white);
+//}
+//
+//.btn-outline-primary {
+//  @include button-outline-variant($color-primary, white, $color-primary-dark, $color-primary-darker);
+//
+//  &:hover {
+//    border-color: $color-primary;
+//  }
+//
+//  &:not(:disabled):not(.disabled){
+//    &:hover {
+//      border-color: $color-primary-dark;
+//      background: $color-primary-dark;
+//    }
+//
+//    &:active {
+//      background-color: $color-primary-darker;
+//      border-color: $color-primary-darker;
+//    }
+//  }
+//}
+//
+//.btn-link {
+//  color: $color-primary;
+//  background-color: transparent;
+//
+//  &:hover {
+//    color: $color-primary-dark;
+//    text-decoration: none;
+//    background-color: transparent;
+//    border-color: transparent;
+//  }
+//
+//  &:active {
+//    color: $color-primary-darker;
+//  }
+//
+//  &:disabled,
+//  &.disabled {
+//    color: $color-text-light;
+//  }
+//}
+//
+//a {
+//  color: $color-primary;
+//  background-color: transparent;
+//  text-decoration: none;
+//
+//  &:hover {
+//    color: $color-primary-dark;
+//    text-decoration: none;
+//    background-color: transparent;
+//    border-color: transparent;
+//  }
+//
+//  &:active {
+//    color: $color-primary-darker;
+//  }
+//
+//  &:disabled,
+//  &.disabled {
+//    color: $color-text-light;
+//    background-color: $color-secondary-light;
+//  }
+//}
+//
+//.link {
+//  color: $color-primary;
+//}
+//
+//button:focus {
+//  box-shadow: none !important;
+//  text-decoration: none !important;
+//}

--- a/ui/admin-portal/src/scss/_btn.scss
+++ b/ui/admin-portal/src/scss/_btn.scss
@@ -19,53 +19,33 @@
 @import "~bootstrap/scss/mixins";
 @import "~bootstrap/scss/buttons";
 
-.btn-primary, .btn-secondary, .btn-danger, .btn-success {
-  color: $light;
+.btn-primary, .btn-secondary, .btn-danger, .btn-success, .btn-info {
+  color: $white;
 }
-//
-//.btn-outline-primary {
-//  @include button-outline-variant($color-primary, white, $color-primary-dark, $color-primary-darker);
-//
-//  &:hover {
-//    border-color: $color-primary;
-//  }
-//
-//  &:not(:disabled):not(.disabled){
-//    &:hover {
-//      border-color: $color-primary-dark;
-//      background: $color-primary-dark;
-//    }
-//
-//    &:active {
-//      background-color: $color-primary-darker;
-//      border-color: $color-primary-darker;
-//    }
-//  }
-//}
-//
-//.btn-link {
-//  color: $color-primary;
-//  background-color: transparent;
-//
-//  &:hover {
-//    color: $color-primary-dark;
-//    text-decoration: none;
-//    background-color: transparent;
-//    border-color: transparent;
-//  }
-//
-//  &:active {
-//    color: $color-primary-darker;
-//  }
-//
-//  &:disabled,
-//  &.disabled {
-//    color: $color-text-light;
-//  }
-//}
-//
+
+.btn-link {
+  color: $primary;
+  background-color: transparent;
+
+  &:hover {
+    color: $secondary;
+    text-decoration: none;
+    background-color: transparent;
+    border-color: transparent;
+  }
+
+  &:active {
+    color: $primary;
+  }
+
+  &:disabled,
+  &.disabled {
+    color: $accent3;
+  }
+}
+
 a {
-  color: $info;
+  color: $primary;
   background-color: transparent;
   text-decoration: none;
 
@@ -86,12 +66,12 @@ a {
     background-color: $accent2;
   }
 }
-//
-//.link {
-//  color: $color-primary;
-//}
-//
-//button:focus {
-//  box-shadow: none !important;
-//  text-decoration: none !important;
-//}
+
+.link {
+  color: $info;
+}
+
+button:focus {
+  box-shadow: none !important;
+  text-decoration: none !important;
+}

--- a/ui/admin-portal/src/scss/_btn.scss
+++ b/ui/admin-portal/src/scss/_btn.scss
@@ -14,22 +14,14 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-@import "variables";
+@import "~src/scss/variables";
 @import "~bootstrap/scss/functions";
 @import "~bootstrap/scss/mixins";
 @import "~bootstrap/scss/buttons";
 
-//.btn-primary {
-//  @include button-variant(
-//      // Regular button (background, border, color)
-//      $color-primary, $color-primary, white,
-//      // Hover
-//      $color-primary-dark, $color-primary-dark, white,
-//      // Active
-//      $color-primary, $color-primary, white,
-//      // Disabled
-//      $color-secondary-lighter, $color-secondary-lighter, white);
-//}
+.btn-primary, .btn-secondary, .btn-danger, .btn-success {
+  color: $light;
+}
 //
 //.btn-outline-primary {
 //  @include button-outline-variant($color-primary, white, $color-primary-dark, $color-primary-darker);
@@ -72,28 +64,28 @@
 //  }
 //}
 //
-//a {
-//  color: $color-primary;
-//  background-color: transparent;
-//  text-decoration: none;
-//
-//  &:hover {
-//    color: $color-primary-dark;
-//    text-decoration: none;
-//    background-color: transparent;
-//    border-color: transparent;
-//  }
-//
-//  &:active {
-//    color: $color-primary-darker;
-//  }
-//
-//  &:disabled,
-//  &.disabled {
-//    color: $color-text-light;
-//    background-color: $color-secondary-light;
-//  }
-//}
+a {
+  color: $info;
+  background-color: transparent;
+  text-decoration: none;
+
+  &:hover {
+    color: $accent1;
+    text-decoration: none;
+    background-color: transparent;
+    border-color: transparent;
+  }
+
+  &:active {
+    color: $secondary;
+  }
+
+  &:disabled,
+  &.disabled {
+    color: $light;
+    background-color: $accent2;
+  }
+}
 //
 //.link {
 //  color: $color-primary;

--- a/ui/admin-portal/src/scss/_variables.scss
+++ b/ui/admin-portal/src/scss/_variables.scss
@@ -19,7 +19,7 @@ $light:      #e4e1d5;
 $dark:       #151f2d;
 $primary: #314874;
 $secondary: #0e7688;
-$info: #1a4669;
+$info: #9b6a0d;
 $accent1:    #383b48;
 $accent2:    #64656d;
 $accent3:    #b2b7bb;

--- a/ui/admin-portal/src/scss/_variables.scss
+++ b/ui/admin-portal/src/scss/_variables.scss
@@ -112,9 +112,13 @@ $danger: #a91206;
 //$color-border: #d7d8d8;
 //$color-background: #f2f2f2;
 //
-//$accordion-button-bg: $color-background;
-//$accordion-button-active-bg: #cee2ea;
-//$accordion-button-active-color: $color-secondary;
-//$accordion-border-color: $color-border;
+$accordion-button-bg: fade-out($accent2, 0.4);
+
+$accordion-border-color: $light;
+
+$accordion-button-active-bg: $accent1;
+$accordion-button-active-color: $light;
+
+
 
 $offcanvas-horizontal-width: 40vw;

--- a/ui/admin-portal/src/scss/_variables.scss
+++ b/ui/admin-portal/src/scss/_variables.scss
@@ -46,7 +46,7 @@ $light:      #e4e1d5;
 $dark:       #151f2d;
 $primary:    #437ad8;
 $secondary:  #43a7f5;
-$info:       #6cadfa;
+$info:       #0f7989;
 $accent1:    #383b48;
 $accent2:    #64656d;
 $accent3:    #b2b7bb;
@@ -54,6 +54,33 @@ $success:    #14b166;
 $warning:    #e6ce13;
 $danger:     #f81907;
 
+//$light:      #e1e2e4;
+//$dark:       #04050a;
+//$primary:    #004c4e;
+//$secondary:  #09798a;
+//$info:       #07abca;
+//$accent1:    #8f0c36;
+//$accent2:    #576b90;
+//$accent3:    #aba9b0;
+//$success:    #00a548;
+//$warning:    #ecc700;
+//$danger:     #f4002f;
+
+//$light:      #e7e5e2;
+//$dark:       #000100;
+//$primary:    #242832;
+//$secondary:  #c32e32;
+//$info:       #f56868;
+//$accent1:    #333f46;
+//$accent2:    #146fb1;
+//$accent3:    #008bcb;
+//$success:    #009a56;
+//$warning:    #e0c800;
+//$danger:     #ee1100;
+
+
+// BIT LESS "BUSINESS" AND MORE CONTRAST WITH THE BROWNS. IS IT TOO 'BRANDED' THOUGH AND NOT GENERAL ENOUGH?
+//https://huemint.com/bootstrap-plus/#palette=dbdbdc-ffffff-101320-37414d-61769a-5799cf-ce9133-af8a60-bdac9a
 //$light:      #dbdbdc;
 //$dark:       #101320;
 //$primary:    #37414d;

--- a/ui/admin-portal/src/scss/_variables.scss
+++ b/ui/admin-portal/src/scss/_variables.scss
@@ -50,9 +50,9 @@ $info:      #9b6a0d;
 $accent1:    #383b48;
 $accent2:    #64656d;
 $accent3:    #b2b7bb;
-$success:    #009c58;
-$warning:    #e1c900;
-$danger:     #ef1200;
+$success: #03864d;
+$warning: #d7c208;
+$danger: #a91206;
 
 //$light:      #e1e2e4;
 //$dark:       #04050a;

--- a/ui/admin-portal/src/scss/_variables.scss
+++ b/ui/admin-portal/src/scss/_variables.scss
@@ -14,27 +14,80 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-$color-primary-lightest: #e9f7fc;
-$color-primary-lighter: #a7e2f4;
-$color-primary-light: #0cd5e4;
-$color-primary: #13b1dd;
-$color-primary-dark: #0b81a6;
-$color-primary-darker: #075168;
+$white: #ffffff;
 
-$color-secondary: #272b2b;
-$color-secondary-light: #888888;
-$color-secondary-lighter: #dedede;
+//$light:      #dae2e4;
+//$dark:       #111317;
+//$primary:    #213f5a;
+//$secondary:  #4a679f;
+//$info:       #678ecf;
+//$accent1:    #dac700;
+//$accent2:    #c2a10e;
+//$accent3:    #a3bad9;
+//$success:    #00b764;
+//$warning:    #eacf00;
+//$danger:     #fe0000;
 
-$color-text-primary: #272b2b;
-$color-text-secondary: #5a6268;
-$color-text-light: #dedede;
+//$light:      #eee1cc;
+//$dark:       #16142b;
+//$primary:    #1545cc;
+//$secondary:  #3378fc;
+//$info:       #00b58b;
+//$accent1:    #424441;
+//$accent2:    #8a8c72;
+//$accent3:    #a2a4a7;
+//$success:    #00ab63;
+//$warning:    #e4cd00;
+//$danger:     #f41b00;
 
-$color-border: #d7d8d8;
-$color-background: #f2f2f2;
 
-$accordion-button-bg: $color-background;
-$accordion-button-active-bg: #cee2ea;
-$accordion-button-active-color: $color-secondary;
-$accordion-border-color: $color-border;
+// FAVOURITE SO FAR, PROFESSIONAL AND CLEAN. NOT ALOT OF VARIATION THOUGH (BLUES/GREYS)
+$light:      #e4e1d5;
+$dark:       #151f2d;
+$primary:    #437ad8;
+$secondary:  #43a7f5;
+$info:       #6cadfa;
+$accent1:    #383b48;
+$accent2:    #64656d;
+$accent3:    #b2b7bb;
+$success:    #14b166;
+$warning:    #e6ce13;
+$danger:     #f81907;
+
+//$light:      #dbdbdc;
+//$dark:       #101320;
+//$primary:    #37414d;
+//$secondary:  #61769a;
+//$info:       #5799cf;
+//$accent1:    #ce9133;
+//$accent2:    #af8a60;
+//$accent3:    #bdac9a;
+//$success:    #1eb265;
+//$warning:    #e8ce1c;
+//$danger:     #fa0d0f;
+
+
+//$color-primary-lightest: #e9f7fc;
+//$color-primary-lighter: #a7e2f4;
+//$color-primary-light: #0cd5e4;
+//$color-primary: #13b1dd;
+//$color-primary-dark: #0b81a6;
+//$color-primary-darker: #075168;
+//
+//$color-secondary: #272b2b;
+//$color-secondary-light: #888888;
+//$color-secondary-lighter: #dedede;
+//
+//$color-text-primary: #272b2b;
+//$color-text-secondary: #5a6268;
+//$color-text-light: #dedede;
+//
+//$color-border: #d7d8d8;
+//$color-background: #f2f2f2;
+//
+//$accordion-button-bg: $color-background;
+//$accordion-button-active-bg: #cee2ea;
+//$accordion-button-active-color: $color-secondary;
+//$accordion-border-color: $color-border;
 
 $offcanvas-horizontal-width: 40vw;

--- a/ui/admin-portal/src/scss/_variables.scss
+++ b/ui/admin-portal/src/scss/_variables.scss
@@ -44,15 +44,15 @@ $white: #ffffff;
 // FAVOURITE SO FAR, PROFESSIONAL AND CLEAN. NOT ALOT OF VARIATION THOUGH (BLUES/GREYS)
 $light:      #e4e1d5;
 $dark:       #151f2d;
-$primary:    #437ad8;
-$secondary:  #43a7f5;
-$info:       #0f7989;
+$primary: #314874;
+$secondary: #0e7688;
+$info: #ab7818;
 $accent1:    #383b48;
 $accent2:    #64656d;
 $accent3:    #b2b7bb;
-$success:    #14b166;
-$warning:    #e6ce13;
-$danger:     #f81907;
+$success:    #009c58;
+$warning:    #e1c900;
+$danger:     #ef1200;
 
 //$light:      #e1e2e4;
 //$dark:       #04050a;

--- a/ui/admin-portal/src/scss/_variables.scss
+++ b/ui/admin-portal/src/scss/_variables.scss
@@ -46,7 +46,7 @@ $light:      #e4e1d5;
 $dark:       #151f2d;
 $primary: #314874;
 $secondary: #0e7688;
-$info: #ab7818;
+$info:      #9b6a0d;
 $accent1:    #383b48;
 $accent2:    #64656d;
 $accent3:    #b2b7bb;

--- a/ui/admin-portal/src/scss/_variables.scss
+++ b/ui/admin-portal/src/scss/_variables.scss
@@ -51,7 +51,7 @@ $accent1:    #383b48;
 $accent2:    #64656d;
 $accent3:    #b2b7bb;
 $success: #03864d;
-$warning: #d7c208;
+$warning: #c7b408;
 $danger: #a91206;
 
 //$light:      #e1e2e4;

--- a/ui/admin-portal/src/scss/_variables.scss
+++ b/ui/admin-portal/src/scss/_variables.scss
@@ -15,38 +15,11 @@
  */
 
 $white: #ffffff;
-
-//$light:      #dae2e4;
-//$dark:       #111317;
-//$primary:    #213f5a;
-//$secondary:  #4a679f;
-//$info:       #678ecf;
-//$accent1:    #dac700;
-//$accent2:    #c2a10e;
-//$accent3:    #a3bad9;
-//$success:    #00b764;
-//$warning:    #eacf00;
-//$danger:     #fe0000;
-
-//$light:      #eee1cc;
-//$dark:       #16142b;
-//$primary:    #1545cc;
-//$secondary:  #3378fc;
-//$info:       #00b58b;
-//$accent1:    #424441;
-//$accent2:    #8a8c72;
-//$accent3:    #a2a4a7;
-//$success:    #00ab63;
-//$warning:    #e4cd00;
-//$danger:     #f41b00;
-
-
-// FAVOURITE SO FAR, PROFESSIONAL AND CLEAN. NOT ALOT OF VARIATION THOUGH (BLUES/GREYS)
 $light:      #e4e1d5;
 $dark:       #151f2d;
 $primary: #314874;
 $secondary: #0e7688;
-$info:      #9b6a0d;
+$info: #1a4669;
 $accent1:    #383b48;
 $accent2:    #64656d;
 $accent3:    #b2b7bb;
@@ -54,71 +27,9 @@ $success: #03864d;
 $warning: #c7b408;
 $danger: #a91206;
 
-//$light:      #e1e2e4;
-//$dark:       #04050a;
-//$primary:    #004c4e;
-//$secondary:  #09798a;
-//$info:       #07abca;
-//$accent1:    #8f0c36;
-//$accent2:    #576b90;
-//$accent3:    #aba9b0;
-//$success:    #00a548;
-//$warning:    #ecc700;
-//$danger:     #f4002f;
-
-//$light:      #e7e5e2;
-//$dark:       #000100;
-//$primary:    #242832;
-//$secondary:  #c32e32;
-//$info:       #f56868;
-//$accent1:    #333f46;
-//$accent2:    #146fb1;
-//$accent3:    #008bcb;
-//$success:    #009a56;
-//$warning:    #e0c800;
-//$danger:     #ee1100;
-
-
-// BIT LESS "BUSINESS" AND MORE CONTRAST WITH THE BROWNS. IS IT TOO 'BRANDED' THOUGH AND NOT GENERAL ENOUGH?
-//https://huemint.com/bootstrap-plus/#palette=dbdbdc-ffffff-101320-37414d-61769a-5799cf-ce9133-af8a60-bdac9a
-//$light:      #dbdbdc;
-//$dark:       #101320;
-//$primary:    #37414d;
-//$secondary:  #61769a;
-//$info:       #5799cf;
-//$accent1:    #ce9133;
-//$accent2:    #af8a60;
-//$accent3:    #bdac9a;
-//$success:    #1eb265;
-//$warning:    #e8ce1c;
-//$danger:     #fa0d0f;
-
-
-//$color-primary-lightest: #e9f7fc;
-//$color-primary-lighter: #a7e2f4;
-//$color-primary-light: #0cd5e4;
-//$color-primary: #13b1dd;
-//$color-primary-dark: #0b81a6;
-//$color-primary-darker: #075168;
-//
-//$color-secondary: #272b2b;
-//$color-secondary-light: #888888;
-//$color-secondary-lighter: #dedede;
-//
-//$color-text-primary: #272b2b;
-//$color-text-secondary: #5a6268;
-//$color-text-light: #dedede;
-//
-//$color-border: #d7d8d8;
-//$color-background: #f2f2f2;
-//
 $accordion-button-bg: fade-out($accent2, 0.4);
-
 $accordion-border-color: $light;
-
 $accordion-button-active-bg: $accent1;
 $accordion-button-active-color: $light;
-
-
 
 $offcanvas-horizontal-width: 40vw;

--- a/ui/admin-portal/src/scss/common.scss
+++ b/ui/admin-portal/src/scss/common.scss
@@ -107,7 +107,7 @@ table {
 .card-header {
   background-color: $accent2 !important;
   background-image: var(--bs-gradient);
-  font-size: 1.1rem;
+  font-size: 1.1em;
   font-weight: 400;
   color: $light !important;
   margin-bottom: 0;

--- a/ui/admin-portal/src/scss/common.scss
+++ b/ui/admin-portal/src/scss/common.scss
@@ -45,14 +45,14 @@
 .page-link {
   position: relative;
   display: block;
-  //color: $color-primary;
-  //background-color: $pagination-bg;
+  color: $accent3;
+  background-color: $dark;
 
   &:hover {
     z-index: 2;
     text-decoration: none;
-    //background-color: $color-primary;
-    //color: $color-background;
+    background-color: $accent1;
+    color: $light;
   }
 
   &:focus {
@@ -65,17 +65,16 @@
 .page-item {
 
   &.active .page-link {
-    //background-color: $color-primary;
-    //border-color: $color-primary;
+    background-color: $primary;
+    border-color: $primary;
   }
 
   &.disabled .page-link {
-    //color: $pagination-disabled-color;
+    color: $accent2;
+    background-color: $accent3;
     pointer-events: none;
     // Opinionated: remove the "hand" cursor set previously for .page-link
     cursor: auto;
-    //background-color: $pagination-disabled-bg;
-    //border-color: $pagination-disabled-border-color;
   }
 }
 
@@ -93,7 +92,7 @@ table {
 }
 
 .card-header {
-  background-color: $accent1 !important;
+  background-color: $accent2 !important;
   color: $light !important;
 }
 

--- a/ui/admin-portal/src/scss/common.scss
+++ b/ui/admin-portal/src/scss/common.scss
@@ -33,20 +33,20 @@
 
 .link,
 .link:not([href]):not([tabindex]){
-  //color: $color-primary-darker;
+  color: $primary;
   cursor: pointer;
-  //text-decoration: $link-decoration;
+  text-decoration: $link-decoration;
   &:hover {
-    //color: $color-primary-dark;
-    //text-decoration: $link-hover-decoration;
+    color: $secondary;
+    text-decoration: $link-hover-decoration;
   }
 }
 
 .page-link {
   position: relative;
   display: block;
-  color: $accent3;
-  background-color: $dark;
+  color: $light;
+  background-color: $accent2;
 
   &:hover {
     z-index: 2;
@@ -84,6 +84,9 @@ table {
   border-radius: 5px;
   td {
     white-space: nowrap;
+    a > i {
+      color: $secondary;
+    }
   }
 }
 

--- a/ui/admin-portal/src/scss/common.scss
+++ b/ui/admin-portal/src/scss/common.scss
@@ -150,6 +150,13 @@ table {
   overflow: initial;
 }
 
+.accordion-button {
+  font-size: 1.1rem;
+  color: $dark;
+  font-weight: 400;
+  background-image: var(--bs-gradient);
+}
+
 ::placeholder { /* Chrome, Firefox, Opera, Safari 10.1+ */
   color: #999 !important;
   opacity: 1; /* Firefox */

--- a/ui/admin-portal/src/scss/common.scss
+++ b/ui/admin-portal/src/scss/common.scss
@@ -15,9 +15,9 @@
  */
 
 @import "~src/scss/variables";
-@import '~bootstrap/scss/bootstrap-reboot';
-@import '~bootstrap/scss/bootstrap';
-@import '~bootstrap/scss/pagination';
+@import 'bootstrap/scss/bootstrap-reboot';
+@import 'bootstrap/scss/bootstrap';
+@import 'bootstrap/scss/pagination';
 
 .section {
   padding: 10px 0;

--- a/ui/admin-portal/src/scss/common.scss
+++ b/ui/admin-portal/src/scss/common.scss
@@ -100,10 +100,6 @@ table {
   }
 }
 
-.scroll-select .multiselect-dropdown .dropdown-btn {
-  overflow-y: scroll !important;
-}
-
 .card-header {
   background-color: $accent2 !important;
   background-image: var(--bs-gradient);
@@ -111,20 +107,6 @@ table {
   font-weight: 400;
   color: $light !important;
   margin-bottom: 0;
-}
-
-.custom-primary .multiselect-dropdown .dropdown-btn .selected-item {
-  //background-color: $color-primary-dark !important;
-  //border: 1px solid $color-primary-dark !important;
-}
-
-.custom-primary .multiselect-item-checkbox input[type=checkbox]:checked + div:before {
-  //background-color: $color-primary-dark !important;
-  //border: 2px solid $color-primary-dark !important;
-}
-
-.custom-primary .multiselect-item-checkbox input[type=checkbox] + div:before {
-  //border: 2px solid $color-primary-dark !important;
 }
 
 .col-form-label i {
@@ -171,11 +153,3 @@ table {
 .side-panel-color {
   background-color: fade-out($accent3, 0.7);
 }
-
-//.text-alert {
-//  color: #ff8900;
-//}
-//
-//.text-tbb-primary {
-//  color: #13B1DD;
-//}

--- a/ui/admin-portal/src/scss/common.scss
+++ b/ui/admin-portal/src/scss/common.scss
@@ -45,13 +45,14 @@
 .page-link {
   position: relative;
   display: block;
-  color: $light;
-  background-color: $accent2;
+  color: $accent1;
+  background-color: $accent3;
+  border-color: $light;
 
   &:hover {
     z-index: 2;
     text-decoration: none;
-    background-color: $accent1;
+    background-color: $accent2;
     color: $light;
   }
 
@@ -65,14 +66,15 @@
 .page-item {
 
   &.active .page-link {
-    background-color: $primary;
-    border-color: $primary;
+    background-color: $accent2;
+    border-color: $accent2;
   }
 
   &.disabled .page-link {
-    color: $accent2;
+    color: $light;
     background-color: $accent3;
     pointer-events: none;
+    border-color: $light;
     // Opinionated: remove the "hand" cursor set previously for .page-link
     cursor: auto;
   }
@@ -92,7 +94,7 @@ table {
         }
       }
       &:hover {
-        color: $accent1;
+        color: $secondary;
       }
     }
   }

--- a/ui/admin-portal/src/scss/common.scss
+++ b/ui/admin-portal/src/scss/common.scss
@@ -84,8 +84,16 @@ table {
   border-radius: 5px;
   td {
     white-space: nowrap;
-    a > i {
-      color: $secondary;
+    a {
+      > i {
+        color: $info;
+        &:hover {
+          color: $accent1;
+        }
+      }
+      &:hover {
+        color: $accent1;
+      }
     }
   }
 }
@@ -97,6 +105,8 @@ table {
 .card-header {
   background-color: $accent2 !important;
   color: $light !important;
+  font-weight: 300;
+  margin-bottom: 0;
 }
 
 .custom-primary .multiselect-dropdown .dropdown-btn .selected-item {

--- a/ui/admin-portal/src/scss/common.scss
+++ b/ui/admin-portal/src/scss/common.scss
@@ -162,6 +162,16 @@ table {
   opacity: 1; /* Firefox */
 }
 
+//// The right hand side panels showing more detail of selected item
+.detail-panel {
+  border-radius: 5px;
+  padding: 1rem;
+}
+
+.side-panel-color {
+  background-color: fade-out($accent3, 0.7);
+}
+
 //.text-alert {
 //  color: #ff8900;
 //}

--- a/ui/admin-portal/src/scss/common.scss
+++ b/ui/admin-portal/src/scss/common.scss
@@ -33,26 +33,26 @@
 
 .link,
 .link:not([href]):not([tabindex]){
-  color: $color-primary-darker;
+  //color: $color-primary-darker;
   cursor: pointer;
-  text-decoration: $link-decoration;
+  //text-decoration: $link-decoration;
   &:hover {
-    color: $color-primary-dark;
-    text-decoration: $link-hover-decoration;
+    //color: $color-primary-dark;
+    //text-decoration: $link-hover-decoration;
   }
 }
 
 .page-link {
   position: relative;
   display: block;
-  color: $color-primary;
-  background-color: $pagination-bg;
+  //color: $color-primary;
+  //background-color: $pagination-bg;
 
   &:hover {
     z-index: 2;
     text-decoration: none;
-    background-color: $color-primary;
-    color: $color-background;
+    //background-color: $color-primary;
+    //color: $color-background;
   }
 
   &:focus {
@@ -65,21 +65,24 @@
 .page-item {
 
   &.active .page-link {
-    background-color: $color-primary;
-    border-color: $color-primary;
+    //background-color: $color-primary;
+    //border-color: $color-primary;
   }
 
   &.disabled .page-link {
-    color: $pagination-disabled-color;
+    //color: $pagination-disabled-color;
     pointer-events: none;
     // Opinionated: remove the "hand" cursor set previously for .page-link
     cursor: auto;
-    background-color: $pagination-disabled-bg;
-    border-color: $pagination-disabled-border-color;
+    //background-color: $pagination-disabled-bg;
+    //border-color: $pagination-disabled-border-color;
   }
 }
 
 table {
+  background-color: $white;
+  border: $white;
+  border-radius: 5px;
   td {
     white-space: nowrap;
   }
@@ -90,21 +93,22 @@ table {
 }
 
 .card-header {
-  background-color: $color-secondary-lighter !important;
+  background-color: $accent1 !important;
+  color: $light !important;
 }
 
 .custom-primary .multiselect-dropdown .dropdown-btn .selected-item {
-  background-color: $color-primary-dark !important;
-  border: 1px solid $color-primary-dark !important;
+  //background-color: $color-primary-dark !important;
+  //border: 1px solid $color-primary-dark !important;
 }
 
 .custom-primary .multiselect-item-checkbox input[type=checkbox]:checked + div:before {
-  background-color: $color-primary-dark !important;
-  border: 2px solid $color-primary-dark !important;
+  //background-color: $color-primary-dark !important;
+  //border: 2px solid $color-primary-dark !important;
 }
 
 .custom-primary .multiselect-item-checkbox input[type=checkbox] + div:before {
-  border: 2px solid $color-primary-dark !important;
+  //border: 2px solid $color-primary-dark !important;
 }
 
 .col-form-label i {
@@ -135,10 +139,10 @@ table {
   opacity: 1; /* Firefox */
 }
 
-.text-alert {
-  color: #ff8900;
-}
-
-.text-tbb-primary {
-  color: #13B1DD;
-}
+//.text-alert {
+//  color: #ff8900;
+//}
+//
+//.text-tbb-primary {
+//  color: #13B1DD;
+//}

--- a/ui/admin-portal/src/scss/common.scss
+++ b/ui/admin-portal/src/scss/common.scss
@@ -106,8 +106,10 @@ table {
 
 .card-header {
   background-color: $accent2 !important;
+  background-image: var(--bs-gradient);
+  font-size: 1.1rem;
+  font-weight: 400;
   color: $light !important;
-  font-weight: 300;
   margin-bottom: 0;
 }
 

--- a/ui/admin-portal/src/styles.scss
+++ b/ui/admin-portal/src/styles.scss
@@ -13,6 +13,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
+@import "~src/scss/variables";
 
 @import '~bootstrap/scss/bootstrap-reboot';
 @import '~bootstrap/scss/bootstrap';
@@ -25,13 +26,14 @@ $fa-font-path: "~@fortawesome/fontawesome-free/webfonts";
 
 @import "~src/scss/common";
 @import "~src/scss/page";
-@import "~src/scss/variables";
+
 @import "~src/scss/btn";
 @import "~src/scss/dragula";
 @import "~@ng-select/ng-select/themes/default.theme.css";
 
 body {
   padding-top: 6rem;
+  background-color: $light;
 }
 
 .nav-link {
@@ -39,14 +41,20 @@ body {
 }
 
 .nav-tabs {
-  border-bottom: $nav-tabs-border-width solid $nav-tabs-border-color;
+  border-bottom: $nav-tabs-border-width solid $white;
 
   .nav-item {
     margin-bottom: -$nav-tabs-border-width;
   }
 
   .nav-link {
-    color: $color-primary-darker;
+    color: $accent1;
+    background-color: $accent3;
+    border-color: $light;
+    &:hover {
+      background-color: $accent2;
+      color: $accent3;
+    }
 
     &.disabled {
       color: $nav-link-disabled-color;
@@ -57,8 +65,8 @@ body {
 
   .nav-link.active,
   .nav-item.show .nav-link {
-    color: $color-primary;
-    background-color: $nav-tabs-link-active-bg;
+    color: $dark;
+    background-color: $secondary;
     border-color: $nav-tabs-link-active-border-color;
   }
 
@@ -70,18 +78,18 @@ h1 {
 }
 
 //Table row highlighting
-.table-hover> tbody> tr:hover{
-  background-color: fade-out($color-primary, 0.8)
+highlighting.table-hover> tbody> tr:hover{
+  background-color: $accent3
 }
 
 //Current item - the one whose detailed data is displayed
 tr.current {
-  background-color: fade-out($color-primary-darker, 0.8)
+  background-color: $accent1
 }
 
 //Selected item(s)- item is one of the selected ones (those with checked selection checkbox)
 tr.selected {
-  background-color: fade-out($color-secondary-lighter, 0.7)
+  background-color: $accent2
 }
 //end - Table row highlighting
 
@@ -95,36 +103,36 @@ label,a > i.fas,i.fab,i.far {
 }
 
 a.is-link, a > i.is-link {
-  color: $color-primary;
+  color: $accent1;
   cursor: pointer;
   &:hover {
-    color: $color-primary-dark;
+    color: $accent3;
   }
 }
 
 .ng-select.ng-select-disabled.disabled {
   &.ng-select-multiple {
     .ng-value-container .ng-value {
-      background-color: #d4d4d4;
+      background-color: $accent1;
     }
   }
   .ng-select-container {
-    background-color: #e9ecef;
+    background-color: $accent3;
     opacity: 1;
   }
 }
 
 // change disabled colour to display on visa intakes
-.ng-select.ng-select-disabled>.ng-select-container {
-  background-color: #f2f2f2;
-  .ng-value-label {
-    background-color: #f2f2f2;
-  }
-}
-
-.form-control:disabled {
-  background-color: #f2f2f2;
-}
+//.ng-select.ng-select-disabled>.ng-select-container {
+//  background-color: #f2f2f2;
+//  .ng-value-label {
+//    background-color: #f2f2f2;
+//  }
+//}
+//
+//.form-control:disabled {
+//  background-color: #f2f2f2;
+//}
 
 label {
   font-weight: 500;

--- a/ui/admin-portal/src/styles.scss
+++ b/ui/admin-portal/src/styles.scss
@@ -38,6 +38,7 @@ body {
 
 .nav-link {
   cursor: pointer;
+  color: $light;
 }
 
 .nav-tabs {
@@ -48,12 +49,12 @@ body {
   }
 
   .nav-link {
-    color: $accent1;
+    color: $dark;
     background-color: $accent3;
     border-color: $light;
     &:hover {
       background-color: $accent2;
-      color: $accent3;
+      color: $light;
     }
 
     &.disabled {
@@ -65,8 +66,8 @@ body {
 
   .nav-link.active,
   .nav-item.show .nav-link {
-    color: $dark;
-    background-color: $secondary;
+    color: $light;
+    background-color: $accent1;
     border-color: $nav-tabs-link-active-border-color;
   }
 
@@ -100,13 +101,18 @@ tr.selected {
 /* FONT AWESOME */
 label,a > i.fas,i.fab,i.far {
   margin-right: 5px;
+  color: inherit;
+}
+
+a {
+  color: $info;
 }
 
 a.is-link, a > i.is-link {
-  color: $accent1;
+  color: $info;
   cursor: pointer;
   &:hover {
-    color: $accent3;
+    color: $accent1;
   }
 }
 

--- a/ui/admin-portal/src/styles.scss
+++ b/ui/admin-portal/src/styles.scss
@@ -85,34 +85,30 @@ highlighting.table-hover> tbody> tr:hover{
 
 //Current item - the one whose detailed data is displayed
 tr.current {
-  background-color: $accent1
+  background-color: fade-out($accent2, 0.9)
 }
 
 //Selected item(s)- item is one of the selected ones (those with checked selection checkbox)
 tr.selected {
-  background-color: $accent2
+  background-color: fade-out($accent1, 0.7)
 }
 //end - Table row highlighting
 
 .dropdown-btn > span {
-  color: #6C757C;
+  color: $accent2;
 }
 
 /* FONT AWESOME */
 label,a > i.fas,i.fab,i.far {
   margin-right: 5px;
-  color: inherit;
+  //color: inherit;
 }
 
-a {
-  color: $info;
-}
-
-a.is-link, a > i.is-link {
-  color: $info;
+a.is-link {
+  color: $primary;
   cursor: pointer;
   &:hover {
-    color: $accent1;
+    color: $secondary;
   }
 }
 
@@ -151,4 +147,8 @@ ngx-wig {
 
 .custom-side-profile {
   overflow: scroll;
+}
+
+.fw-500 {
+  font-weight: 500;
 }

--- a/ui/admin-portal/src/styles.scss
+++ b/ui/admin-portal/src/styles.scss
@@ -106,7 +106,7 @@ label,a > {
   }
 }
 
-a.is-link {
+a .is-link {
   color: $primary;
   cursor: pointer;
   &:hover {
@@ -153,4 +153,9 @@ ngx-wig {
 
 .text-accent-1 {
   color: $accent1;
+}
+
+.btn-accent-1 {
+  background-color: $accent1;
+  color: $white;
 }

--- a/ui/admin-portal/src/styles.scss
+++ b/ui/admin-portal/src/styles.scss
@@ -99,9 +99,11 @@ tr.selected {
 }
 
 /* FONT AWESOME */
-label,a > i.fas,i.fab,i.far {
-  margin-right: 5px;
-  //color: inherit;
+label,a > {
+  i.fas,i.fab,i.far {
+    margin-right: 5px;
+    //color: inherit;
+  }
 }
 
 a.is-link {

--- a/ui/admin-portal/src/styles.scss
+++ b/ui/admin-portal/src/styles.scss
@@ -15,21 +15,21 @@
  */
 @import "~src/scss/variables";
 
-@import '~bootstrap/scss/bootstrap-reboot';
-@import '~bootstrap/scss/bootstrap';
+@import 'bootstrap/scss/bootstrap-reboot';
+@import 'bootstrap/scss/bootstrap';
 
 $fa-font-path: "~@fortawesome/fontawesome-free/webfonts";
-@import '~@fortawesome/fontawesome-free/scss/fontawesome.scss';
-@import '~@fortawesome/fontawesome-free/scss/brands.scss';
-@import '~@fortawesome/fontawesome-free/scss/solid.scss';
-@import '~@fortawesome/fontawesome-free/scss/regular.scss';
+@import '@fortawesome/fontawesome-free/scss/fontawesome.scss';
+@import '@fortawesome/fontawesome-free/scss/brands.scss';
+@import '@fortawesome/fontawesome-free/scss/solid.scss';
+@import '@fortawesome/fontawesome-free/scss/regular.scss';
 
 @import "~src/scss/common";
 @import "~src/scss/page";
 
 @import "~src/scss/btn";
 @import "~src/scss/dragula";
-@import "~@ng-select/ng-select/themes/default.theme.css";
+@import "@ng-select/ng-select/themes/default.theme.css";
 
 body {
   padding-top: 6rem;

--- a/ui/admin-portal/src/styles.scss
+++ b/ui/admin-portal/src/styles.scss
@@ -148,3 +148,7 @@ ngx-wig {
 .custom-side-profile {
   overflow: scroll;
 }
+
+.text-accent-1 {
+  color: $accent1;
+}

--- a/ui/admin-portal/src/styles.scss
+++ b/ui/admin-portal/src/styles.scss
@@ -148,7 +148,3 @@ ngx-wig {
 .custom-side-profile {
   overflow: scroll;
 }
-
-.fw-500 {
-  font-weight: 500;
-}


### PR DESCRIPTION
Apologies for the large PR! Updated admin portal colour theming and some other redesigning of components. 

The SCSS files are still confusing with some old CSS and will need more cleaning up. I'm trying to use the classes that bootstrap provides (color being primary, secondary, info, success, warning, danger) as much as possible:
- btn-{color}
- link-{color}
- text-{color}

I also use the spacing classes such as margin/padding classes: https://getbootstrap.com/docs/5.0/utilities/spacing/

Note bootstrap doesn't provide classes for the accent colours, so if needed can create those in a global scss file eg:
`.btn-accent-1 { background-color: $accent1, color: $white }`

Another note, I am getting these intellj warnings regarding imports in SCSS files (bootstrap and font-awesome) here's an example below when pushing changes to the common.scss file. The imports haven't changed in this PR, and it still seems to be importing fine. However just wanted to flag.
<img width="953" alt="Screen Shot 2023-11-24 at 11 16 30 am" src="https://github.com/Talent-Catalog/talentcatalog/assets/43192228/486544d3-51a0-460b-a75b-9fc02e47a46a">
