### PR TITLE
Add python venv to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@
 
 ### END John Camerons extra changes
 
+# Python virtual environment
+infra/elasticsearch/tc_env*
 
 # User-specific stuff
 .idea/**/workspace.xml


### PR DESCRIPTION
Line to avoid python venv ending up in git.
Also avoids having > 700 files showing as uncommitted and accidently missing adding/committing files that should be in the repo. 