### PR TITLE
remove isAdmin flag - use roles instead

### DIFF
--- a/server/src/main/java/org/tctalent/server/request/user/SendResetPasswordEmailRequest.java
+++ b/server/src/main/java/org/tctalent/server/request/user/SendResetPasswordEmailRequest.java
@@ -25,6 +25,5 @@ import lombok.ToString;
 @ToString
 public class SendResetPasswordEmailRequest {
     private String email;
-    private Boolean isAdmin;
     private String reCaptchaV3Token;
 }

--- a/server/src/main/java/org/tctalent/server/service/db/email/EmailHelper.java
+++ b/server/src/main/java/org/tctalent/server/service/db/email/EmailHelper.java
@@ -24,6 +24,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
 import org.tctalent.server.exception.EmailSendFailedException;
+import org.tctalent.server.model.db.Role;
 import org.tctalent.server.model.db.SavedSearch;
 import org.tctalent.server.model.db.User;
 import org.thymeleaf.TemplateEngine;
@@ -77,7 +78,7 @@ public class EmailHelper {
         }
     }
 
-    public void sendResetPasswordEmail(User user, boolean isAdminRequest) throws EmailSendFailedException {
+    public void sendResetPasswordEmail(User user) throws EmailSendFailedException {
 
         String email = user.getEmail();
         String displayName = user.getDisplayName();
@@ -90,7 +91,7 @@ public class EmailHelper {
             final Context ctx = new Context();
             ctx.setVariable("displayName", displayName);
 
-            String resetUrl = isAdminRequest ? adminUrl : portalUrl;
+            String resetUrl = user.getRole() == Role.user ? portalUrl : adminUrl;
             ctx.setVariable("resetUrl", resetUrl + "/reset-password/" + token);
             ctx.setVariable("year", currentYear());
 

--- a/server/src/main/java/org/tctalent/server/service/db/impl/UserServiceImpl.java
+++ b/server/src/main/java/org/tctalent/server/service/db/impl/UserServiceImpl.java
@@ -581,13 +581,13 @@ public class UserServiceImpl implements UserService {
             this.userRepository.save(user);
 
             try {
-                emailHelper.sendResetPasswordEmail(user, request.getIsAdmin());
+                emailHelper.sendResetPasswordEmail(user);
             } catch (EmailSendFailedException e) {
                 log.error("unable to send reset password email for " + user.getEmail());
             }
 
             // temporary for testing till emails are working
-            String resetUrl = request.getIsAdmin().equals(Boolean.TRUE) ? adminUrl : portalUrl;
+            String resetUrl = user.getRole() == Role.user ? portalUrl : adminUrl;
             log.info("RESET URL: " + resetUrl + "/reset-password/" + user.getResetToken());
         } else {
             log.error("unable to send reset email for " + request.getEmail());

--- a/server/src/test/java/org/tctalent/server/service/db/email/EmailTester.java
+++ b/server/src/test/java/org/tctalent/server/service/db/email/EmailTester.java
@@ -35,7 +35,7 @@ public class EmailTester {
     private static void testStubSend() {
         EmailSender emailSender = stubEmailSender();
         EmailHelper helper = new EmailHelper(emailSender, textTemplateEngine(), htmlTemplateEngine());
-        helper.sendResetPasswordEmail(user(), false);
+        helper.sendResetPasswordEmail(user());
     }
 
     private static User user() {

--- a/ui/admin-portal/src/app/components/account/reset-password/reset-password.component.ts
+++ b/ui/admin-portal/src/app/components/account/reset-password/reset-password.component.ts
@@ -48,7 +48,6 @@ export class ResetPasswordComponent implements OnInit {
 
     const req: SendResetPasswordEmailRequest = new SendResetPasswordEmailRequest();
     req.email = this.email;
-    req.isAdmin = true;
 
     this.userService.sendResetPassword(req).subscribe(
         () => {

--- a/ui/admin-portal/src/app/model/candidate.ts
+++ b/ui/admin-portal/src/app/model/candidate.ts
@@ -778,5 +778,4 @@ export function getDestinationOccupationSubcatLink(countryId: number): string {
 
 export class SendResetPasswordEmailRequest {
   email: string;
-  isAdmin: boolean;
 }


### PR DESCRIPTION
This PR

- removes the isAdmin flag on reset password requests
- it is better to use roles 

