### PR TITLE
Commons logging exclusion

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -52,6 +52,10 @@ repositories {
     mavenCentral()
 }
 
+configurations.configureEach {
+    exclude group: "commons-logging", module: "commons-logging"
+}
+
 dependencies {
 
     //Instead of defaulting Lombok version, specify recent Lombok version to address this issue:


### PR DESCRIPTION
To avoid classpath clashes following split of elastic and spring.