### PR TITLE
840 emails not sending in prod

### DIFF
--- a/.idea/aws.xml
+++ b/.idea/aws.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="accountSettings">
+    <option name="activeProfile" value="profile:default" />
     <option name="activeRegion" value="us-east-1" />
     <option name="recentlyUsedProfiles">
       <list>

--- a/server/src/main/java/org/tctalent/server/service/db/email/EmailHelper.java
+++ b/server/src/main/java/org/tctalent/server/service/db/email/EmailHelper.java
@@ -24,8 +24,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
 import org.tctalent.server.exception.EmailSendFailedException;
-import org.tctalent.server.model.db.Role;
 import org.tctalent.server.model.db.JobChat;
+import org.tctalent.server.model.db.Role;
 import org.tctalent.server.model.db.SavedSearch;
 import org.tctalent.server.model.db.User;
 import org.tctalent.server.model.db.partner.Partner;
@@ -101,7 +101,7 @@ public class EmailHelper {
             ctx.setVariable("resetUrl", resetUrl + "/reset-password/" + token);
             ctx.setVariable("year", currentYear());
 
-            subject = "Talent Beyond Boundaries - Reset Your Password";
+            subject = "Talent Catalog - Reset Your Password";
             bodyText = textTemplateEngine.process("reset-password", ctx);
             bodyHtml = htmlTemplateEngine.process("reset-password", ctx);
 


### PR DESCRIPTION
The code changes in this PR are not in fact related to fixing the issue. The issue was fixing just using configuration - see comments in issue.

The only code change in this PR is to change the subject heading of the password reset email from Talent Beyond Boundaries - Reset ...
to Talent Catalog - Reset... 