### PR TITLE
unit tests for other admin apis part 3

### DIFF
--- a/server/src/main/java/org/tctalent/server/api/admin/PartnerAdminApi.java
+++ b/server/src/main/java/org/tctalent/server/api/admin/PartnerAdminApi.java
@@ -20,7 +20,7 @@ import java.util.List;
 import java.util.Map;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -41,22 +41,15 @@ import org.tctalent.server.service.db.JobService;
 import org.tctalent.server.service.db.PartnerService;
 import org.tctalent.server.service.db.UserService;
 
-@RestController()
+@RestController
 @RequestMapping("/api/admin/partner")
+@RequiredArgsConstructor
 public class PartnerAdminApi implements
         ITableApi<SearchPartnerRequest, UpdatePartnerRequest, UpdatePartnerRequest> {
 
     private final PartnerService partnerService;
     private final JobService jobService;
     private final UserService userService;
-
-    @Autowired
-    public PartnerAdminApi(PartnerService partnerService, JobService jobService,
-        UserService userService) {
-        this.partnerService = partnerService;
-        this.jobService = jobService;
-        this.userService = userService;
-    }
 
     @Override
     public @NotNull Map<String, Object> create(UpdatePartnerRequest request) throws EntityExistsException {

--- a/server/src/main/java/org/tctalent/server/api/admin/PublishedLinkAdminApi.java
+++ b/server/src/main/java/org/tctalent/server/api/admin/PublishedLinkAdminApi.java
@@ -16,7 +16,8 @@
 
 package org.tctalent.server.api.admin;
 
-import org.springframework.beans.factory.annotation.Autowired;
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -26,22 +27,16 @@ import org.springframework.web.bind.annotation.RestController;
 import org.tctalent.server.model.db.SavedList;
 import org.tctalent.server.service.db.SavedListService;
 
-import java.net.URI;
-
-@RestController()
+@RestController
 @RequestMapping("/published")
+@RequiredArgsConstructor
 public class PublishedLinkAdminApi {
 
     private final SavedListService savedListService;
 
-    @Autowired
-    public PublishedLinkAdminApi(SavedListService savedListService) {
-        this.savedListService = savedListService;
-    }
-
     @GetMapping("{short-name}")
-    public ResponseEntity<Void> redirect(@PathVariable("short-name") String shortName){
-        SavedList list = this.savedListService.findByShortName(shortName);
+    public ResponseEntity<Void> redirect(@PathVariable("short-name") String shortName) {
+        SavedList list = savedListService.findByShortName(shortName);
         if (list != null && list.getPublishedDocLink() != null) {
             return ResponseEntity.status(HttpStatus.FOUND).location(URI.create(list.getPublishedDocLink())).build();
         } else {

--- a/server/src/main/java/org/tctalent/server/api/admin/RootRouteAdminApi.java
+++ b/server/src/main/java/org/tctalent/server/api/admin/RootRouteAdminApi.java
@@ -17,6 +17,7 @@
 package org.tctalent.server.api.admin;
 
 import java.net.URI;
+import java.util.Objects;
 import javax.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -72,10 +73,9 @@ public class RootRouteAdminApi {
 
 
         if (showHeaders != null) {
-            headers.forEach((key, value) -> {
+            headers.forEach((key, value) ->
                 log.info(String.format(
-                    "Header '%s' = %s", key, String.join("|", value)));
-            });
+                    "Header '%s' = %s", key, String.join("|", value))));
             String ipAddress = request.getHeader("X-Forward-For");
             if(ipAddress == null) {
                 log.info("Ip address: " + request.getRemoteAddr());
@@ -110,12 +110,8 @@ public class RootRouteAdminApi {
         String landingPage = info.getLandingPage();
 
         //If we have a landing page, go there, otherwise go straight to candidate-portal/login.
-        String routingUrl;
-        if (landingPage != null) {
-            routingUrl = landingPage;
-        } else {
-            routingUrl = "/candidate-portal/login";
-        }
+        String routingUrl = Objects.requireNonNullElse(landingPage, "/candidate-portal/login");
+
         if (queryString != null) {
             routingUrl += "?" + queryString;
         }

--- a/server/src/main/java/org/tctalent/server/api/admin/RootRouteAdminApi.java
+++ b/server/src/main/java/org/tctalent/server/api/admin/RootRouteAdminApi.java
@@ -18,8 +18,7 @@ package org.tctalent.server.api.admin;
 
 import java.net.URI;
 import javax.servlet.http.HttpServletRequest;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -38,10 +37,10 @@ import org.tctalent.server.util.SubdomainRedirectHelper;
 /**
  * Handle rerouting when user just types in a domain - eg just tctalent.org
  */
-@RestController()
+@RestController
 @RequestMapping("/")
+@Slf4j
 public class RootRouteAdminApi {
-    private static final Logger log = LoggerFactory.getLogger(RootRouteAdminApi.class);
 
     private final BrandingService brandingService;
     private final RootRequestService rootRequestService;
@@ -57,7 +56,7 @@ public class RootRouteAdminApi {
      * otherwise just go to candidate-portal/login.
      * @return Rerouted url or redirect for partner subdomains
      */
-    @GetMapping()
+    @GetMapping
     public Object route(
         HttpServletRequest request,
         @RequestHeader MultiValueMap<String, String> headers,
@@ -78,7 +77,7 @@ public class RootRouteAdminApi {
                     "Header '%s' = %s", key, String.join("|", value)));
             });
             String ipAddress = request.getHeader("X-Forward-For");
-            if(ipAddress== null) {
+            if(ipAddress == null) {
                 log.info("Ip address: " + request.getRemoteAddr());
             }
         }

--- a/server/src/main/java/org/tctalent/server/api/admin/SalesforceAdminApi.java
+++ b/server/src/main/java/org/tctalent/server/api/admin/SalesforceAdminApi.java
@@ -17,7 +17,7 @@
 package org.tctalent.server.api.admin;
 
 import java.util.Map;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.lang.Nullable;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -33,15 +33,11 @@ import org.tctalent.server.service.db.SalesforceService;
 import org.tctalent.server.util.SalesforceHelper;
 import org.tctalent.server.util.dto.DtoBuilder;
 
-@RestController()
+@RestController
 @RequestMapping("/api/admin/sf")
+@RequiredArgsConstructor
 public class SalesforceAdminApi {
   private final SalesforceService salesforceService;
-
-  @Autowired
-  public SalesforceAdminApi(SalesforceService salesforceService) {
-    this.salesforceService = salesforceService;
-  }
 
   /**
    * Returns info (including "name") about the Salesforce opportunity corresponding to the given

--- a/server/src/main/java/org/tctalent/server/request/PagedSearchRequest.java
+++ b/server/src/main/java/org/tctalent/server/request/PagedSearchRequest.java
@@ -17,6 +17,7 @@
 package org.tctalent.server.request;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 import org.springframework.data.domain.PageRequest;
@@ -26,15 +27,15 @@ import org.springframework.data.domain.Sort.Direction;
 /**
  * Request that includes paging and sorting fields.
  */
-@Getter @Setter @ToString
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
 public class PagedSearchRequest {
     private Integer pageSize;
     private Integer pageNumber;
     private Sort.Direction sortDirection;
     private String[] sortFields;
-
-    public PagedSearchRequest() {
-    }
 
     public PagedSearchRequest(Sort.Direction sortDirection, String[] sortFields) {
         this.sortDirection = sortDirection;

--- a/server/src/test/java/org/tctalent/server/api/admin/AdminApiTestUtil.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/AdminApiTestUtil.java
@@ -73,6 +73,7 @@ import org.tctalent.server.model.db.User;
 import org.tctalent.server.model.db.VisaEligibility;
 import org.tctalent.server.model.db.YesNo;
 import org.tctalent.server.model.db.YesNoUnsure;
+import org.tctalent.server.model.sf.Opportunity;
 import org.tctalent.server.request.candidate.PublishedDocColumnProps;
 
 /**
@@ -277,6 +278,12 @@ public class AdminApiTestUtil {
         salesforceJobOpp.setId(135L);
         salesforceJobOpp.setSfId("sales-force-job-opp-id");
         return salesforceJobOpp;
+    }
+
+    static Opportunity getSalesforceOpportunity() {
+        Opportunity opportunity = new Opportunity();
+        opportunity.setName("SF Opportunity");
+        return opportunity;
     }
 
     static CandidateReviewStatusItem getCandidateReviewStatusItem() {

--- a/server/src/test/java/org/tctalent/server/api/admin/AdminApiTestUtil.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/AdminApiTestUtil.java
@@ -107,6 +107,10 @@ public class AdminApiTestUtil {
                     "test.candidate3@some.thing",
                     Role.user);
 
+    static User getUser() {
+        return caller;
+    }
+
     static List<Candidate> listOfCandidates() {
         return List.of(
                 new Candidate(candidate1, "+123-456-789", "+123-456-789", caller),
@@ -586,4 +590,30 @@ public class AdminApiTestUtil {
             new Industry("Health", Status.active)
         );
     }
+
+    public static PartnerImpl getPartner() {
+        PartnerImpl partner = new PartnerImpl();
+        partner.setName("TC Partner");
+        partner.setAbbreviation("TCP");
+        partner.setJobCreator(true);
+        partner.setSourcePartner(true);
+        partner.setLogo("logo_url");
+        partner.setWebsiteUrl("website_url");
+        partner.setRegistrationLandingPage("registration_landing_page");
+        partner.setNotificationEmail("notification@email.address");
+        partner.setStatus(Status.active);
+        return partner;
+    }
+
+    public static List<PartnerImpl> getListOfPartners() {
+        PartnerImpl partner1 = getPartner();
+        PartnerImpl partner2 = getPartner();
+        partner2.setName("TC Partner 2");
+        PartnerImpl partner3 = getPartner();
+        partner3.setName("TC Partner 3");
+        return List.of(
+          partner1, partner2, partner3
+        );
+    }
+
 }

--- a/server/src/test/java/org/tctalent/server/api/admin/PartnerAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/PartnerAdminApiTest.java
@@ -1,0 +1,360 @@
+/*
+ * Copyright (c) 2023 Talent Beyond Boundaries.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.api.admin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.tctalent.server.api.admin.AdminApiTestUtil.getJob;
+import static org.tctalent.server.api.admin.AdminApiTestUtil.getUser;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.tctalent.server.model.db.PartnerImpl;
+import org.tctalent.server.model.db.SalesforceJobOpp;
+import org.tctalent.server.model.db.Status;
+import org.tctalent.server.model.db.User;
+import org.tctalent.server.request.partner.SearchPartnerRequest;
+import org.tctalent.server.request.partner.UpdatePartnerJobContactRequest;
+import org.tctalent.server.request.partner.UpdatePartnerRequest;
+import org.tctalent.server.service.db.JobService;
+import org.tctalent.server.service.db.PartnerService;
+import org.tctalent.server.service.db.UserService;
+
+/**
+ * Unit tests for Partner Admin Api endpoints.
+ *
+ * @author sadatmalik
+ */
+@WebMvcTest(PartnerAdminApi.class)
+@AutoConfigureMockMvc
+class PartnerAdminApiTest extends ApiTestBase {
+  private static final long PARTNER_ID = 1L;
+
+  private static final String BASE_PATH = "/api/admin/partner";
+  private static final String SEARCH_PAGED_PATH = "/search-paged";
+  private static final String UPDATE_JOB_CONTACT_PATH = "/update-job-contact";
+
+  private static final List<PartnerImpl> partnerList = AdminApiTestUtil.getListOfPartners();
+  private static final PartnerImpl partner = AdminApiTestUtil.getPartner();
+
+  private final Page<PartnerImpl> partnerPage =
+      new PageImpl<>(
+          partnerList,
+          PageRequest.of(0,10, Sort.unsorted()),
+          1
+      );
+
+  @MockBean PartnerService partnerService;
+  @MockBean JobService jobService;
+  @MockBean UserService userService;
+
+  @Autowired MockMvc mockMvc;
+  @Autowired ObjectMapper objectMapper;
+  @Autowired PartnerAdminApi partnerAdminApi;
+
+  @BeforeEach
+  void setUp() {
+    configureAuthentication();
+  }
+
+  @Test
+  public void testWebOnlyContextLoads() {
+    assertThat(partnerAdminApi).isNotNull();
+  }
+
+  @Test
+  @DisplayName("create partner succeeds")
+  void createPartnerSucceeds() throws Exception {
+    UpdatePartnerRequest request = new UpdatePartnerRequest();
+    request.setName("My TC Partner");
+    request.setStatus(Status.active);
+
+    given(partnerService
+        .create(any(UpdatePartnerRequest.class)))
+        .willReturn(partner);
+
+    mockMvc.perform(post(BASE_PATH)
+            .header("Authorization", "Bearer " + "jwt-token")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request))
+            .accept(MediaType.APPLICATION_JSON))
+
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$", notNullValue()))
+        .andExpect(jsonPath("$.name", is("TC Partner")))
+        .andExpect(jsonPath("$.abbreviation", is("TCP")))
+        .andExpect(jsonPath("$.jobCreator", is(true)))
+        .andExpect(jsonPath("$.sourcePartner", is(true)))
+        .andExpect(jsonPath("$.logo", is("logo_url")))
+        .andExpect(jsonPath("$.websiteUrl", is("website_url")))
+        .andExpect(jsonPath("$.registrationLandingPage", is("registration_landing_page")))
+        .andExpect(jsonPath("$.notificationEmail", is("notification@email.address")))
+        .andExpect(jsonPath("$.status", is("active")));
+
+    verify(partnerService).create(any(UpdatePartnerRequest.class));
+  }
+
+  @Test
+  @DisplayName("get partner by id succeeds")
+  void getPartnerByIdSucceeds() throws Exception {
+
+    given(partnerService
+        .getPartner(anyLong()))
+        .willReturn(partner);
+
+    mockMvc.perform(get(BASE_PATH + "/" + PARTNER_ID)
+            .header("Authorization", "Bearer " + "jwt-token")
+            .contentType(MediaType.APPLICATION_JSON))
+
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$", notNullValue()))
+        .andExpect(jsonPath("$.name", is("TC Partner")))
+        .andExpect(jsonPath("$.abbreviation", is("TCP")))
+        .andExpect(jsonPath("$.jobCreator", is(true)))
+        .andExpect(jsonPath("$.sourcePartner", is(true)))
+        .andExpect(jsonPath("$.logo", is("logo_url")))
+        .andExpect(jsonPath("$.websiteUrl", is("website_url")))
+        .andExpect(jsonPath("$.registrationLandingPage", is("registration_landing_page")))
+        .andExpect(jsonPath("$.notificationEmail", is("notification@email.address")))
+        .andExpect(jsonPath("$.status", is("active")));
+
+    verify(partnerService).getPartner(anyLong());
+  }
+
+  @Test
+  @DisplayName("list all partners succeeds")
+  void listAllPartnersSucceeds() throws Exception {
+
+    given(partnerService
+        .listPartners())
+        .willReturn(partnerList);
+
+    mockMvc.perform(get(BASE_PATH)
+            .header("Authorization", "Bearer " + "jwt-token")
+            .contentType(MediaType.APPLICATION_JSON))
+
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$", hasSize(3)))
+        .andExpect(jsonPath("$.[0].name", is("TC Partner")))
+        .andExpect(jsonPath("$.[0].abbreviation", is("TCP")))
+        .andExpect(jsonPath("$.[0].jobCreator", is(true)))
+        .andExpect(jsonPath("$.[0].sourcePartner", is(true)))
+        .andExpect(jsonPath("$.[0].logo", is("logo_url")))
+        .andExpect(jsonPath("$.[0].websiteUrl", is("website_url")))
+        .andExpect(jsonPath("$.[0].registrationLandingPage", is("registration_landing_page")))
+        .andExpect(jsonPath("$.[0].notificationEmail", is("notification@email.address")))
+        .andExpect(jsonPath("$.[0].status", is("active")))
+        .andExpect(jsonPath("$.[1].name", is("TC Partner 2")))
+        .andExpect(jsonPath("$.[1].abbreviation", is("TCP")))
+        .andExpect(jsonPath("$.[1].jobCreator", is(true)))
+        .andExpect(jsonPath("$.[1].sourcePartner", is(true)))
+        .andExpect(jsonPath("$.[1].logo", is("logo_url")))
+        .andExpect(jsonPath("$.[1].websiteUrl", is("website_url")))
+        .andExpect(jsonPath("$.[1].registrationLandingPage", is("registration_landing_page")))
+        .andExpect(jsonPath("$.[1].notificationEmail", is("notification@email.address")))
+        .andExpect(jsonPath("$.[1].status", is("active")))
+        .andExpect(jsonPath("$.[2].name", is("TC Partner 3")))
+        .andExpect(jsonPath("$.[2].abbreviation", is("TCP")))
+        .andExpect(jsonPath("$.[2].jobCreator", is(true)))
+        .andExpect(jsonPath("$.[2].sourcePartner", is(true)))
+        .andExpect(jsonPath("$.[2].logo", is("logo_url")))
+        .andExpect(jsonPath("$.[2].websiteUrl", is("website_url")))
+        .andExpect(jsonPath("$.[2].registrationLandingPage", is("registration_landing_page")))
+        .andExpect(jsonPath("$.[2].notificationEmail", is("notification@email.address")))
+        .andExpect(jsonPath("$.[2].status", is("active")));
+
+    verify(partnerService).listPartners();
+  }
+
+  @Test
+  @DisplayName("search paged partners succeeds")
+  void searchPagedSucceeds() throws Exception {
+    SearchPartnerRequest request = new SearchPartnerRequest();
+
+    given(partnerService
+        .searchPaged(any(SearchPartnerRequest.class)))
+        .willReturn(partnerPage);
+
+    mockMvc.perform(post(BASE_PATH + SEARCH_PAGED_PATH)
+            .header("Authorization", "Bearer " + "jwt-token")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request))
+            .accept(MediaType.APPLICATION_JSON))
+
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.totalElements", is(3)))
+        .andExpect(jsonPath("$.totalPages", is(1)))
+        .andExpect(jsonPath("$.number", is(0)))
+        .andExpect(jsonPath("$.hasNext", is(false)))
+        .andExpect(jsonPath("$.hasPrevious", is(false)))
+        .andExpect(jsonPath("$.content", notNullValue()))
+        .andExpect(jsonPath("$.content[0].name", is("TC Partner")))
+        .andExpect(jsonPath("$.content[0].abbreviation", is("TCP")))
+        .andExpect(jsonPath("$.content[0].jobCreator", is(true)))
+        .andExpect(jsonPath("$.content[0].sourcePartner", is(true)))
+        .andExpect(jsonPath("$.content[0].logo", is("logo_url")))
+        .andExpect(jsonPath("$.content[0].websiteUrl", is("website_url")))
+        .andExpect(jsonPath("$.content[0].registrationLandingPage", is("registration_landing_page")))
+        .andExpect(jsonPath("$.content[0].notificationEmail", is("notification@email.address")))
+        .andExpect(jsonPath("$.content[0].status", is("active")))
+        .andExpect(jsonPath("$.content[1].name", is("TC Partner 2")))
+        .andExpect(jsonPath("$.content[1].abbreviation", is("TCP")))
+        .andExpect(jsonPath("$.content[1].jobCreator", is(true)))
+        .andExpect(jsonPath("$.content[1].sourcePartner", is(true)))
+        .andExpect(jsonPath("$.content[1].logo", is("logo_url")))
+        .andExpect(jsonPath("$.content[1].websiteUrl", is("website_url")))
+        .andExpect(jsonPath("$.content[1].registrationLandingPage", is("registration_landing_page")))
+        .andExpect(jsonPath("$.content[1].notificationEmail", is("notification@email.address")))
+        .andExpect(jsonPath("$.content[1].status", is("active")))
+        .andExpect(jsonPath("$.content[2].name", is("TC Partner 3")))
+        .andExpect(jsonPath("$.content[2].abbreviation", is("TCP")))
+        .andExpect(jsonPath("$.content[2].jobCreator", is(true)))
+        .andExpect(jsonPath("$.content[2].sourcePartner", is(true)))
+        .andExpect(jsonPath("$.content[2].logo", is("logo_url")))
+        .andExpect(jsonPath("$.content[2].websiteUrl", is("website_url")))
+        .andExpect(jsonPath("$.content[2].registrationLandingPage", is("registration_landing_page")))
+        .andExpect(jsonPath("$.content[2].notificationEmail", is("notification@email.address")))
+        .andExpect(jsonPath("$.content[2].status", is("active")));
+
+    verify(partnerService).searchPaged(any(SearchPartnerRequest.class));
+  }
+
+  @Test
+  @DisplayName("update partner by id succeeds")
+  void updatePartnerByIdSucceeds() throws Exception {
+    UpdatePartnerRequest request = new UpdatePartnerRequest();
+    request.setDefaultContactId(11L);
+
+    given(userService
+        .getUser(11L))
+        .willReturn(getUser());
+
+    given(partnerService
+        .update(anyLong(), any(UpdatePartnerRequest.class)))
+        .willReturn(partner);
+
+    mockMvc.perform(put(BASE_PATH + "/" + PARTNER_ID)
+            .header("Authorization", "Bearer " + "jwt-token")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request))
+            .accept(MediaType.APPLICATION_JSON))
+
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$", notNullValue()))
+        .andExpect(jsonPath("$.name", is("TC Partner")))
+        .andExpect(jsonPath("$.abbreviation", is("TCP")))
+        .andExpect(jsonPath("$.jobCreator", is(true)))
+        .andExpect(jsonPath("$.sourcePartner", is(true)))
+        .andExpect(jsonPath("$.logo", is("logo_url")))
+        .andExpect(jsonPath("$.websiteUrl", is("website_url")))
+        .andExpect(jsonPath("$.registrationLandingPage", is("registration_landing_page")))
+        .andExpect(jsonPath("$.notificationEmail", is("notification@email.address")))
+        .andExpect(jsonPath("$.status", is("active")));
+
+    verify(userService).getUser(anyLong());
+    verify(partnerService).update(anyLong(), any(UpdatePartnerRequest.class));
+  }
+
+  @Test
+  @DisplayName("update job contact by partner id succeeds")
+  void updateJobContactByPartnerIdSucceeds() throws Exception {
+    long partnerId = 7L;
+    long jobId = 9L;
+    long userId = 11L;
+
+    UpdatePartnerJobContactRequest request = new UpdatePartnerJobContactRequest();
+    request.setJobId(jobId);
+    request.setUserId(userId);
+
+    given(partnerService
+        .getPartner(anyLong()))
+        .willReturn(partner);
+
+    given(jobService
+        .getJob(jobId))
+        .willReturn(getJob());
+
+    given(userService
+        .getUser(userId))
+        .willReturn(getUser());
+
+    mockMvc.perform(put(BASE_PATH + "/" + partnerId + UPDATE_JOB_CONTACT_PATH)
+            .header("Authorization", "Bearer " + "jwt-token")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request))
+            .accept(MediaType.APPLICATION_JSON))
+
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$", notNullValue()))
+        .andExpect(jsonPath("$.name", is("TC Partner")))
+        .andExpect(jsonPath("$.abbreviation", is("TCP")))
+        .andExpect(jsonPath("$.jobCreator", is(true)))
+        .andExpect(jsonPath("$.sourcePartner", is(true)))
+        .andExpect(jsonPath("$.logo", is("logo_url")))
+        .andExpect(jsonPath("$.websiteUrl", is("website_url")))
+        .andExpect(jsonPath("$.registrationLandingPage", is("registration_landing_page")))
+        .andExpect(jsonPath("$.notificationEmail", is("notification@email.address")))
+        .andExpect(jsonPath("$.status", is("active")));
+
+    verify(partnerService).getPartner(anyLong());
+    verify(jobService).getJob(anyLong());
+    verify(userService).getUser(anyLong());
+    verify(partnerService).updateJobContact(any(PartnerImpl.class), any(SalesforceJobOpp.class), any(User.class));
+
+    assertEquals(jobId, partner.getContextJobId());
+  }
+}

--- a/server/src/test/java/org/tctalent/server/api/admin/PublishedLinkAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/PublishedLinkAdminApiTest.java
@@ -49,7 +49,7 @@ class PublishedLinkAdminApiTest extends ApiTestBase {
 
   private static final String BASE_PATH = "/published";
 
-  private SavedList savedList = new SavedList();
+  private final SavedList savedList = new SavedList();
 
   @MockBean SavedListService savedListService;
 

--- a/server/src/test/java/org/tctalent/server/api/admin/PublishedLinkAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/PublishedLinkAdminApiTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2023 Talent Beyond Boundaries.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.api.admin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.tctalent.server.model.db.SavedList;
+import org.tctalent.server.service.db.SavedListService;
+
+/**
+ * Unit tests for Published Admin Api endpoints.
+ *
+ * @author sadatmalik
+ */
+@WebMvcTest(PublishedLinkAdminApi.class)
+@AutoConfigureMockMvc
+class PublishedLinkAdminApiTest extends ApiTestBase {
+  private static final String SHORT_NAME = "short-name";
+
+  private static final String BASE_PATH = "/published";
+
+  private SavedList savedList = new SavedList();
+
+  @MockBean SavedListService savedListService;
+
+  @Autowired MockMvc mockMvc;
+  @Autowired ObjectMapper objectMapper;
+  @Autowired PublishedLinkAdminApi publishedLinkAdminApi;
+
+  @BeforeEach
+  void setUp() {
+    configureAuthentication();
+  }
+
+  @Test
+  public void testWebOnlyContextLoads() {
+    assertThat(publishedLinkAdminApi).isNotNull();
+  }
+
+  @Test
+  @DisplayName("short name redirect published doc link found")
+  void shortNameRedirectFound() throws Exception {
+    savedList.setPublishedDocLink("published-doc-link");
+
+    given(savedListService
+        .findByShortName(anyString()))
+        .willReturn(savedList);
+
+    mockMvc.perform(get(BASE_PATH + "/" + SHORT_NAME)
+            .header("Authorization", "Bearer " + "jwt-token")
+            .accept(MediaType.APPLICATION_JSON))
+
+        .andDo(print())
+        .andExpect(status().isFound());
+
+    verify(savedListService).findByShortName(anyString());
+  }
+
+  @Test
+  @DisplayName("short name redirect published doc link not found")
+  void shortNameRedirectNotFound() throws Exception {
+
+    given(savedListService
+        .findByShortName(anyString()))
+        .willReturn(savedList);
+
+    mockMvc.perform(get(BASE_PATH + "/" + SHORT_NAME)
+            .header("Authorization", "Bearer " + "jwt-token")
+            .accept(MediaType.APPLICATION_JSON))
+
+        .andDo(print())
+        .andExpect(status().isNotFound());
+
+    verify(savedListService).findByShortName(anyString());
+  }
+
+}

--- a/server/src/test/java/org/tctalent/server/api/admin/RootRouteAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/RootRouteAdminApiTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2023 Talent Beyond Boundaries.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.api.admin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.tctalent.server.model.db.BrandingInfo;
+import org.tctalent.server.service.db.BrandingService;
+import org.tctalent.server.service.db.RootRequestService;
+
+/**
+ * Unit tests for Root Route Admin Api endpoints.
+ *
+ * @author sadatmalik
+ */
+@WebMvcTest(RootRouteAdminApi.class)
+@AutoConfigureMockMvc
+class RootRouteAdminApiTest extends ApiTestBase {
+  private static final String BASE_PATH = "/";
+
+  private BrandingInfo brandingInfo;
+
+  @MockBean BrandingService brandingService;
+  @MockBean RootRequestService rootRequestService;
+
+  @Autowired MockMvc mockMvc;
+  @Autowired ObjectMapper objectMapper;
+  @Autowired RootRouteAdminApi rootRouteAdminApi;
+
+  @BeforeEach
+  void setUp() {
+    configureAuthentication();
+    brandingInfo = new BrandingInfo();
+  }
+
+  @Test
+  public void testWebOnlyContextLoads() {
+    assertThat(rootRouteAdminApi).isNotNull();
+  }
+
+  @Test
+  @DisplayName("redirect sub-domain url to plain url succeeds")
+  void redirectSubDomainUrlToPlainUrlSucceeds() throws Exception {
+
+    mockMvc.perform(get(BASE_PATH)
+            .header("Authorization", "Bearer " + "jwt-token")
+            .header("Host", "crs.tctalent.org")
+            .queryParam("h", "true")
+            .accept(MediaType.APPLICATION_JSON))
+
+        .andDo(print())
+        .andExpect(status().isFound())
+        .andExpect(header().string("Location", containsString(("tctalent.org?p=crs"))));
+  }
+
+  @Test
+  @DisplayName("go to landing page succeeds")
+  void goToLandingPageSucceeds() throws Exception {
+    brandingInfo.setLandingPage("landing-page-url");
+
+    given(brandingService
+        .getBrandingInfo(anyString()))
+        .willReturn(brandingInfo);
+
+    mockMvc.perform(get(BASE_PATH)
+            .header("Authorization", "Bearer " + "jwt-token")
+            .queryParam("p", "partner")
+            .accept(MediaType.APPLICATION_JSON))
+
+        .andDo(print())
+        .andExpect(status().isFound())
+        .andExpect(header().string("Location", containsString(("landing-page-url"))));
+  }
+
+  @Test
+  @DisplayName("go to candidate=portal if no landing page found succeeds")
+  void goToCandidatePortalIfNoLandingPageSucceeds() throws Exception {
+
+    given(brandingService
+        .getBrandingInfo(anyString()))
+        .willReturn(brandingInfo);
+
+    mockMvc.perform(get(BASE_PATH)
+            .header("Authorization", "Bearer " + "jwt-token")
+            .queryParam("p", "partner")
+            .accept(MediaType.APPLICATION_JSON))
+
+        .andDo(print())
+        .andExpect(status().isFound())
+        .andExpect(header().string("Location", containsString(("/candidate-portal/login"))));
+  }
+
+  @Test
+  @DisplayName("redirect contains query string succeeds")
+  void RedirectContainsQueryStringSucceeds() throws Exception {
+
+    given(brandingService
+        .getBrandingInfo(anyString()))
+        .willReturn(brandingInfo);
+
+    mockMvc.perform(get(BASE_PATH)
+            .header("Authorization", "Bearer " + "jwt-token")
+            .header("Host", "tctalent.org")
+            .queryParam("p", "partner")
+            .accept(MediaType.APPLICATION_JSON))
+
+        .andDo(print())
+        .andExpect(status().isFound())
+        .andExpect(header().string("Location", containsString(("?p=partner"))));
+  }
+
+}

--- a/server/src/test/java/org/tctalent/server/api/admin/RootRouteAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/RootRouteAdminApiTest.java
@@ -123,7 +123,7 @@ class RootRouteAdminApiTest extends ApiTestBase {
 
   @Test
   @DisplayName("redirect contains query string succeeds")
-  void RedirectContainsQueryStringSucceeds() throws Exception {
+  void redirectContainsQueryStringSucceeds() throws Exception {
 
     given(brandingService
         .getBrandingInfo(anyString()))

--- a/server/src/test/java/org/tctalent/server/api/admin/SalesforceAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/SalesforceAdminApiTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2023 Talent Beyond Boundaries.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.api.admin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.tctalent.server.exception.SalesforceException;
+import org.tctalent.server.model.sf.Opportunity;
+import org.tctalent.server.request.opportunity.UpdateEmployerOpportunityRequest;
+import org.tctalent.server.service.db.SalesforceService;
+
+/**
+ * Unit tests for Salesforce Api endpoints.
+ *
+ * @author sadatmalik
+ */
+@WebMvcTest(SalesforceAdminApi.class)
+@AutoConfigureMockMvc
+class SalesforceAdminApiTest extends ApiTestBase {
+  private static final String SF_OPPORTUNITY_URL
+      = "https://talentbeyondboundaries.lightning.force.com/lightning/r/Opportunity/";
+  private static final String SF_OPPORTUNITY_ID = "001ABCDEF012345678";
+  private static final String BASE_PATH = "/api/admin/sf";
+  private static final String SF_OPPORTUNITY_PATH = "/opportunity";
+  private static final String UPDATE_EMPLOYER_OPPORTUNITY_PATH = "/update-emp-opp";
+
+  private final Opportunity opportunity = AdminApiTestUtil.getSalesforceOpportunity();
+
+  @MockBean SalesforceService salesforceService;
+
+  @Autowired MockMvc mockMvc;
+  @Autowired ObjectMapper objectMapper;
+  @Autowired SalesforceAdminApi salesforceAdminApi;
+
+  @BeforeEach
+  void setUp() {
+    configureAuthentication();
+  }
+
+  @Test
+  public void testWebOnlyContextLoads() {
+    assertThat(salesforceAdminApi).isNotNull();
+  }
+
+  @Test
+  @DisplayName("get opportunity succeeds")
+  void getOpportunitySucceeds() throws Exception {
+
+    given(salesforceService
+        .findOpportunity(anyString()))
+        .willReturn(opportunity);
+
+    mockMvc.perform(get(BASE_PATH + SF_OPPORTUNITY_PATH)
+            .header("Authorization", "Bearer " + "jwt-token")
+            .queryParam("url", SF_OPPORTUNITY_URL + SF_OPPORTUNITY_ID)
+            .accept(MediaType.APPLICATION_JSON))
+
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.name", is("SF Opportunity")));
+
+    verify(salesforceService).findOpportunity(anyString());
+  }
+
+  @Test
+  @DisplayName("get opportunity fails with salesforce exception")
+  void getOpportunityFailsWithSalesforceException() throws Exception {
+
+    given(salesforceService
+        .findOpportunity(anyString()))
+        .willThrow(new SalesforceException("SalesforceException message"));
+
+    mockMvc.perform(get(BASE_PATH + SF_OPPORTUNITY_PATH)
+            .header("Authorization", "Bearer " + "jwt-token")
+            .queryParam("url", SF_OPPORTUNITY_URL + SF_OPPORTUNITY_ID)
+            .accept(MediaType.APPLICATION_JSON))
+
+        .andDo(print())
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code", is("salesforce")))
+        .andExpect(jsonPath("$.message", is("SalesforceException message")));
+
+    verify(salesforceService).findOpportunity(anyString());
+  }
+
+  @Test
+  @DisplayName("update employer opportunity succeeds")
+  void updateEmployerOpportunitySucceeds() throws Exception {
+    UpdateEmployerOpportunityRequest request = new UpdateEmployerOpportunityRequest();
+
+    mockMvc.perform(put(BASE_PATH + UPDATE_EMPLOYER_OPPORTUNITY_PATH)
+            .header("Authorization", "Bearer " + "jwt-token")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request))
+            .accept(MediaType.APPLICATION_JSON))
+
+        .andDo(print())
+        .andExpect(status().isOk());
+
+    verify(salesforceService).updateEmployerOpportunity(any(UpdateEmployerOpportunityRequest.class));
+  }
+
+  @Test
+  @DisplayName("update employer opportunity fails with salesforce exception")
+  void updateEmployerOpportunityFailsWithSalesforceException() throws Exception {
+    UpdateEmployerOpportunityRequest request = new UpdateEmployerOpportunityRequest();
+
+    doThrow(new SalesforceException("SalesforceException message"))
+        .when(salesforceService)
+            .updateEmployerOpportunity(any(UpdateEmployerOpportunityRequest.class));
+
+    mockMvc.perform(put(BASE_PATH + UPDATE_EMPLOYER_OPPORTUNITY_PATH)
+            .header("Authorization", "Bearer " + "jwt-token")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request))
+            .accept(MediaType.APPLICATION_JSON))
+
+        .andDo(print())
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code", is("salesforce")))
+        .andExpect(jsonPath("$.message", is("SalesforceException message")));
+
+    verify(salesforceService).updateEmployerOpportunity(any(UpdateEmployerOpportunityRequest.class));
+  }
+
+}


### PR DESCRIPTION
This PR contains unit tests for these admin apis:

- PartnerAdminApi
- PublishedLinkAdminApi
- RootRouteAdminApi
- SalesforceAdminApi

And resolves some IntelliJ warnings in related classes.