### PR TITLE
TEMP BUG FIX: disable Other Languages field when Keyword Search populated

### DIFF
--- a/ui/admin-portal/src/app/components/search/define-search/define-search.component.html
+++ b/ui/admin-portal/src/app/components/search/define-search/define-search.component.html
@@ -314,7 +314,8 @@
                                                [languages]="languages"
                                                [languageLevels]="languageLevels"
                                                [model]="otherLanguageModel"
-                                               (modelUpdated)="handleLanguageLevelChange($event, 'other')">
+                                               (modelUpdated)="handleLanguageLevelChange($event, 'other')"
+                                               [disable]="elastic()">
               </app-language-level-form-control>
             </div>
 


### PR DESCRIPTION
Hopefully I can fix this bug today, but this is our fail-safe pre-release solution:

<img width="300" alt="Screenshot 2024-03-27 at 8 34 56 am" src="https://github.com/Talent-Catalog/talentcatalog/assets/111261894/0ecdb3ac-2970-4b6e-8f7a-08358d3f8dce">
