### PR TITLE
Removes reCaptcha processing on candidate portal controller

### DIFF
--- a/server/src/main/java/org/tctalent/server/api/portal/AuthPortalApi.java
+++ b/server/src/main/java/org/tctalent/server/api/portal/AuthPortalApi.java
@@ -71,7 +71,7 @@ public class AuthPortalApi {
     }
 
     @PostMapping("logout")
-    public ResponseEntity logout() {
+    public ResponseEntity<Void> logout() {
         this.userService.logout();
         return ResponseEntity.ok().build();
     }

--- a/server/src/main/java/org/tctalent/server/api/portal/AuthPortalApi.java
+++ b/server/src/main/java/org/tctalent/server/api/portal/AuthPortalApi.java
@@ -39,28 +39,24 @@ import org.tctalent.server.request.LoginRequest;
 import org.tctalent.server.request.candidate.RegisterCandidateRequest;
 import org.tctalent.server.response.JwtAuthenticationResponse;
 import org.tctalent.server.service.db.CandidateService;
-import org.tctalent.server.service.db.CaptchaService;
 import org.tctalent.server.service.db.UserService;
 import org.tctalent.server.util.dto.DtoBuilder;
 
-@RestController()
+@RestController
 @RequestMapping("/api/portal/auth")
 public class AuthPortalApi {
     private static final Logger log = LoggerFactory.getLogger(AuthPortalApi.class);
 
     private final UserService userService;
     private final CandidateService candidateService;
-    private final CaptchaService captchaService;
     private final TranslationConfig translationConfig;
 
     @Autowired
     public AuthPortalApi(UserService userService,
-        CaptchaService captchaService,
         CandidateService candidateService,
         TranslationConfig translationConfig) {
         this.userService = userService;
         this.candidateService = candidateService;
-        this.captchaService = captchaService;
         this.translationConfig = translationConfig;
     }
 
@@ -79,10 +75,6 @@ public class AuthPortalApi {
         InvalidPasswordFormatException, UserDeactivatedException,
         ReCaptchaInvalidException {
 
-        //Do check for automated logins. Throws exception if it looks
-        //automated.
-        captchaService.processCaptchaV3Token(request.getReCaptchaV3Token(), "login");
-
         JwtAuthenticationResponse response = userService.login(request);
         return jwtDto().build(response);
     }
@@ -97,10 +89,6 @@ public class AuthPortalApi {
     public Map<String, Object> register(
         HttpServletRequest httpRequest, @Valid @RequestBody RegisterCandidateRequest request)
             throws AccountLockedException, ReCaptchaInvalidException {
-
-        //Do check for automated registrations. Throws exception if it looks
-        //automated.
-        captchaService.processCaptchaV3Token(request.getReCaptchaV3Token(), "registration");
 
         LoginRequest loginRequest = candidateService.register(request, httpRequest);
 

--- a/server/src/main/java/org/tctalent/server/api/portal/AuthPortalApi.java
+++ b/server/src/main/java/org/tctalent/server/api/portal/AuthPortalApi.java
@@ -20,9 +20,8 @@ import java.util.Map;
 import javax.security.auth.login.AccountLockedException;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -44,21 +43,13 @@ import org.tctalent.server.util.dto.DtoBuilder;
 
 @RestController
 @RequestMapping("/api/portal/auth")
+@RequiredArgsConstructor
+@Slf4j
 public class AuthPortalApi {
-    private static final Logger log = LoggerFactory.getLogger(AuthPortalApi.class);
 
     private final UserService userService;
     private final CandidateService candidateService;
     private final TranslationConfig translationConfig;
-
-    @Autowired
-    public AuthPortalApi(UserService userService,
-        CandidateService candidateService,
-        TranslationConfig translationConfig) {
-        this.userService = userService;
-        this.candidateService = candidateService;
-        this.translationConfig = translationConfig;
-    }
 
     @PostMapping("xlate")
     public void authorizeInContextTranslation(@RequestBody AuthenticateInContextTranslationRequest request)


### PR DESCRIPTION
This PR resolves an issue where login attempts are disallowed in Staging due to reCaptcha processing. 

We are no longer using reCaptcha (it has been removed from the client (Angular) code) so it can be safely removed from the server code as well.