### PR TITLE
Replaced Old with External for intake button and note text

### DIFF
--- a/ui/admin-portal/src/app/components/candidates/view/tab/candidate-intake-tab/candidate-intake-tab.component.html
+++ b/ui/admin-portal/src/app/components/candidates/view/tab/candidate-intake-tab/candidate-intake-tab.component.html
@@ -40,7 +40,7 @@
       <div class="btn-group">
           <button class="btn btn-sm btn-primary border border-white" (click)="inputOldIntakeNote('Full Intake', $event.target)" [disabled]="saving">
             <i *ngIf="saving" class="fas fa-spinner fa-spin" ></i>
-            Input Original Intake
+            Input External Intake
           </button>
           <button class="btn btn-sm btn-success border border-white" (click)="createIntakeNote('Full Intake', 'start', $event.target)" [disabled]="saving || clickedOldIntake">
             Start New Intake
@@ -51,7 +51,7 @@
       </div>
       <div>
         <div class="text-muted small font-italic">- Before starting or updating the interview, please click appropriate button.</div>
-        <div class="text-muted small font-italic">- If entering an old intake click Input Original Intake and ignore other buttons.</div>
+        <div class="text-muted small font-italic">- If entering an external intake click 'Input External Intake' and ignore other buttons.</div>
         <div class="text-muted small font-italic">- This will create a note on the right to help track changes. Only click once per intake.</div>
       </div>
 

--- a/ui/admin-portal/src/app/components/candidates/view/tab/candidate-mini-intake-tab/candidate-mini-intake-tab.component.html
+++ b/ui/admin-portal/src/app/components/candidates/view/tab/candidate-mini-intake-tab/candidate-mini-intake-tab.component.html
@@ -39,7 +39,7 @@
       <div class="btn-group">
         <button class="btn btn-sm btn-primary border border-white" (click)="inputOldIntakeNote('Mini Intake', $event.target)" [disabled]="saving">
           <i *ngIf="saving" class="fas fa-spinner fa-spin" ></i>
-          Input Original Intake
+          Input External Intake
         </button>
         <button class="btn btn-sm btn-success border border-white" (click)="createIntakeNote('Mini Intake', 'start', $event.target)" [disabled]="saving || clickedOldIntake">
           Start Intake
@@ -50,7 +50,7 @@
       </div>
       <div>
         <div class="text-muted small font-italic">- Before starting or updating the interview, please click appropriate button.</div>
-        <div class="text-muted small font-italic">- If entering an old intake click Input Original Intake and ignore other buttons.</div>
+        <div class="text-muted small font-italic">- If entering an external intake click 'Input External Intake' and ignore other buttons.</div>
         <div class="text-muted small font-italic">- This will create a note on the right to help track changes. Only click once per intake.</div>
       </div>
 


### PR DESCRIPTION
HOTFIX: As per #533 and our chat in our call yesterday, we decided to keep the button 'Input Old Intake' which was used when we manually entered paper/google doc intakes a couple years ago. This button prompts the user to enter the date the intake was collected, as well as the user who collected the intake. It then triggers a note to be created to indicate that this intake was completed. 

With Mindset helping us and potentially using a different survey software to capture the data, we thought this button could be reused to precisely capture the who/when information of the intake when Mindset reenter the data from their software into the TC. This just required us to better name the button and the corresponding note to help make the button action a bit clearer.

This is currently pushed to master BUT not yet deployed due to finding that the production system is not running the latest task (see Slack message in our team channel).