### PR TITLE
show “factors preventing. . . etc." only for “yes” to international opps

### DIFF
--- a/ui/admin-portal/src/app/components/candidates/intake/avail-immediate/avail-immediate.component.html
+++ b/ui/admin-portal/src/app/components/candidates/intake/avail-immediate/avail-immediate.component.html
@@ -40,7 +40,7 @@
     </div>
   </div>
 
-  <div *ngIf="availImmediate === 'No'|| availImmediate == 'Unsure'">
+  <div *ngIf="availImmediate === 'Yes'">
     <div class="mb-3">
       <label class="form-label" for="availImmediateReason">Factors preventing immediate availability for international work.</label>
       <ng-select id="availImmediateReason" [formControlName]="'availImmediateReason'" (clear)="setNoResponse('availImmediateReason')"

--- a/ui/admin-portal/src/app/components/candidates/intake/avail-immediate/avail-immediate.component.html
+++ b/ui/admin-portal/src/app/components/candidates/intake/avail-immediate/avail-immediate.component.html
@@ -19,7 +19,7 @@
 </div>
 <form [formGroup]="form">
   <div class="mb-3">
-    <label class="form-label" for="availImmediate">Are you interested in international employment opportunities now?</label>
+    <label class="form-label" for="availImmediate">Are you available for international employment opportunities now?</label>
     <div class="float-end">
       <app-autosave-status
         [saving]="saving"
@@ -40,7 +40,7 @@
     </div>
   </div>
 
-  <div *ngIf="availImmediate === 'Yes'">
+  <div *ngIf="availImmediate === 'No'|| availImmediate == 'Unsure'">
     <div class="mb-3">
       <label class="form-label" for="availImmediateReason">Factors preventing immediate availability for international work.</label>
       <ng-select id="availImmediateReason" [formControlName]="'availImmediateReason'" (clear)="setNoResponse('availImmediateReason')"


### PR DESCRIPTION
Very tiny PR that adjusts the Interest in International Recruitment:

- Flips the "factors preventing immediate availability" questions
- Displays only for "Yes" to international opportunities

PR amended following team refinement: We will not flip the question but clarify its meaning instead. See PR comments.
