### PR TITLE
416 visa related candidate dependant information needs to be stored separately on the tc database

### DIFF
--- a/server/src/main/java/org/tctalent/server/api/admin/CandidateVisaCheckAdminApi.java
+++ b/server/src/main/java/org/tctalent/server/api/admin/CandidateVisaCheckAdminApi.java
@@ -178,6 +178,7 @@ public class CandidateVisaCheckAdminApi
                 .add("occupationSubCategory")
                 .add("englishThreshold")
                 .add("englishThresholdNotes")
+                .add("relocatingDependantIds")
                 ;
     }
 

--- a/server/src/main/java/org/tctalent/server/api/admin/CandidateVisaJobCheckAdminApi.java
+++ b/server/src/main/java/org/tctalent/server/api/admin/CandidateVisaJobCheckAdminApi.java
@@ -119,6 +119,7 @@ public class CandidateVisaJobCheckAdminApi
                 .add("occupationSubCategory")
                 .add("englishThreshold")
                 .add("englishThresholdNotes")
+                .add("relocatingDependantIds")
                 ;
     }
 

--- a/server/src/main/java/org/tctalent/server/model/db/CandidateVisaJobCheck.java
+++ b/server/src/main/java/org/tctalent/server/model/db/CandidateVisaJobCheck.java
@@ -111,6 +111,9 @@ public class CandidateVisaJobCheck extends CandidateVisaJobCheckBase {
         if (data.getVisaJobEnglishThresholdNotes() != null) {
             setEnglishThresholdNotes(data.getVisaJobEnglishThresholdNotes());
         }
+        if (data.getVisaJobRelocatingDependantIds() != null) {
+            setRelocatingDependantIds(data.getVisaJobRelocatingDependantIds());
+        }
 
     }
 

--- a/server/src/main/java/org/tctalent/server/model/db/CandidateVisaJobCheckBase.java
+++ b/server/src/main/java/org/tctalent/server/model/db/CandidateVisaJobCheckBase.java
@@ -16,6 +16,9 @@
 
 package org.tctalent.server.model.db;
 
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
@@ -24,6 +27,7 @@ import javax.persistence.ManyToOne;
 import javax.persistence.MappedSuperclass;
 import lombok.Getter;
 import lombok.Setter;
+import org.springframework.util.CollectionUtils;
 
 @Getter
 @Setter
@@ -112,4 +116,33 @@ public class CandidateVisaJobCheckBase extends AbstractDomainObject<Long> {
     private YesNo englishThreshold;
 
     private String englishThresholdNotes;
+
+    /**
+     * String of the ids of the candidate dependants that are relocating as part of the visa job check.
+     * This is a simple string of ids to avoid a lengthy and unnecessary many-to-many relationship,
+     * as we don't need to track the inverse relationship of dependants and their associated visa job checks.
+     * It is a string as opposed to a List of ids due to the error: ''Basic' attribute type should not be a container'
+     */
+    private String relocatingDependantIds;
+
+    /**
+     * Get the string of relocating dependant ids and convert to a comma separated list of ids(long).
+     * @return List of candidate dependant ids
+     */
+    public List<Long> getRelocatingDependantIds() {
+        return relocatingDependantIds != null ?
+            Stream.of(relocatingDependantIds.split(","))
+                .map(Long::parseLong)
+                .collect(Collectors.toList()) : null;
+    }
+
+    /**
+     * Set the list of ids (long) to a string of ids comma separated to save to database.
+     */
+    public void setRelocatingDependantIds(List<Long> relocatingDependantIds) {
+        this.relocatingDependantIds = !CollectionUtils.isEmpty(relocatingDependantIds) ?
+            relocatingDependantIds.stream()
+                .map(String::valueOf)
+                .collect(Collectors.joining(",")) : null;
+    }
 }

--- a/server/src/main/java/org/tctalent/server/request/candidate/visa/CandidateVisaCheckData.java
+++ b/server/src/main/java/org/tctalent/server/request/candidate/visa/CandidateVisaCheckData.java
@@ -16,6 +16,7 @@
 
 package org.tctalent.server.request.candidate.visa;
 
+import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
@@ -84,4 +85,5 @@ public class CandidateVisaCheckData {
     private String visaJobOccupationSubCategory;
     private YesNo visaJobEnglishThreshold;
     private String visaJobEnglishThresholdNotes;
+    private List<Long> visaJobRelocatingDependantIds;
 }

--- a/server/src/main/resources/db/migration/V1_285__add_relocating_dependants_field.sql
+++ b/server/src/main/resources/db/migration/V1_285__add_relocating_dependants_field.sql
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2023 Talent Beyond Boundaries.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+alter table candidate_visa_job_check add column relocating_dependant_ids text;

--- a/ui/admin-portal/src/app/app.module.ts
+++ b/ui/admin-portal/src/app/app.module.ts
@@ -762,6 +762,9 @@ import {ViewChatPostsComponent} from './components/chat/view-chat-posts/view-cha
 import {
   JobGroupChatsTabComponent
 } from './components/job/view/tab/job-group-chats-tab/job-group-chats-tab.component';
+import {
+  RelocatingDependantsComponent
+} from './components/candidates/visa/visa-job-assessments/relocating-dependants/relocating-dependants.component';
 
 @NgModule({
   declarations: [
@@ -1068,7 +1071,8 @@ import {
     ManageChatsComponent,
     JobSourceContactsWithChatsComponent,
     ViewChatPostsComponent,
-    JobGroupChatsTabComponent
+    JobGroupChatsTabComponent,
+    RelocatingDependantsComponent
   ],
   imports: [
     BrowserModule,

--- a/ui/admin-portal/src/app/components/candidates/view/tab/candidate-visa-tab/ca/job/visa-job-check-ca.component.html
+++ b/ui/admin-portal/src/app/components/candidates/view/tab/candidate-visa-tab/ca/job/visa-job-check-ca.component.html
@@ -172,6 +172,13 @@
 
   <ngb-panel id="family-assessment" title="Family Assessment">
     <ng-template ngbPanelContent>
+      <div>
+        <app-relocating-dependants
+          [visaJobCheck]="selectedJobCheck"
+          [entity]="visaCheckRecord"
+          [dependants]="candidateIntakeData.candidateDependants">
+        </app-relocating-dependants>
+      </div>
       <div class="card card-body intake-data">
         <app-fixed-input [question]="'Marital status'" [answer]="candidateIntakeData?.maritalStatus"></app-fixed-input>
         <app-fixed-input [question]="'Spouse\'s highest level education'" [answer]="candidateIntakeData?.partnerEduLevel?.name"></app-fixed-input>

--- a/ui/admin-portal/src/app/components/candidates/visa/visa-job-assessments/relocating-dependants/relocating-dependants.component.html
+++ b/ui/admin-portal/src/app/components/candidates/visa/visa-job-assessments/relocating-dependants/relocating-dependants.component.html
@@ -1,0 +1,34 @@
+<div *ngIf="error">
+  {{error}}
+</div>
+<form [formGroup]="form">
+  <div *ngIf="editable" class="mb-3">
+    <label class="form-label" for="visaJobRelocatingDependantIds">Which dependants hope to relocate with the candidate?</label>
+    <div class="float-end">
+      <app-autosave-status
+        [saving]="saving"
+        [typing]="typing">
+      </app-autosave-status>
+    </div>
+    <ng-select
+      id="visaJobRelocatingDependantIds"
+      [items]="dependants"
+      [multiple]="true"
+      placeholder="Select or type..."
+      bindValue="id"
+      bindLabel="relation"
+      [formControlName]="'visaJobRelocatingDependantIds'">
+      <ng-template ng-multi-label-tmp let-items="items" let-clear="clear">
+        <div class="ng-value" *ngFor="let item of items">
+          <span class="ng-value-label">{{item.relation}}<span *ngIf="item?.name">: {{item?.name}}</span></span>
+          <span class="ng-value-icon right" (click)="clear(item)" aria-hidden="true">×</span>
+        </div>
+      </ng-template>
+      <ng-template ng-option-tmp let-item="item">
+        <span>{{item.relation}}<span *ngIf="item?.name">: {{item.name}}</span></span>
+      </ng-template>
+    </ng-select>
+
+    <div class="form-text">If a dependant isn't listed in the dropdown, you may need to add the dependant to the Dependants section under the Full Intake tab.</div>
+  </div>
+</form>

--- a/ui/admin-portal/src/app/components/candidates/visa/visa-job-assessments/relocating-dependants/relocating-dependants.component.spec.ts
+++ b/ui/admin-portal/src/app/components/candidates/visa/visa-job-assessments/relocating-dependants/relocating-dependants.component.spec.ts
@@ -1,0 +1,25 @@
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+
+import {RelocatingDependantsComponent} from './relocating-dependants.component';
+
+describe('RelocatingDependantsComponent', () => {
+  let component: RelocatingDependantsComponent;
+  let fixture: ComponentFixture<RelocatingDependantsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ RelocatingDependantsComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(RelocatingDependantsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/ui/admin-portal/src/app/components/candidates/visa/visa-job-assessments/relocating-dependants/relocating-dependants.component.ts
+++ b/ui/admin-portal/src/app/components/candidates/visa/visa-job-assessments/relocating-dependants/relocating-dependants.component.ts
@@ -1,0 +1,26 @@
+import {Component, Input, OnInit} from '@angular/core';
+import {VisaCheckComponentBase} from "../../../../util/intake/VisaCheckComponentBase";
+import {FormBuilder} from "@angular/forms";
+import {CandidateVisaCheckService} from "../../../../../services/candidate-visa-check.service";
+import {CandidateDependant,} from "../../../../../model/candidate";
+
+@Component({
+  selector: 'app-relocating-dependants',
+  templateUrl: './relocating-dependants.component.html',
+  styleUrls: ['./relocating-dependants.component.scss']
+})
+export class RelocatingDependantsComponent extends VisaCheckComponentBase implements OnInit {
+
+  @Input() dependants: CandidateDependant[];
+
+  constructor(fb: FormBuilder, candidateVisaCheckService: CandidateVisaCheckService) {
+    super(fb, candidateVisaCheckService);
+  }
+
+  ngOnInit(): void {
+    this.form = this.fb.group({
+      visaJobId: [this.visaJobCheck?.id],
+      visaJobRelocatingDependantIds: [this.visaJobCheck?.relocatingDependantIds],
+    });
+  }
+}

--- a/ui/admin-portal/src/app/model/candidate.ts
+++ b/ui/admin-portal/src/app/model/candidate.ts
@@ -343,6 +343,7 @@ export interface CandidateVisaJobCheck {
   occupationSubCategory?: string;
   englishThreshold?: YesNo;
   englishThresholdNotes?: string;
+  relocatingDependantIds?: number[];
 }
 /*
   Enumerations. These should match equivalent enumerations on the server (Java)

--- a/ui/admin-portal/src/app/util/enum.ts
+++ b/ui/admin-portal/src/app/util/enum.ts
@@ -103,8 +103,11 @@ export function isEnumOptionArray(obj: Object): obj is EnumOption[] {
     if (obj.length > 0) {
       //Look at first item in array and check its type
       const item = obj[0];
+      // When sending ids in multiselect, we know enum option is false if the item is a number.
+      if (!isFinite(item)) {
+        gotOne = isEnumOption(item);
+      }
       //EnumOption objects have a key and a stringValue property.
-      gotOne = isEnumOption(item);
     }
   }
   return gotOne;


### PR DESCRIPTION
Added new field to allow users to select which dependants are to be included on each visa job check. Although a many to many table seemed to make sense (one visa job check can have multiple dependants, but also a dependant can be associated with multiple visa job checks) it felt a little unnecessary, as we dont need the inverse relationship of looking at a dependant and seeing which visa jobs are associated. 

I discussed with @camerojo and it seemed saving a list of ids of the candidate dependants was a simpler and better solution for what we are needing. I added some doc to the code as to why it is saved as a string (and I used a similar example of countryIds string in SavedSearch). This then required some conversion to a list of ids so that we could display these in the ng select.