### PR TITLE
add GA4 tag to candidate portal

### DIFF
--- a/ui/candidate-portal/src/app/components/app.component.ts
+++ b/ui/candidate-portal/src/app/components/app.component.ts
@@ -20,8 +20,9 @@ import {LanguageService} from '../services/language.service';
 import {LanguageLoader} from "../services/language.loader";
 import {AuthenticationService} from "../services/authentication.service";
 import {User} from "../model/user";
-import {Router} from "@angular/router";
+import {NavigationEnd, Router} from "@angular/router";
 import {ChatService} from "../services/chat.service";
+import {environment} from "../../environments/environment";
 
 @Component({
   selector: 'app-root',
@@ -44,6 +45,7 @@ export class AppComponent implements OnInit {
   }
 
   ngOnInit(): void {
+    this.trackPageViews();
 
     this.authenticationService.loggedInUser$.subscribe(
       (user) => {
@@ -87,4 +89,34 @@ export class AppComponent implements OnInit {
     //Show login screen
     this.router.navigate(['login']);
   }
+
+  /**
+   * Tracks page views in a Single Page Application (SPA) context using Google Analytics.
+   *
+   * In traditional websites, navigation between pages naturally triggers a page load,
+   * which Google Analytics uses to track page views. However, in SPAs like those built with Angular,
+   * navigation changes the content dynamically without reloading the entire page. This function
+   * subscribes to Angular Router events to detect when navigation ends and a new "page" is viewed,
+   * manually sending page view information to Google Analytics.
+   *
+   * The `NavigationEnd` event indicates a successful route change, at which point we use the
+   * `gtag` function with the 'config' command to send the current page path to Google Analytics.
+   *
+   * Additionally, console logs are included for testing purposes.
+   *
+   * See, for example, https://blog.mestwin.net/add-google-analytics-to-angular-application-in-3-easy-steps
+   */
+  trackPageViews() {
+    this.router.events.subscribe(event => {
+      if (event instanceof NavigationEnd) {
+        gtag('config', environment.googleAnalyticsId, {
+          'page_path': event.urlAfterRedirects
+        });
+        // console.log('Sending Google Analytics tracking for: ', event.urlAfterRedirects);
+        // console.log('Google Analytics property ID: ', environment.googleAnalyticsId);
+      }
+    });
+  }
 }
+
+declare let gtag: Function;

--- a/ui/candidate-portal/src/environments/environment.prod.ts
+++ b/ui/candidate-portal/src/environments/environment.prod.ts
@@ -25,5 +25,6 @@ export const environment = {
   chatApiUrl: '/api/admin',
   apiUrl: '/api/portal',
   systemApiUrl: '/api/system',
-  s3BucketUrl: 'https://s3.us-east-1.amazonaws.com/files.tbbtalent.org'
+  s3BucketUrl: 'https://s3.us-east-1.amazonaws.com/files.tbbtalent.org',
+  googleAnalyticsId: 'G-BPDYWB77Y3'
 };

--- a/ui/candidate-portal/src/environments/environment.ts
+++ b/ui/candidate-portal/src/environments/environment.ts
@@ -25,7 +25,8 @@ export const environment = {
   chatApiUrl: 'http://localhost:8080/api/admin',
   apiUrl: 'http://localhost:8080/api/portal',
   systemApiUrl: 'http://localhost:8080/api/system',
-  s3BucketUrl: 'https://s3.us-east-1.amazonaws.com/dev.files.tbbtalent.org'
+  s3BucketUrl: 'https://s3.us-east-1.amazonaws.com/dev.files.tbbtalent.org',
+  googleAnalyticsId: 'G-K9ML1Y40B4' // for testing
 };
 
 /*

--- a/ui/candidate-portal/src/index.html
+++ b/ui/candidate-portal/src/index.html
@@ -17,7 +17,7 @@
 <!doctype html>
 <html lang="en">
 <head>
-  <!-- Global site tag (gtag.js) - Google Analytics -->
+  <!-- Global site tag (gtag.js) - Google Universal Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=UA-163314566-2"></script>
   <script>
     window.dataLayer = window.dataLayer || [];
@@ -25,6 +25,14 @@
     gtag('js', new Date());
 
     gtag('config', 'UA-163314566-2');
+  </script>
+
+  <!-- Google tag (gtag.js) - GA4 -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-BPDYWB77Y3"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
   </script>
 
   <meta charset="utf-8">


### PR DESCRIPTION
This PR:

- adds the new GA4 tag for Google Analytics
- this will eventually supersede the Universal Analytics tag
- we will run both in parallel until UA is sunset by Google



