### PR TITLE
Hotfix-2.2.0-Fix-issue-642-closed-opps-being-published

### DIFF
--- a/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.ts
+++ b/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.ts
@@ -242,7 +242,7 @@ export class ShowCandidatesComponent implements OnInit, OnChanges, OnDestroy {
     if (isSavedList(this.candidateSource)) {
       this.searchForm = this.fb.group({
         keyword: [''],
-        showClosedOpps: []
+        showClosedOpps: [false]
       });
       this.subscribeToFilterChanges();
 


### PR DESCRIPTION
Fix bug where Closed cases were being published because checkbox was initializing as null instead of false.

Fixes issue #642 