### PR TITLE
use elasticsearch for find by phoneemailexternal

### DIFF
--- a/server/src/main/java/org/tctalent/server/model/es/CandidateEs.java
+++ b/server/src/main/java/org/tctalent/server/model/es/CandidateEs.java
@@ -91,8 +91,8 @@ public class CandidateEs {
 
     @Id
     private String id;
-
     private String externalId;
+    private String candidateNumber;
 
     @Field(type = FieldType.Text)
     private String additionalInfo;
@@ -242,6 +242,8 @@ public class CandidateEs {
         this.setFullName();
         this.email = candidate.getUser() == null ? null
             : candidate.getUser().getEmail();
+        this.externalId = candidate.getExternalId();
+        this.candidateNumber = candidate.getCandidateNumber();
 
         this.gender = candidate.getGender();
         this.country = candidate.getCountry() == null ? null

--- a/server/src/main/java/org/tctalent/server/model/es/CandidateEs.java
+++ b/server/src/main/java/org/tctalent/server/model/es/CandidateEs.java
@@ -92,6 +92,8 @@ public class CandidateEs {
     @Id
     private String id;
 
+    private String externalId;
+
     @Field(type = FieldType.Text)
     private String additionalInfo;
 

--- a/server/src/main/java/org/tctalent/server/model/es/CandidateEs.java
+++ b/server/src/main/java/org/tctalent/server/model/es/CandidateEs.java
@@ -140,6 +140,8 @@ public class CandidateEs {
      */
     private String fullName;
 
+    private String email;
+
     @Field(type = FieldType.Text)
     private List<String> jobExperiences;
 
@@ -236,6 +238,8 @@ public class CandidateEs {
         this.lastName = candidate.getUser() == null ? null
             : candidate.getUser().getLastName();
         this.setFullName();
+        this.email = candidate.getUser() == null ? null
+            : candidate.getUser().getEmail();
 
         this.gender = candidate.getGender();
         this.country = candidate.getCountry() == null ? null

--- a/server/src/main/java/org/tctalent/server/repository/db/CandidateRepository.java
+++ b/server/src/main/java/org/tctalent/server/repository/db/CandidateRepository.java
@@ -173,13 +173,6 @@ public interface CandidateRepository extends JpaRepository<Candidate, Long>, Jpa
                                           @Param("userSourceCountries") Set<Country> userSourceCountries,
                                           Pageable pageable);
 
-    @Query(" select distinct c from Candidate c "
-            + " where lower(c.externalId) like lower(:externalId) "
-            + sourceCountryRestriction)
-    Page<Candidate> searchCandidateExternalId(@Param("externalId") String externalId,
-                                              @Param("userSourceCountries") Set<Country> userSourceCountries,
-                                              Pageable pageable);
-
     @Query(" select c from Candidate c "
             + " join c.user u "
             + " where c.id = :id "

--- a/server/src/main/java/org/tctalent/server/repository/db/CandidateRepository.java
+++ b/server/src/main/java/org/tctalent/server/repository/db/CandidateRepository.java
@@ -154,25 +154,6 @@ public interface CandidateRepository extends JpaRepository<Candidate, Long>, Jpa
                                          @Param("userSourceCountries") Set<Country> userSourceCountries,
                                          Pageable pageable);
 
-    /**
-     * Note that we need to pass in a CandidateStatus.deleted constant in the
-     * "exclude" parameter because I haven't been able to just put
-     * CanadidateStatus.deleted constant directly into the query.
-     * Theoretically the fully qualified name should work eg
-     * " and c.status <> db.model.org.tctalent.server.CandidateStatus.deleted"
-     * See https://stackoverflow.com/questions/8217144/problems-with-making-a-query-when-using-enum-in-entity
-     * but Hibernate rejects that at run time with the following error:
-     * org.hibernate.hql.internal.ast.QuerySyntaxException: Invalid path
-     * - JC
-     */
-    @Query(" select distinct c from Candidate c "
-            + " where c.candidateNumber like :candidateNumber "
-            + excludeDeleted
-            + sourceCountryRestriction)
-    Page<Candidate> searchCandidateNumber(@Param("candidateNumber") String candidateNumber,
-                                          @Param("userSourceCountries") Set<Country> userSourceCountries,
-                                          Pageable pageable);
-
     @Query(" select c from Candidate c "
             + " join c.user u "
             + " where c.id = :id "

--- a/server/src/main/java/org/tctalent/server/repository/db/CandidateRepository.java
+++ b/server/src/main/java/org/tctalent/server/repository/db/CandidateRepository.java
@@ -173,15 +173,6 @@ public interface CandidateRepository extends JpaRepository<Candidate, Long>, Jpa
                                           @Param("userSourceCountries") Set<Country> userSourceCountries,
                                           Pageable pageable);
 
-    @Query(" select distinct c from Candidate c left join c.user u "
-            + " where (lower(c.phone) like lower(:emailOrPhone) "
-            + " or lower(u.email) like lower(:emailOrPhone)) "
-            + excludeDeleted
-            + sourceCountryRestriction)
-    Page<Candidate> searchCandidateEmailOrPhone(@Param("emailOrPhone") String emailOrPhone,
-                                          @Param("userSourceCountries") Set<Country> userSourceCountries,
-                                          Pageable pageable);
-
     @Query(" select distinct c from Candidate c "
             + " where lower(c.externalId) like lower(:externalId) "
             + sourceCountryRestriction)

--- a/server/src/main/java/org/tctalent/server/service/db/es/ElasticsearchService.java
+++ b/server/src/main/java/org/tctalent/server/service/db/es/ElasticsearchService.java
@@ -42,4 +42,16 @@ public interface ElasticsearchService {
    * @throws IllegalArgumentException if the provided input string is null.
    */
   Set<Long> findByPhoneOrEmail(@NonNull String input);
+
+  /**
+   * Retrieves a set of candidate IDs by elastic searching for a specified external ID
+   *
+   * @param externalId the external ID string to search for in the Elasticsearch index. Must not be
+   *                  null.
+   * @return a {@link Set} of {@link Long} candidate IDs that match the search criteria.
+   *         The set will be empty if no candidates are found.
+   * @throws IllegalArgumentException if the provided input string is null.
+   */
+  Set<Long> findByExternalId(@NonNull String externalId);
+
 }

--- a/server/src/main/java/org/tctalent/server/service/db/es/ElasticsearchService.java
+++ b/server/src/main/java/org/tctalent/server/service/db/es/ElasticsearchService.java
@@ -23,8 +23,7 @@ import org.springframework.lang.NonNull;
 public interface ElasticsearchService {
 
   /**
-   * Retrieves a set of candidate IDs by searching for a specified name.
-   * This method uses Elasticsearch to perform a search based on the full name of candidates.
+   * Retrieves a set of candidate IDs by elastic searching for a specified name.
    *
    * @param name the full name to search for in the Elasticsearch index. Must not be null.
    * @return a {@link Set} of {@link Long} candidate IDs that match the search criteria.
@@ -33,4 +32,14 @@ public interface ElasticsearchService {
    */
   Set<Long> findByName(@NonNull String name);
 
+  /**
+   * Retrieves a set of candidate IDs by elastic searching for a specified input string
+   * that matches either the phone number or email in the Elasticsearch index.
+   *
+   * @param input the input string to search for in the Elasticsearch index. Must not be null.
+   * @return a {@link Set} of {@link Long} candidate IDs that match the search criteria.
+   *         The set will be empty if no candidates are found.
+   * @throws IllegalArgumentException if the provided input string is null.
+   */
+  Set<Long> findByPhoneOrEmail(@NonNull String input);
 }

--- a/server/src/main/java/org/tctalent/server/service/db/es/ElasticsearchService.java
+++ b/server/src/main/java/org/tctalent/server/service/db/es/ElasticsearchService.java
@@ -33,6 +33,16 @@ public interface ElasticsearchService {
   Set<Long> findByName(@NonNull String name);
 
   /**
+   * Retrieves a set of candidate IDs by elastic searching for a specified candidate number.
+   *
+   * @param number the candidate number to search for in the Elasticsearch index. Must not be null.
+   * @return a {@link Set} of {@link Long} candidate IDs that match the search criteria.
+   *         The set will be empty if no candidates are found.
+   * @throws IllegalArgumentException if the provided name is null.
+   */
+  Set<Long> findByNumber(@NonNull String number);
+
+  /**
    * Retrieves a set of candidate IDs by elastic searching for a specified input string
    * that matches either the phone number or email in the Elasticsearch index.
    *

--- a/server/src/main/java/org/tctalent/server/service/db/es/ElasticsearchServiceImpl.java
+++ b/server/src/main/java/org/tctalent/server/service/db/es/ElasticsearchServiceImpl.java
@@ -26,6 +26,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.MatchBoolPrefixQueryBuilder;
 import org.elasticsearch.index.query.Operator;
+import org.elasticsearch.index.query.PrefixQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.sort.SortBuilders;
@@ -62,6 +63,9 @@ import org.tctalent.server.service.db.UserService;
 @Service
 public class ElasticsearchServiceImpl implements ElasticsearchService {
 
+  private static final String FULL_NAME_FIELD = "fullName";
+  private static final String PHONE_NUMBER_FIELD = "phone";
+  private static final String EMAIL_FIELD = "email";
   private static final String STATUS_KEYWORD = "status.keyword";
   private static final String COUNTRY_KEYWORD = "country.keyword";
 
@@ -82,11 +86,25 @@ public class ElasticsearchServiceImpl implements ElasticsearchService {
     return candidateIds;
   }
 
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public Set<Long> findByPhoneOrEmail(@NonNull String number) {
+    BoolQueryBuilder boolQuery = computeFindByPhoneOrEmailQuery(number);
+    SearchHits<CandidateEs> hits = executeQuery(boolQuery);
+    LinkedHashSet<Long> candidateIds = extractCandidateIds(hits);
+
+    log.info("Found candidate IDs: " + candidateIds);
+
+    return candidateIds;
+  }
+
   @NotNull
   private BoolQueryBuilder computeFindByNameQuery(String name) {
     // Create match_bool_prefix query for name
     MatchBoolPrefixQueryBuilder nameQuery = QueryBuilders
-        .matchBoolPrefixQuery("fullName", name)
+        .matchBoolPrefixQuery(FULL_NAME_FIELD, name)
         .operator(Operator.AND);
 
     // Construct the boolean query
@@ -97,7 +115,31 @@ public class ElasticsearchServiceImpl implements ElasticsearchService {
     boolQuery = filterOnDeletedStatus(boolQuery);
     boolQuery = filterOnSourceCountryRestrictions(boolQuery);
 
-    log.info("Elasticsearch query:\n" + boolQuery);
+    log.debug("Elasticsearch query:\n" + boolQuery);
+    return boolQuery;
+  }
+
+  @NotNull
+  private BoolQueryBuilder computeFindByPhoneOrEmailQuery(String input) {
+    // Create prefix query for phone number
+    PrefixQueryBuilder phoneQuery = QueryBuilders
+        .prefixQuery(PHONE_NUMBER_FIELD, input);
+
+    // Create prefix query for email
+    PrefixQueryBuilder emailQuery = QueryBuilders
+        .prefixQuery(EMAIL_FIELD, input);
+
+    // Construct the boolean query with should clause
+    BoolQueryBuilder boolQuery = QueryBuilders.boolQuery()
+        .should(phoneQuery)
+        .should(emailQuery)
+        .minimumShouldMatch(1);  // Ensures at least one should clause must match
+
+    // Filter out deleted Statuses and account for country restrictions
+    boolQuery = filterOnDeletedStatus(boolQuery);
+    boolQuery = filterOnSourceCountryRestrictions(boolQuery);
+
+    log.debug("Elasticsearch query:\n" + boolQuery);
     return boolQuery;
   }
 

--- a/server/src/main/java/org/tctalent/server/service/db/impl/CandidateServiceImpl.java
+++ b/server/src/main/java/org/tctalent/server/service/db/impl/CandidateServiceImpl.java
@@ -403,13 +403,13 @@ public class CandidateServiceImpl implements CandidateService {
                 .orElseThrow(() -> new InvalidSessionException("Not logged in"));
 
         boolean searchForNumber = s.length() > 0 && Character.isDigit(s.charAt(0));
-        Set<Country> sourceCountries = userService.getDefaultSourceCountries(loggedInUser);
         Page<Candidate> candidates;
 
         if (searchForNumber) {
-            candidates = candidateRepository.searchCandidateNumber(
-                        s +'%', sourceCountries,
-                    request.getPageRequestWithoutSort());
+            // Get candidate ids from Elasticsearch then fetch and return from the database
+            Set<Long> candidateIds = elasticsearchService.findByNumber(s);
+            candidates = getCandidates(request, candidateIds);
+
         } else {
             if (authService.hasAdminPrivileges(loggedInUser.getRole())) {
                 // Get candidate ids from Elasticsearch then fetch and return from the database


### PR DESCRIPTION
This PR:

- Uses the elastic search service for quick search on candidate number, phone, email, and externalId
- Removes the no longer used candidate repository methods - they are non-performant and should not be inadvertently used by developers