### PR TITLE
387 add unverified filter to search results

### DIFF
--- a/server/src/main/java/org/tctalent/server/model/db/CandidateReviewStatusItem.java
+++ b/server/src/main/java/org/tctalent/server/model/db/CandidateReviewStatusItem.java
@@ -16,10 +16,6 @@
 
 package org.tctalent.server.model.db;
 
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
@@ -28,6 +24,9 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 /**
  * This indicates whether a candidate who turns up in a saved search really belongs in that search.
@@ -37,7 +36,7 @@ import javax.persistence.Table;
  * saved search for bakers! You could just modify the candidate's profile to remove that movie
  * preference - but you may not want to do that. Another way is to note that the candidate does
  * not really belong in the "Baker" saved search. You can do that by creating one of these objects
- * - setting the reviewStatus to {@link ReviewStatus#rejected}. Then the candidate will not longer
+ * - setting the reviewStatus to {@link ReviewStatus#rejected}. Then the candidate will no longer
  * appear in the search (unless you explicitly ask to see candidates rejected from the search).
  */
 @Getter

--- a/server/src/main/java/org/tctalent/server/repository/db/CandidateRepository.java
+++ b/server/src/main/java/org/tctalent/server/repository/db/CandidateRepository.java
@@ -31,6 +31,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.tctalent.server.model.db.Candidate;
 import org.tctalent.server.model.db.CandidateStatus;
 import org.tctalent.server.model.db.Country;
+import org.tctalent.server.model.db.ReviewStatus;
 
 /**
  * See notes on "join fetch" in the doc for {@link #findByIdLoadCandidateOccupations}
@@ -119,6 +120,15 @@ public interface CandidateRepository extends JpaRepository<Candidate, Long>, Jpa
             + " or c.sflink is not null")
     Page<Candidate> findByStatusesOrSfLinkIsNotNull(
         @Param("statuses") List<CandidateStatus> statuses, Pageable pageable);
+
+
+    @Query("select c from Candidate c "
+        + "join CandidateReviewStatusItem cri "
+        + "on c.id = cri.candidate.id "
+        + "where cri.savedSearch.id = :savedSearchId "
+        + "and cri.reviewStatus not in (:statuses)")
+    Page<Candidate> findReviewedCandidatesBySavedSearchId(@Param("savedSearchId") Long savedSearchId,
+        @Param("statuses") List<ReviewStatus> statuses, Pageable pageable);
 
     @Transactional
     @Modifying

--- a/server/src/main/java/org/tctalent/server/repository/db/CandidateReviewStatusRepository.java
+++ b/server/src/main/java/org/tctalent/server/repository/db/CandidateReviewStatusRepository.java
@@ -32,9 +32,4 @@ public interface CandidateReviewStatusRepository extends JpaRepository<Candidate
   Set<Candidate> findReviewedCandidatesForSearch(
       @Param("savedSearchId") Long savedSearchId, @Param("statuses") List<ReviewStatus> statuses);
 
-  @Query(" select review.candidate.id from CandidateReviewStatusItem review "
-      + " where review.savedSearch.id = :savedSearchId and review.reviewStatus in (:statuses) ")
-  Set<Long> findReviewedCandidateIdsForSearch(
-      @Param("savedSearchId") Long savedSearchId, @Param("statuses") List<ReviewStatus> statuses);
-
 }

--- a/server/src/main/java/org/tctalent/server/repository/db/CandidateReviewStatusRepository.java
+++ b/server/src/main/java/org/tctalent/server/repository/db/CandidateReviewStatusRepository.java
@@ -32,4 +32,9 @@ public interface CandidateReviewStatusRepository extends JpaRepository<Candidate
   Set<Candidate> findReviewedCandidatesForSearch(
       @Param("savedSearchId") Long savedSearchId, @Param("statuses") List<ReviewStatus> statuses);
 
+  @Query(" select review.candidate.id from CandidateReviewStatusItem review "
+      + " where review.savedSearch.id = :savedSearchId and review.reviewStatus in (:statuses) ")
+  Set<Long> findReviewedCandidateIdsForSearch(
+      @Param("savedSearchId") Long savedSearchId, @Param("statuses") List<ReviewStatus> statuses);
+
 }

--- a/server/src/main/java/org/tctalent/server/request/reviewstatus/CreateCandidateReviewStatusRequest.java
+++ b/server/src/main/java/org/tctalent/server/request/reviewstatus/CreateCandidateReviewStatusRequest.java
@@ -17,19 +17,12 @@
 package org.tctalent.server.request.reviewstatus;
 
 import javax.validation.constraints.NotNull;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.tctalent.server.model.db.ReviewStatus;
 
 @Getter
 @Setter
-@Builder
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
-@NoArgsConstructor(access = AccessLevel.PUBLIC)
 public class CreateCandidateReviewStatusRequest {
 
     @NotNull

--- a/server/src/main/java/org/tctalent/server/request/reviewstatus/CreateCandidateReviewStatusRequest.java
+++ b/server/src/main/java/org/tctalent/server/request/reviewstatus/CreateCandidateReviewStatusRequest.java
@@ -17,13 +17,19 @@
 package org.tctalent.server.request.reviewstatus;
 
 import javax.validation.constraints.NotNull;
-
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.tctalent.server.model.db.ReviewStatus;
 
 @Getter
 @Setter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PUBLIC)
 public class CreateCandidateReviewStatusRequest {
 
     @NotNull

--- a/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.ts
+++ b/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.ts
@@ -229,7 +229,11 @@ export class ShowCandidatesComponent implements OnInit, OnChanges, OnDestroy {
     this.loggedInUser = this.authenticationService.getLoggedInUser();
     this.selectedCandidates = [];
 
-    this.statuses = [ReviewStatus[ReviewStatus.rejected], ReviewStatus[ReviewStatus.verified]];
+    this.statuses = [
+      ReviewStatus[ReviewStatus.rejected],
+      ReviewStatus[ReviewStatus.verified],
+      ReviewStatus[ReviewStatus.unverified]
+    ];
 
     //Different use of searchForm depending on whether saved search or saved list
 


### PR DESCRIPTION
This PR:

- Adds an unverified review status filter to saved search results
- The use case is for when a user wants to see only candidates that they have already verified and/or rejected
- These candidates have entries in the review status items table and are retrieved from there

