### PR TITLE
348 highlight the es search term in the candidate profile

### DIFF
--- a/ui/admin-portal/src/app/components/candidates/view/additional-info/view-candidate-additional-info.component.html
+++ b/ui/admin-portal/src/app/components/candidates/view/additional-info/view-candidate-additional-info.component.html
@@ -25,7 +25,9 @@
   </div>
 
   <div class="card-body">
-    <p>{{candidate?.additionalInfo}}</p>
+    <p [innerHtml]="candidate?.additionalInfo"
+       appHighlightSearch>
+    </p>
   </div>
 
 </div>

--- a/ui/admin-portal/src/app/components/candidates/view/certification/view-candidate-certification.component.html
+++ b/ui/admin-portal/src/app/components/candidates/view/certification/view-candidate-certification.component.html
@@ -42,7 +42,10 @@
     <div *ngFor="let candidateCertification of candidateCertifications">
       <div class="row">
         <div class="col-6">
-          <span class="card-title">{{candidateCertification.name}}</span>
+          <span class="card-title"
+                [innerHtml]="candidateCertification.name"
+                appHighlightSearch>
+          </span>
         </div>
 
         <div class="col-6">
@@ -58,7 +61,10 @@
 
       <div class="row">
         <div class="col-sm-12 col-md-6">
-          <label class="col-form-label text-muted card-subtitle">{{candidateCertification.institution}}</label>
+          <label class="col-form-label text-muted card-subtitle"
+                 [innerHtml]="candidateCertification.institution"
+                 appHighlightSearch>
+          </label>
         </div>
       </div>
       <div class="row">

--- a/ui/admin-portal/src/app/components/candidates/view/contact/view-candidate-contact.component.html
+++ b/ui/admin-portal/src/app/components/candidates/view/contact/view-candidate-contact.component.html
@@ -42,19 +42,31 @@
 
         <div class="form-control-plaintext address">
 
-          <span class="field" *ngIf="candidate.address1">{{candidate.address1}}</span>
+          <span class="field" *ngIf="candidate.address1"
+                [innerHtml]="candidate.address1"
+                appHighlightSearch>
+          </span>
 
           <span class="comma"></span>
 
-          <span class="field" *ngIf="candidate.city">{{candidate.city}}</span>
+          <span class="field" *ngIf="candidate.city"
+                [innerHtml]="candidate.city"
+                appHighlightSearch>
+          </span>
 
           <span class="comma"></span>
 
-          <span class="field" *ngIf="candidate.state">{{candidate.state}}</span>
+          <span class="field" *ngIf="candidate.state"
+                [innerHtml]="candidate.state"
+                appHighlightSearch>
+          </span>
 
           <span class="comma"></span>
 
-          <span class="field" *ngIf="candidate.country">{{candidate.country?.name}}</span>
+          <span class="field" *ngIf="candidate.country"
+                [innerHtml]="candidate.country?.name"
+                appHighlightSearch>
+          </span>
 
         </div>
       </div>
@@ -63,7 +75,9 @@
         <label class="col-form-label"><i class="fas fa-user"></i>Gender</label>
 
         <div class="form-control-plaintext">
-          <span>{{candidate.gender}}</span>
+          <span [innerHtml]="candidate.gender"
+                appHighlightSearch>
+          </span>
         </div>
       </div>
 
@@ -79,7 +93,9 @@
         <label class="col-form-label"><i class="fas fa-phone"></i>Phone</label>
 
         <div class="form-control-plaintext">
-          <span>{{candidate.phone}}</span>
+          <span [innerHtml]="candidate.phone"
+                appHighlightSearch>
+          </span>
         </div>
       </div>
 
@@ -87,7 +103,9 @@
         <label class="col-form-label"><i class="fab fa-whatsapp"></i>Whatsapp</label>
 
         <div class="form-control-plaintext">
-          <span>{{candidate.whatsapp}}</span>
+          <span [innerHtml]="candidate.whatsapp"
+                appHighlightSearch>
+          </span>
         </div>
       </div>
 
@@ -95,7 +113,9 @@
         <label class="col-form-label"><i class="fas fa-globe"></i>Country of Nationality</label>
 
         <div class="form-control-plaintext">
-          <span>{{candidate.nationality?.name}}</span>
+          <span [innerHtml]="candidate.nationality?.name"
+                appHighlightSearch>
+          </span>
         </div>
       </div>
 
@@ -112,7 +132,9 @@
         <label class="col-form-label"><i class="fas fa-envelope"></i>Email</label>
 
         <div class="form-control-plaintext">
-          <span>{{candidate.user.email}}</span>
+          <span [innerHtml]="candidate.user.email"
+                appHighlightSearch>
+          </span>
         </div>
       </div>
 

--- a/ui/admin-portal/src/app/components/candidates/view/education/view-candidate-education.component.html
+++ b/ui/admin-portal/src/app/components/candidates/view/education/view-candidate-education.component.html
@@ -51,9 +51,15 @@
       <div class="row">
 
         <div class="col-6">
-          <span class="card-title">{{edu.educationType}} in {{edu.educationMajor?.name}} : {{edu.courseName}}</span>
+          <span class="card-title"
+                [innerHtml]="edu.educationType + ' in ' + edu.educationMajor?.name + ' : ' + edu.courseName"
+                appHighlightSearch>
+          </span>
           <div class="col-12">
-            <span class="text-muted">{{edu.institution}}, {{edu.country.name}}</span>
+            <span class="text-muted"
+                  [innerHtml]="edu.institution + ', ' + edu.country.name"
+                  appHighlightSearch>
+            </span>
           </div>
 
           <div class="col-12">
@@ -85,7 +91,10 @@
 
   </div>
   <div *ngIf="candidate.migrationEducationMajor" class="card-footer">
-      <span class="text-muted">Migrated Major: {{candidate.migrationEducationMajor.name}}</span>
+      <span class="text-muted"
+            [innerHtml]="'Migrated Major: ' +candidate.migrationEducationMajor.name"
+            appHighlightSearch>
+      </span>
   </div>
 
 </div>

--- a/ui/admin-portal/src/app/components/candidates/view/language/view-candidate-language.component.html
+++ b/ui/admin-portal/src/app/components/candidates/view/language/view-candidate-language.component.html
@@ -40,8 +40,9 @@
       <!-- LANGUAGE CARDS -->
       <ng-container *ngFor="let language of candidateLanguages; let i = index;">
         <div class="row">
-          <div class="col-10 mb-2">
-            {{language.language.name}}
+          <div class="col-10 mb-2"
+               [innerHtml]="language.language.name"
+               appHighlightSearch>
           </div>
           <div class="col-2" *ngIf="editable">
             <div class="btn-group float-end">
@@ -58,14 +59,19 @@
           </div>
         </div>
         <div class="row">
-          <div class="col-12" *ngIf="language.migrationLanguage">
-            Migrated Language: {{language.migrationLanguage}}
+          <div class="col-12" *ngIf="language.migrationLanguage"
+               [innerHtml]="'Migrated Language:' + language.migrationLanguage"
+               appHighlightSearch>
           </div>
           <div class="col-sm-12 col-md-6">
-            <span>Speaking: <i>{{language.spokenLevel.name}}</i></span>
+            <span>Speaking:
+              <i [innerHtml]="language.spokenLevel.name" appHighlightSearch></i>
+            </span>
           </div>
           <div class="col-sm-12 col-md-6">
-            <span>Reading and Writing: <i>{{language.writtenLevel.name}}</i></span>
+            <span>Reading and Writing:
+              <i [innerHtml]="language.writtenLevel.name" appHighlightSearch></i>
+            </span>
           </div>
         </div>
         <hr *ngIf="i < candidateLanguages?.length - 1">
@@ -94,17 +100,23 @@
   </p>
   <ng-container *ngFor="let language of candidateLanguages; let i = index;">
     <div class="row">
-      <div class="col-sm-11">
-        {{language.language.name}}
+      <div class="col-sm-11"
+           [innerHtml]="language.language.name"
+           appHighlightSearch>
       </div>
-      <div class="col-12" *ngIf="language.migrationLanguage">
-        Migrated Language: {{language.migrationLanguage}}
+      <div class="col-12" *ngIf="language.migrationLanguage"
+           [innerHtml]="'Migrated Language: ' + language.migrationLanguage"
+           appHighlightSearch>
       </div>
       <div class="col-sm-12 col-md-6">
-        <span>Speaking: <i>{{language.spokenLevel.name}}</i></span>
+        <span>Speaking:
+          <i [innerHtml]="language.spokenLevel.name" appHighlightSearch></i>
+        </span>
       </div>
       <div class="col-sm-12 col-md-6">
-        <span>Reading and Writing: <i>{{language.writtenLevel.name}}</i></span>
+        <span>Reading and Writing:
+          <i [innerHtml]="language.writtenLevel.name" appHighlightSearch></i>
+        </span>
       </div>
     </div>
     <hr *ngIf="i < candidateLanguages?.length - 1">

--- a/ui/admin-portal/src/app/components/candidates/view/media/view-candidate-media-willingness.component.html
+++ b/ui/admin-portal/src/app/components/candidates/view/media/view-candidate-media-willingness.component.html
@@ -9,7 +9,9 @@
   </div>
 
   <div class="card-body">
-    <p>{{candidate?.mediaWillingness}}</p>
+    <p [innerHtml]="candidate?.mediaWillingness"
+       appHighlightSearch>
+    </p>
   </div>
 
 </div>

--- a/ui/admin-portal/src/app/components/candidates/view/occupation/experience/view-candidate-job-experience.component.html
+++ b/ui/admin-portal/src/app/components/candidates/view/occupation/experience/view-candidate-job-experience.component.html
@@ -58,8 +58,14 @@
       <div class="row">
 
         <div class="col-10">
-          <h6 class="card-title">{{experience.role}}</h6>
-          <p *ngIf="experience.description" [ngClass]="isHtml(experience?.description)?'html':'text'" [innerHtml]="experience.description"></p>
+          <h6 class="card-title"
+              [innerHtml]="experience.role"
+              appHighlightSearch>
+          </h6>
+          <p *ngIf="experience.description" [ngClass]="isHtml(experience?.description)?'html':'text'"
+             [innerHtml]="experience.description"
+             appHighlightSearch>
+          </p>
           <small class="text-muted">
             {{experience.startDate | date: 'customMonthYear' }} - {{experience.endDate | date: 'customMonthYear' }}
           </small>
@@ -83,7 +89,10 @@
 
 
         <div class="col-12">
-          <span class="font-italic">{{experience.companyName}}, {{experience.country.name}}</span>
+          <span class="font-italic"
+                [innerHtml]="experience.companyName + ', ' + experience.country.name"
+                appHighlightSearch>
+          </span>
         </div>
 
         <div class="col-12">

--- a/ui/admin-portal/src/app/components/candidates/view/registration/view-candidate-registration.component.html
+++ b/ui/admin-portal/src/app/components/candidates/view/registration/view-candidate-registration.component.html
@@ -39,8 +39,9 @@
 
         <div class="form-control-plaintext">
           <span>
-            <a target="_blank" [href]="candidate.user.partner.websiteUrl">
-            {{candidate.user.partner.name}} ({{candidate.user.partner.abbreviation}})
+            <a target="_blank" [href]="candidate.user.partner.websiteUrl"
+               [innerHtml]="candidate.user.partner.name + ' ' + candidate.user.partner.abbreviation"
+               appHighlightSearch>
             </a>
           </span>
         </div>
@@ -50,7 +51,10 @@
         <label class="col-form-label"><i class="fas fa-id-badge"></i>Partner's id for candidate</label>
 
         <div class="form-control-plaintext">
-          <span *ngIf="candidate.partnerRef">{{candidate.partnerRef}}</span>
+          <span *ngIf="candidate.partnerRef"
+                [innerHtml]="candidate.partnerRef"
+                appHighlightSearch>
+          </span>
         </div>
       </div>
 
@@ -58,7 +62,13 @@
         <label class="col-form-label"><i class="fas fa-id-badge"></i>External Id</label>
 
         <div class="form-control-plaintext">
-          <span>{{candidate.externalId}}</span><span *ngIf="candidate.externalIdSource">: {{candidate.externalIdSource}}</span>
+          <span
+              [innerHtml]="candidate.externalId"
+              appHighlightSearch>
+          </span>
+          <span *ngIf="candidate.externalIdSource"
+                [innerHtml]="': ' + candidate.externalIdSource"
+                appHighlightSearch></span>
         </div>
       </div>
 
@@ -66,7 +76,11 @@
         <label class="col-form-label"><i class="far fa-registered"></i>UNHCR Registered</label>
 
         <div class="form-control-plaintext">
-          <span>{{candidate.unhcrRegistered}}</span><span *ngIf="candidate.unhcrNumber && candidate.unhcrRegistered === 'Yes'"> - #{{candidate.unhcrNumber}}</span>
+          <span>{{candidate.unhcrRegistered}}</span>
+          <span *ngIf="candidate.unhcrNumber && candidate.unhcrRegistered === 'Yes'"
+                [innerHtml]="' - #' + candidate.unhcrNumber"
+                appHighlightSearch>
+          </span>
         </div>
       </div>
 
@@ -74,7 +88,11 @@
         <label class="col-form-label"><i class="far fa-registered"></i>UNRWA Registered</label>
 
         <div class="form-control-plaintext">
-          <span>{{candidate.unrwaRegistered}}</span><span *ngIf="candidate.unrwaNumber && candidate.unrwaRegistered === 'Yes'"> - #{{candidate.unrwaNumber}}</span>
+          <span>{{candidate.unrwaRegistered}}</span>
+          <span *ngIf="candidate.unrwaNumber && candidate.unrwaRegistered === 'Yes'"
+                [innerHtml]="' - #' + candidate.unrwaNumber"
+                appHighlightSearch>
+          </span>
         </div>
       </div>
 
@@ -98,7 +116,9 @@
         <label class="col-form-label"><i class="fas fa-question"></i>Partner Query Parameter</label>
 
         <div class="form-control-plaintext">
-          <span>{{candidate.regoPartnerParam}}</span>
+          <span [innerHtml]="candidate.regoPartnerParam"
+                appHighlightSearch>
+          </span>
         </div>
       </div>
 
@@ -106,7 +126,9 @@
         <label class="col-form-label"><i class="fas fa-question"></i>Referrer Query Parameter</label>
 
         <div class="form-control-plaintext">
-          <span>{{candidate.regoReferrerParam}}</span>
+          <span [innerHtml]="candidate.regoReferrerParam"
+                appHighlightSearch>
+          </span>
         </div>
       </div>
 
@@ -114,7 +136,9 @@
         <label class="col-form-label"><i class="fas fa-question"></i>UTM Campaign</label>
 
         <div class="form-control-plaintext">
-          <span>{{candidate.regoUtmCampaign}}</span>
+          <span [innerHtml]="candidate.regoUtmCampaign"
+                appHighlightSearch>
+          </span>
         </div>
       </div>
 
@@ -122,7 +146,9 @@
         <label class="col-form-label"><i class="fas fa-question"></i>UTM Content</label>
 
         <div class="form-control-plaintext">
-          <span>{{candidate.regoUtmContent}}</span>
+          <span [innerHtml]="candidate.regoUtmContent"
+                appHighlightSearch>
+          </span>
         </div>
       </div>
 
@@ -130,7 +156,9 @@
         <label class="col-form-label"><i class="fas fa-question"></i>UTM Medium</label>
 
         <div class="form-control-plaintext">
-          <span>{{candidate.regoUtmMedium}}</span>
+          <span [innerHtml]="candidate.regoUtmMedium"
+                appHighlightSearch>
+          </span>
         </div>
       </div>
 
@@ -138,7 +166,9 @@
         <label class="col-form-label"><i class="fas fa-question"></i>UTM Source</label>
 
         <div class="form-control-plaintext">
-          <span>{{candidate.regoUtmSource}}</span>
+          <span [innerHtml]="candidate.regoUtmSource"
+                appHighlightSearch>
+          </span>
         </div>
       </div>
 
@@ -146,7 +176,9 @@
         <label class="col-form-label"><i class="fas fa-question"></i>UTM Term</label>
 
         <div class="form-control-plaintext">
-          <span>{{candidate.regoUtmTerm}}</span>
+          <span [innerHtml]="candidate.regoUtmTerm"
+                appHighlightSearch>
+          </span>
         </div>
       </div>
 

--- a/ui/admin-portal/src/app/components/candidates/view/skill/view-candidate-skill.component.html
+++ b/ui/admin-portal/src/app/components/candidates/view/skill/view-candidate-skill.component.html
@@ -35,8 +35,14 @@
       </div>
     </div>
     <div class="row" *ngFor="let skill of candidateSkills">
-      <div class="col-6">{{skill.skill}}</div>
-      <div class="col-6">{{skill.timePeriod}} years</div>
+      <div class="col-6"
+           [innerHtml]="skill.skill"
+           appHighlightSearch>
+      </div>
+      <div class="col-6"
+           [innerHtml]="skill.timePeriod + ' years'"
+           appHighlightSearch>
+      </div>
     </div>
   </div>
 </div>

--- a/ui/admin-portal/src/app/components/candidates/view/survey/view-candidate-survey.component.html
+++ b/ui/admin-portal/src/app/components/candidates/view/survey/view-candidate-survey.component.html
@@ -29,13 +29,19 @@
       <div class="mb-3 col-sm-12 col-md-6">
         <label class="col-form-label">Source:</label>
         <div >
-          <span class="form-control-plaintext">{{candidate?.surveyType?.name}}</span>
+          <span class="form-control-plaintext"
+                [innerHtml]="candidate?.surveyType?.name"
+                appHighlightSearch>
+          </span>
         </div>
       </div>
       <div class="mb-3 col-sm-12 col-md-6">
         <label class="col-form-label">Comment:</label>
         <div >
-          <span class="form-control-plaintext">{{candidate?.surveyComment}}</span>
+          <span class="form-control-plaintext"
+                [innerHtml]="candidate?.surveyComment"
+                appHighlightSearch>
+          </span>
         </div>
       </div>
 

--- a/ui/admin-portal/src/app/components/search/define-search/define-search.component.ts
+++ b/ui/admin-portal/src/app/components/search/define-search/define-search.component.ts
@@ -82,7 +82,7 @@ import {Partner} from "../../../model/partner";
 import {PartnerService} from "../../../services/partner.service";
 import {AuthenticationService} from "../../../services/authentication.service";
 import {SearchQueryService} from "../../../services/search-query.service";
-import {debounceTime, distinctUntilChanged, takeUntil} from "rxjs/operators";
+import {first} from "rxjs/operators";
 
 @Component({
   selector: 'app-define-search',
@@ -215,12 +215,10 @@ export class DefineSearchComponent implements OnInit, OnChanges, OnDestroy {
     this.loading = true;
     this.error = null;
 
-    this.searchForm.valueChanges.pipe(
-      debounceTime(300),
-      distinctUntilChanged(),
-      takeUntil(this.destroy$)
-    ).subscribe(value => {
-      this.searchQueryService.changeSearchQuery(value.simpleQueryString || '');
+    this.searchForm.get('simpleQueryString').valueChanges.pipe(
+        first()
+    ).subscribe(initialValue => {
+      this.searchQueryService.changeSearchQuery(initialValue || '');
     });
 
     const partnerRequest: SearchPartnerRequest = {sourcePartner: true};
@@ -337,6 +335,8 @@ export class DefineSearchComponent implements OnInit, OnChanges, OnDestroy {
     //See the html of this component, for which <app-show-candidates takes
     //searchRequest as an input.
     this.searchRequest = request;
+
+    this.searchQueryService.changeSearchQuery(this.searchForm.value.simpleQueryString || '');
   }
 
   getIdsMultiSelect(request): SearchCandidateRequestPaged {

--- a/ui/admin-portal/src/app/components/search/define-search/define-search.component.ts
+++ b/ui/admin-portal/src/app/components/search/define-search/define-search.component.ts
@@ -19,7 +19,6 @@ import {
   ElementRef,
   Input,
   OnChanges,
-  OnDestroy,
   OnInit,
   SimpleChanges,
   ViewChild
@@ -38,7 +37,7 @@ import {FormArray, FormBuilder, FormGroup} from '@angular/forms';
 import {SearchSavedSearchesComponent} from '../load-search/search-saved-searches.component';
 import {CreateUpdateSearchComponent} from '../create-update/create-update-search.component';
 import {SavedSearchService} from '../../../services/saved-search.service';
-import {forkJoin, Subject} from 'rxjs';
+import {forkJoin} from 'rxjs';
 import {JoinSavedSearchComponent} from '../join-search/join-saved-search.component';
 import {EducationLevel} from '../../../model/education-level';
 import {EducationLevelService} from '../../../services/education-level.service';
@@ -89,9 +88,7 @@ import {first} from "rxjs/operators";
   templateUrl: './define-search.component.html',
   styleUrls: ['./define-search.component.scss']
 })
-export class DefineSearchComponent implements OnInit, OnChanges, OnDestroy {
-  private destroy$ = new Subject<void>();
-
+export class DefineSearchComponent implements OnInit, OnChanges {
   @ViewChild('modifiedDate', {static: true}) modifiedDatePicker: DateRangePickerComponent;
   @ViewChild('englishLanguage', {static: true}) englishLanguagePicker: LanguageLevelFormControlComponent;
   @ViewChild('otherLanguage', {static: true}) otherLanguagePicker: LanguageLevelFormControlComponent;
@@ -264,11 +261,6 @@ export class DefineSearchComponent implements OnInit, OnChanges, OnDestroy {
       this.loading = false;
       this.error = error;
     });
-  }
-
-  ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   get simpleQueryString(): string {

--- a/ui/admin-portal/src/app/directives/directive.module.ts
+++ b/ui/admin-portal/src/app/directives/directive.module.ts
@@ -14,13 +14,14 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-import { NgModule } from "@angular/core";
-import { LowercaseDirective } from "./lowercase.directive";
-import { CommonModule } from "@angular/common";
+import {NgModule} from "@angular/core";
+import {LowercaseDirective} from "./lowercase.directive";
+import {CommonModule} from "@angular/common";
+import {HighlightSearchDirective} from './highlight-search.directive';
 
 @NgModule({
-  declarations: [LowercaseDirective],
-  exports: [LowercaseDirective],
+  declarations: [LowercaseDirective, HighlightSearchDirective],
+  exports: [LowercaseDirective, HighlightSearchDirective],
   imports: [CommonModule],
 })
 export class DirectiveModule {}

--- a/ui/admin-portal/src/app/directives/highlight-search.directive.ts
+++ b/ui/admin-portal/src/app/directives/highlight-search.directive.ts
@@ -1,0 +1,126 @@
+import {Directive, ElementRef, OnDestroy, OnInit} from '@angular/core';
+import {SearchQueryService} from "../services/search-query.service";
+import {Subject} from "rxjs";
+import {takeUntil} from "rxjs/operators";
+
+/**
+ * Use this directive to dynamically highlight current elastic search terms within an element's
+ * text content.
+ *
+ * @author sadatmalik
+ */
+@Directive({
+  selector: '[appHighlightSearch]'
+})
+export class HighlightSearchDirective implements OnInit, OnDestroy {
+  private destroy$ = new Subject<void>();
+  private currentSearchTerms = [];
+
+  constructor(
+    private el: ElementRef,
+    private searchQueryService: SearchQueryService
+  ) {}
+
+  ngOnInit(): void {
+    this.searchQueryService.currentSearchTerms.pipe(
+      takeUntil(this.destroy$)
+    ).subscribe(terms => {
+      this.currentSearchTerms = terms;
+      this.applyHighlighting();
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  private removeHighlighting(): void {
+    const highlightedElements = this.el.nativeElement.querySelectorAll('.highlight');
+    highlightedElements.forEach((node: Node) => {
+      const parent = node.parentNode;
+      parent.replaceChild(document.createTextNode(node.textContent), node);
+      parent.normalize();
+    });
+  }
+
+  private applyHighlighting(): void {
+    this.removeHighlighting(); // Clear existing highlights
+    if (!this.currentSearchTerms || this.currentSearchTerms.length === 0) {
+      return;
+    }
+
+    const regex = this.createTermsRegex(this.currentSearchTerms);
+    const textNodes = [];
+    const walk = document.createTreeWalker(this.el.nativeElement, NodeFilter.SHOW_TEXT, null);
+    let node: Node;
+
+    // First, collect all text nodes
+    while (node = walk.nextNode()) {
+      textNodes.push(node);
+    }
+
+    // Then, process each text node for highlighting
+    textNodes.forEach((textNode) => {
+      this.highlightInTextNode(textNode, regex);
+    });
+  }
+
+  private createTermsRegex(searchTerms: string[]): RegExp {
+    // Escape special regex characters in terms then join them with '|' to match any of them
+    const termsRegex = searchTerms.map(term =>
+        term.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&')
+    ).join('|');
+    // Return a regex to find any of the terms
+    return new RegExp(`(${termsRegex})`, 'gi');
+  }
+
+  private highlightInTextNode(node: Node, regex: RegExp): void {
+    if (!regex.test(node.nodeValue))
+      return; // Skip nodes that don't contain the term
+
+    const docFrag = document.createDocumentFragment();
+    let text = node.nodeValue;
+    let startIndex = 0;
+    let match: RegExpExecArray;
+
+    // Reset the lastIndex of the regex to start from the beginning
+    regex.lastIndex = 0;
+
+    try {
+      // Process matches in the text node
+      while ((match = regex.exec(text))) {
+
+        // Add text before the match
+        if (match.index > startIndex) {
+          const beforeMatch = text.slice(startIndex, match.index);
+          docFrag.appendChild(document.createTextNode(beforeMatch));
+        }
+
+        // Create and add a highlighted span for the match
+        const highlightSpan = document.createElement('span');
+        highlightSpan.className = 'highlight';
+        highlightSpan.textContent = match[0];
+        docFrag.appendChild(highlightSpan);
+
+        // Update startIndex to the end of the current match
+        startIndex = match.index + match[0].length;
+      }
+
+      // Add any remaining text after the last match
+      if (startIndex < text.length) {
+        const afterLastMatch = text.slice(startIndex);
+        docFrag.appendChild(document.createTextNode(afterLastMatch));
+      }
+
+      // Replace the original text node with the new content if there was a match
+      if (docFrag.hasChildNodes()) {
+        node.parentNode.replaceChild(docFrag, node);
+      }
+
+    } catch (error) {
+      console.error('Failed to highlight search term: ', error);
+    }
+  }
+
+}

--- a/ui/admin-portal/src/app/services/search-query.service.ts
+++ b/ui/admin-portal/src/app/services/search-query.service.ts
@@ -1,0 +1,77 @@
+import {Injectable} from '@angular/core';
+import {BehaviorSubject, Observable} from "rxjs";
+import {debounceTime, distinctUntilChanged} from "rxjs/operators";
+import {Subject} from "rxjs/index";
+
+@Injectable({
+  providedIn: 'root'
+})
+export class SearchQueryService {
+
+  private searchQueryUpdate = new Subject<string>();
+  private searchTermsSource = new BehaviorSubject<string[]>([]);
+
+  constructor() {
+    this.searchQueryUpdate.pipe(
+      debounceTime(300), // Adjust time based on user experience
+      distinctUntilChanged()
+    ).subscribe(query => {
+      this.processSearchQuery(query);
+    });
+  }
+
+  changeSearchQuery(query: string) {
+    this.searchQueryUpdate.next(query);
+  }
+
+  private processSearchQuery(query: string) {
+    if (query && query.length > 0) {
+      try {
+        const queryArray = this.parseSearchQuery(query);
+        this.searchTermsSource.next(queryArray);
+      } catch (error) {
+        console.error('Failed to parse search query: ' + query, error);
+      }
+    } else {
+      this.searchTermsSource.next([]);
+    }
+  }
+
+  get currentSearchTerms(): Observable<string[]> {
+    return this.searchTermsSource.asObservable();
+  }
+
+  /*
+   * Parses the input search query string based on elastic search syntax. Extracts and returns an
+   * array of search terms and phrases.
+   *
+   * Example input: 'accountant + (excel powerpoint) "hospital director"'
+   * Example output: ["accountant", "excel", "powerpoint", "hospital director"]
+   *
+   * @param {string} query - The search query string entered by the user.
+   * @returns {string[]} An array of search terms and phrases extracted from the input query.
+   */
+  private parseSearchQuery(query): string[] {
+    // Handle phrases in quotes as a single term
+    const phrases = [...query.matchAll(/"([^"]+)"/g)].map(match => match[1]);
+
+    // Remove the phrases from the query to simplify splitting the rest
+    let modifiedQuery = query.replace(/"[^"]+"/g, '');
+
+    // Remove brackets from bracketed expressions
+    modifiedQuery = modifiedQuery.replace(/\(([^)]+)\)/g, '$1');
+
+    // Split by space for OR, and plus for AND, then filter out empty strings and operators
+    const words = modifiedQuery.split(/\s+|\++/).filter(token => token && token !== '+');
+
+    // Combine words and phrases
+    const wordsAndPhrases = words.concat(phrases);
+
+    // Handle wildcard: Remove '*' from the terms
+    const searchTerms = wordsAndPhrases.map(term => term.replace(/\*/g, ''));
+
+    // Sort terms by length, from longest to shortest
+    return searchTerms.sort((a, b) => b.length - a.length);
+  }
+
+}

--- a/ui/admin-portal/src/app/services/search-query.service.ts
+++ b/ui/admin-portal/src/app/services/search-query.service.ts
@@ -1,7 +1,6 @@
 import {Injectable} from '@angular/core';
-import {BehaviorSubject, Observable} from "rxjs";
+import {BehaviorSubject, Observable, Subject} from "rxjs";
 import {debounceTime, distinctUntilChanged} from "rxjs/operators";
-import {Subject} from "rxjs/index";
 
 @Injectable({
   providedIn: 'root'

--- a/ui/admin-portal/src/app/services/search-query.service.ts
+++ b/ui/admin-portal/src/app/services/search-query.service.ts
@@ -1,29 +1,15 @@
 import {Injectable} from '@angular/core';
-import {BehaviorSubject, Observable, Subject} from "rxjs";
-import {debounceTime, distinctUntilChanged} from "rxjs/operators";
+import {BehaviorSubject, Observable} from "rxjs";
 
 @Injectable({
   providedIn: 'root'
 })
 export class SearchQueryService {
-
-  private searchQueryUpdate = new Subject<string>();
   private searchTermsSource = new BehaviorSubject<string[]>([]);
 
-  constructor() {
-    this.searchQueryUpdate.pipe(
-      debounceTime(300), // Adjust time based on user experience
-      distinctUntilChanged()
-    ).subscribe(query => {
-      this.processSearchQuery(query);
-    });
-  }
+  constructor() {}
 
   changeSearchQuery(query: string) {
-    this.searchQueryUpdate.next(query);
-  }
-
-  private processSearchQuery(query: string) {
     if (query && query.length > 0) {
       try {
         const queryArray = this.parseSearchQuery(query);

--- a/ui/admin-portal/src/scss/_variables.scss
+++ b/ui/admin-portal/src/scss/_variables.scss
@@ -25,6 +25,7 @@ $accent2:    #64656d;
 $accent3:    #b2b7bb;
 $success: #03864d;
 $warning: #c7b408;
+$highlight: #ffff00;
 $danger: #a91206;
 
 $accordion-button-bg: fade-out($accent2, 0.4);

--- a/ui/admin-portal/src/styles.scss
+++ b/ui/admin-portal/src/styles.scss
@@ -104,6 +104,10 @@ tr.selected {
   color: $accent2;
 }
 
+.highlight {
+  background-color: $highlight;
+}
+
 /* FONT AWESOME */
 label,a > {
   i.fas,i.fa-solid,i.fab,i.far {


### PR DESCRIPTION
This PR:

- adds a new service that parses and propagates ES search terms
- adds a new directive that applies ES search term highlighting to a given element
- applies the directive to the General, Experience, Education, and Additional Info candidate sidebar tabs
- does not apply the directive to Tasks, Notes, and Jobs sidebar tabs as these are not data provided by the candidate

