### PR TITLE
818 make admin portal reaction pickers open on the buttons instead of as a centered modal

### DIFF
--- a/ui/admin-portal/src/app/components/chat/create-update-post/create-update-post.component.html
+++ b/ui/admin-portal/src/app/components/chat/create-update-post/create-update-post.component.html
@@ -39,7 +39,6 @@
             title="Add emoji...&nbsp;&nbsp;👍"
             [autoFocus]="true"
             [perLine]="8"
-            [emojisToShowFilter]="emojisToShowFilter"
           ></emoji-mart>
         </div>
     </quill-editor>

--- a/ui/admin-portal/src/app/components/chat/create-update-post/create-update-post.component.ts
+++ b/ui/admin-portal/src/app/components/chat/create-update-post/create-update-post.component.ts
@@ -111,9 +111,4 @@ export class CreateUpdatePostComponent implements OnInit {
     }
   }
 
-  // These emojis didn't work for some reason — this function excludes them from the picker.
-  emojisToShowFilter = (emoji: any) => {
-    return emoji.shortName !== 'relaxed' && emoji.shortName !== 'white_frowning_face'
-  }
-
 }

--- a/ui/admin-portal/src/app/components/chat/view-chat-posts/view-chat-posts.component.ts
+++ b/ui/admin-portal/src/app/components/chat/view-chat-posts/view-chat-posts.component.ts
@@ -90,7 +90,11 @@ export class ViewChatPostsComponent extends PostsComponentBase
       if (clickedElementId.includes('reactionBtn') && this.editor.emojiPickerVisible) {
         // If click was on reaction picker toggle button, close the editor picker
         this.editor.emojiPickerVisible = false
-      } else if (!sectionClass.includes('emoji') &&
+      } else if (clickedElementId.includes('emojiBtn') && postWithOpenPicker != null) {
+        // If click was on editor picker toggle button, close the post reaction picker
+        postWithOpenPicker.reactionPickerVisible = false;
+      }
+      else if (!sectionClass.includes('emoji') &&
           !clickedElementId.includes('reactionBtn') &&
           !clickedElementId.includes('emojiBtn')) {
         // If click was not on any emoji picker toggle button or emoji picker, close any open picker

--- a/ui/admin-portal/src/app/components/chat/view-post/view-post.component.html
+++ b/ui/admin-portal/src/app/components/chat/view-post/view-post.component.html
@@ -41,5 +41,4 @@
   emoji="point_up"
   title="Add emoji..."
   [autoFocus]="true"
-  [emojisToShowFilter]="emojisToShowFilter"
 ></emoji-mart>

--- a/ui/admin-portal/src/app/components/chat/view-post/view-post.component.html
+++ b/ui/admin-portal/src/app/components/chat/view-post/view-post.component.html
@@ -10,7 +10,7 @@
     id="reactionBtn"
     [ngClass]="!this.reactionPickerVisible ?
     'reaction-btn' : 'reaction-btn-selected'"
-    (click)="onClickReactionBtn()">
+    (click)="onClickReactionBtn($event)">
       <i id="reactionBtnSmiley" class="fa-regular fa-face-smile fa-xs">
       <i id="reactionBtnPlus" class="fa-solid fa-plus fa-2xs"></i></i>
     </button>
@@ -35,6 +35,7 @@
 
 <emoji-mart
   id="reactionPicker"
+  [ngStyle]="{'left': reactionPickerXPos + 'px', 'top': reactionPickerYPos + 'px'}"
   *ngIf="reactionPickerVisible"
   (emojiClick)="onSelectEmoji($event)"
   emoji="point_up"
@@ -42,5 +43,3 @@
   [autoFocus]="true"
   [emojisToShowFilter]="emojisToShowFilter"
 ></emoji-mart>
-
-<div *ngIf="reactionPickerVisible" class="overlay"></div>

--- a/ui/admin-portal/src/app/components/chat/view-post/view-post.component.scss
+++ b/ui/admin-portal/src/app/components/chat/view-post/view-post.component.scss
@@ -48,22 +48,11 @@ button.update-reaction-btn:hover {
 
 emoji-mart#reactionPicker {
   position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  z-index: 3;
+  left: 0;
+  top: 0;
+  z-index: 1050;
 }
 
 div#reactionTooltipEmoji {
   font-size: xx-large;
-}
-
-.overlay {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background-color: rgba(0, 0, 0, 0.5);
-  z-index: 2;
 }

--- a/ui/admin-portal/src/app/components/chat/view-post/view-post.component.ts
+++ b/ui/admin-portal/src/app/components/chat/view-post/view-post.component.ts
@@ -113,11 +113,6 @@ export class ViewPostComponent implements OnInit, OnChanges {
                           })
   }
 
-  // These emojis don't work for some reason — this function excludes them from the picker.
-  emojisToShowFilter = (emoji: any) => {
-    return emoji.shortName !== 'relaxed' && emoji.shortName !== 'white_frowning_face'
-  }
-
   private setIsCurrentPostClosePickerIfFalse(currentPost: ChatPost) {
     this.isCurrentPost = currentPost === this.post;
     if (!this.isCurrentPost) {

--- a/ui/admin-portal/src/app/components/chat/view-post/view-post.component.ts
+++ b/ui/admin-portal/src/app/components/chat/view-post/view-post.component.ts
@@ -73,19 +73,20 @@ export class ViewPostComponent implements OnInit, OnChanges {
     return UserService.userToString(user, false, false);
   }
 
-  // Toggles the picker on and off, situating it appropriately
-  // The picker's height is 425px, so using that here to calculate where it should appear
+  // Toggles the picker on and off, situating it appropriately in relation to the button
+  // The picker's height is 353 x 425 px, navbar is 85px
   public onClickReactionBtn(event) {
     if (event.clientY < 510 && window.innerHeight - event.clientY < 425) {
       // Won't fit above, won't fit below - place halfway
-      this.reactionPickerYPos = event.clientY -213
+      this.reactionPickerYPos = event.clientY - 213;
     } else if (window.innerHeight - event.clientY < 425 && event.clientY > 510) {
       // Won't fit below, will fit above - place above
       this.reactionPickerYPos = event.clientY - 425;
     } else {
-      // Will fit below, won't fit above - place below
+      // Will fit below, won't fit above OR will fit either side - place below
       this.reactionPickerYPos = event.clientY;
     }
+    // Always place to the left of the button without concealing it
     this.reactionPickerXPos = event.clientX - 370;
     this.reactionPickerVisible = !this.reactionPickerVisible;
   }

--- a/ui/admin-portal/src/app/components/chat/view-post/view-post.component.ts
+++ b/ui/admin-portal/src/app/components/chat/view-post/view-post.component.ts
@@ -74,12 +74,12 @@ export class ViewPostComponent implements OnInit, OnChanges {
   }
 
   // Toggles the picker on and off, situating it appropriately
+  // The picker's height is 425px, so using that here to calculate where it should appear
   public onClickReactionBtn(event) {
-    console.log(event.clientY)
-    if (event.clientY < 510 && window.screen.availHeight - event.clientY < 480) {
+    if (event.clientY < 510 && window.innerHeight - event.clientY < 425) {
       // Won't fit above, won't fit below - place halfway
       this.reactionPickerYPos = event.clientY -213
-    } else if (window.screen.availHeight - event.clientY < 480 && event.clientY > 510) {
+    } else if (window.innerHeight - event.clientY < 425 && event.clientY > 510) {
       // Won't fit below, will fit above - place above
       this.reactionPickerYPos = event.clientY - 425;
     } else {

--- a/ui/candidate-portal/src/app/components/chat/create-update-post/create-update-post.component.html
+++ b/ui/candidate-portal/src/app/components/chat/create-update-post/create-update-post.component.html
@@ -54,7 +54,6 @@
             title="Add emoji..."
             [autoFocus]="true"
             [perLine]="8"
-            [emojisToShowFilter]="emojisToShowFilter"
           ></emoji-mart>
         </span>
       </div>

--- a/ui/candidate-portal/src/app/components/chat/create-update-post/create-update-post.component.ts
+++ b/ui/candidate-portal/src/app/components/chat/create-update-post/create-update-post.component.ts
@@ -134,9 +134,4 @@ export class CreateUpdatePostComponent implements OnInit {
     }
   }
 
-  // These emojis didn't work for some reason — this function excludes them from the picker.
-  emojisToShowFilter = (emoji: any) => {
-    return emoji.shortName !== 'relaxed' && emoji.shortName !== 'white_frowning_face'
-  }
-
 }

--- a/ui/candidate-portal/src/app/components/chat/view-post/view-post.component.html
+++ b/ui/candidate-portal/src/app/components/chat/view-post/view-post.component.html
@@ -39,7 +39,6 @@
   emoji="point_up"
   title="Add emoji..."
   [autoFocus]="true"
-  [emojisToShowFilter]="emojisToShowFilter"
 ></emoji-mart>
 
 <div *ngIf="reactionPickerVisible" class="overlay"></div>

--- a/ui/candidate-portal/src/app/components/chat/view-post/view-post.component.ts
+++ b/ui/candidate-portal/src/app/components/chat/view-post/view-post.component.ts
@@ -85,11 +85,6 @@ export class ViewPostComponent implements OnInit {
                           })
   }
 
-  // These emojis don't work for some reason — this function excludes them from the picker.
-  emojisToShowFilter = (emoji: any) => {
-    return emoji.shortName !== 'relaxed' && emoji.shortName !== 'white_frowning_face'
-  }
-
   // Below commented-out methods and class property were closing unwanted emoji pickers.
   // Leaving them here as they're likely to be useful for future styling and functionality.
   // Used in conjunction with @Input currentPost.


### PR DESCRIPTION
- Reinstates and refines the logic to ensure that no two pickers are open at the same time
- Reaction emoji picker opens to the left of the appropriate button, with y position set to avoid concealment by navbar or cutoff at the bottom of the screen