### PR TITLE
Replace future deleted class with replacement

### DIFF
--- a/server/src/test/java/org/tctalent/server/repository/es/CandidateEsRepositoryTest.java
+++ b/server/src/test/java/org/tctalent/server/repository/es/CandidateEsRepositoryTest.java
@@ -21,6 +21,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.ElasticsearchRestTemplate;
 import org.springframework.data.elasticsearch.core.SearchHits;
 import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
@@ -46,7 +47,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 public class CandidateEsRepositoryTest {
 
     @Autowired
-    private ElasticsearchRestTemplate elasticsearchTemplate;
+    private ElasticsearchOperations elasticsearchOperations;
 
     @Autowired
     private CandidateRepository candidateRepository;
@@ -78,7 +79,7 @@ public class CandidateEsRepositoryTest {
                 .withQuery(fuzzyQuery("candidateAttachments", "Condell"))
                 .build();
 
-        final SearchHits<CandidateEs> cands = elasticsearchTemplate
+        final SearchHits<CandidateEs> cands = elasticsearchOperations
                 .search(searchQuery, CandidateEs.class, IndexCoordinates.of("jobs2"));
 
         assertEquals(1, cands.getTotalHits());


### PR DESCRIPTION
As part of the upgrade, the rest template class used is deleted in version 5. It has been deprecated for some time. 
Putting this small change through to minimise other bigger changes.