### PR TITLE
Fix User Creation Error When Partner Not Selected

### DIFF
--- a/server/src/main/java/org/tctalent/server/service/db/impl/UserServiceImpl.java
+++ b/server/src/main/java/org/tctalent/server/service/db/impl/UserServiceImpl.java
@@ -236,15 +236,8 @@ public class UserServiceImpl implements UserService {
                 }
             }
         } else {
-            //If user does not already have a source partner, assign one
-            if (currentPartner == null) {
-                if (creatingUser == null) {
-                    //If we do not know who created this user, set up a default partner
-                    newSourcePartner = partnerService.getDefaultSourcePartner();
-                } else {
-                    newSourcePartner = creatingUser.getPartner();
-                }
-            }
+            //Throw an exception if no partner is specified
+            throw new InvalidRequestException("A partner must be specified.");
         }
         //If we have a new source partner, update it.
         if (newSourcePartner != null) {

--- a/ui/admin-portal/src/app/components/settings/users/create-update-user/create-update-user.component.ts
+++ b/ui/admin-portal/src/app/components/settings/users/create-update-user/create-update-user.component.ts
@@ -59,7 +59,7 @@ export class CreateUpdateUserComponent implements OnInit {
       username: [this.user?.username, Validators.required],
       firstName: [this.user?.firstName, Validators.required],
       lastName: [this.user?.lastName, Validators.required],
-      partnerId: [this.user?.partner.id],
+      partnerId: [this.user?.partner.id, Validators.required],
       status: [this.user? this.user.status : Status.active],
       role: [this.user?.role, Validators.required],
       jobCreator: [this.user ? this.user.jobCreator : false],


### PR DESCRIPTION
**Fixed Both Front-End and Server-Side Code for User Creation When no Partner is specified**
- Ensure the Save button remains inactive if a partner is not specified during user creation.
- Implement server-side validation to throw an exception when no partner is specified, instead of attempting to apply a default partner.