### PR TITLE
hotfix - set hikari cp max lifetime

### DIFF
--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -65,7 +65,7 @@ spring:
     hikari:
       maximum-pool-size: ${SPRING_DBPOOL_MAX:10}
       minimum-idle:  ${SPRING_DBPOOL_MIN:10}
-      maxLifetime: ${SPRING_DBPOOL_MAX_LIFETIME:1800000} # 30 minutes
+      max-lifetime: ${SPRING_DBPOOL_MAX_LIFETIME:1800000} # 30 minutes
 
 #  To catch resource not found errors (404)
 #  See https://stackoverflow.com/questions/36733254/spring-boot-rest-how-to-configure-404-resource-not-found/36734193#36734193

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -65,6 +65,7 @@ spring:
     hikari:
       maximum-pool-size: ${SPRING_DBPOOL_MAX:10}
       minimum-idle:  ${SPRING_DBPOOL_MIN:10}
+      maxLifetime: ${SPRING_DBPOOL_MAX_LIFETIME:1800000} # 30 minutes
 
 #  To catch resource not found errors (404)
 #  See https://stackoverflow.com/questions/36733254/spring-boot-rest-how-to-configure-404-resource-not-found/36734193#36734193


### PR DESCRIPTION
This PR:

- adds explicit configuration for hikari db connection lifetime
- aws task revision 24 sets the corresponding property
- the service should be restarted with task definition 24 when this PR is merged and deployed
- the change has already been applied to prod - this is a hotfix branch to apply the same configuration to staging