### PR TITLE
Ensure the comparisons are against like types.

### DIFF
--- a/server/src/main/java/org/tctalent/server/repository/db/CandidateSpecification.java
+++ b/server/src/main/java/org/tctalent/server/repository/db/CandidateSpecification.java
@@ -221,10 +221,10 @@ public class CandidateSpecification {
             if (!Collections.isEmpty(request.getNationalityIds())) {
                 if (request.getNationalitySearchType() == null || SearchType.or.equals(request.getNationalitySearchType())) {
                     conjunction.getExpressions().add(
-                            builder.isTrue(candidate.get("nationality").in(request.getNationalityIds()))
+                            builder.isTrue(candidate.get("nationality").get("id").in(request.getNationalityIds()))
                     );
                 } else {
-                    conjunction.getExpressions().add(candidate.get("nationality").in(request.getNationalityIds()).not()
+                    conjunction.getExpressions().add(candidate.get("nationality").get("id").in(request.getNationalityIds()).not()
                     );
                 }
             }
@@ -235,10 +235,10 @@ public class CandidateSpecification {
             if (!Collections.isEmpty(request.getCountryIds())) {
                 if (request.getCountrySearchType() == null || SearchType.or.equals(request.getCountrySearchType())) {
                     conjunction.getExpressions().add(
-                        builder.isTrue(candidate.get("country").in(request.getCountryIds()))
+                        builder.isTrue(candidate.get("country").get("id").in(request.getCountryIds()))
                     );
                 } else {
-                    conjunction.getExpressions().add(candidate.get("country").in(request.getCountryIds()).not());
+                    conjunction.getExpressions().add(candidate.get("country").get("id").in(request.getCountryIds()).not());
                 }
             // If request ids IS EMPTY only show source countries
             } else if (loggedInUser != null &&
@@ -251,7 +251,7 @@ public class CandidateSpecification {
             // PARTNER SEARCH
             if (!Collections.isEmpty(request.getPartnerIds())) {
                 conjunction.getExpressions().add(
-                    builder.isTrue(user.get("partner").in(request.getPartnerIds()))
+                    builder.isTrue(user.get("partner").get("id").in(request.getPartnerIds()))
                 );
             }
 

--- a/server/src/main/java/org/tctalent/server/repository/db/GetSavedListsQuery.java
+++ b/server/src/main/java/org/tctalent/server/repository/db/GetSavedListsQuery.java
@@ -116,7 +116,7 @@ public class GetSavedListsQuery implements Specification<SavedList> {
         if (request.getOwned() != null && request.getOwned()) {
             if (loggedInUser != null) {
                 ors.getExpressions().add(
-                        cb.equal(savedList.get("createdBy"), loggedInUser.getId())
+                        cb.equal(savedList.get("createdBy"), loggedInUser)
                 );
             }
         }

--- a/server/src/main/java/org/tctalent/server/repository/db/SavedSearchSpecification.java
+++ b/server/src/main/java/org/tctalent/server/repository/db/SavedSearchSpecification.java
@@ -131,7 +131,7 @@ public class SavedSearchSpecification {
             if (request.getOwned() != null && request.getOwned()) {
                 if (loggedInUser != null) {
                     ors.getExpressions().add(
-                         builder.equal(savedSearch.get("createdBy"), loggedInUser.getId())
+                         builder.equal(savedSearch.get("createdBy"), loggedInUser)
                     );
                 }
             }


### PR DESCRIPTION
Changes to ensure comparisons use ID rather than the object. This has an impact when the new version of JPA/Hibernate/Spring arrives, so doing this as a small check-in to separate from the rest.