### PR TITLE
Stop keydown.enter default behaviour for current and future candidate-search inputs

### DIFF
--- a/ui/admin-portal/src/app/components/search/define-search/define-search.component.html
+++ b/ui/admin-portal/src/app/components/search/define-search/define-search.component.html
@@ -76,31 +76,33 @@
 
       <form class="filter-form side-panel-color" [formGroup]="searchForm" (ngSubmit)="apply()" #formWrapper>
         <ng-template #keywordSearchTip>
-          Search candidate CVs using these tips to create powerful queries:
-          <ul id="keyword-search-tip-list">
-            <li>
-              <code>+</code> means AND, <code>space</code> means OR -
-              e.g. <code>welder diesel+mechanic</code> finds all profiles containing the word
-              'welder' OR <em>both</em> the words 'diesel' AND 'mechanic'.
-            </li>
-            <li>
-              Match the first part of a word using <code>*</code> - e.g. <code>account*</code>
-              will find 'accounting' and 'accountant'.
-            </li>
-            <li>
-              Search for phrases as well as words by using double quotes
-              - e.g. <code>accountant + "hospital director"</code> will find profiles with the word
-              'accountant' AND the phrase 'hospital director'.
-            </li>
-            <li>
-              Use brackets to group terms - e.g. <code>accountant + (excel powerpoint)</code>
-              finds profiles containing the word 'accountant' AND <em>either</em> 'excel' or
-              'powerpoint', whereas <code>(accountant + excel) powerpoint</code> finds profiles
-              containing 'accountant' AND 'excel', OR profiles containing the word 'powerpoint'.
-            </li>
-          </ul>
-          You can further refine your query by applying the available filters below.
-          Click the 'Search' button to execute.
+          <span class="search-tips-content">
+            Search candidate CVs using these tips to create powerful queries:
+            <ul>
+              <li>
+                <code>+</code> means AND, <code>space</code> means OR -
+                e.g. <code>welder diesel+mechanic</code> finds all profiles containing the word
+                'welder' OR <em>both</em> the words 'diesel' AND 'mechanic'.
+              </li>
+              <li>
+                Match the first part of a word using <code>*</code> - e.g. <code>account*</code>
+                will find 'accounting' and 'accountant'.
+              </li>
+              <li>
+                Search for phrases as well as words by using double quotes
+                - e.g. <code>accountant + "hospital director"</code> will find profiles with the word
+                'accountant' AND the phrase 'hospital director'.
+              </li>
+              <li>
+                Use brackets to group terms - e.g. <code>accountant + (excel powerpoint)</code>
+                finds profiles containing the word 'accountant' AND <em>either</em> 'excel' or
+                'powerpoint', whereas <code>(accountant + excel) powerpoint</code> finds profiles
+                containing 'accountant' AND 'excel', OR profiles containing the word 'powerpoint'.
+              </li>
+            </ul>
+            You can further refine your query by applying the available filters below.
+            Click the 'Search' button to execute.
+          </span>
         </ng-template>
 
         <div class="container-fluid">
@@ -469,17 +471,21 @@
             <!-- REFERRER -->
             <div class="col-md-4">
               <label class="form-label" for="referrer">Referrer</label>
-              <button class="tool-tip-button"
-                      ngbTooltip="Search ignores upper or lower case so don't worry about case.
-                      Also % can be used as a wild card. So 'ab%' will find any referers which
-                      begin with 'ab'. Or '%irc%' will find any referers with irc appearing
-                      anywhere in the name."
+              <button class="tool-tip-button" [ngbTooltip]="referrerTooltip"
                       placement="" triggers="click" tooltipClass="search-tips">
                 <i class="fa-regular fa-circle-question fa-xs"></i>
               </button>
               <input id="referrer" class="form-control"
                      name="referrer" [formControlName]="'regoReferrerParam'" appLowercase>
             </div>
+            <ng-template #referrerTooltip>
+              <span class="search-tips-content">
+                Search ignores upper or lower case so don't worry about case.
+                Also <code>%</code> can be used as a wild card. So <code>ab%</code> will find any
+                referrers beginning with <code>ab</code>. Or <code>%irc%</code> will find any referrers
+                with <code>irc</code> appearing anywhere in the name.
+              </span>
+            </ng-template>
 
             <!-- CANDIDATE OPPS -->
             <div class="col-md-4">

--- a/ui/admin-portal/src/app/components/search/define-search/define-search.component.html
+++ b/ui/admin-portal/src/app/components/search/define-search/define-search.component.html
@@ -107,8 +107,7 @@
           <div class="row">
             <div class="mb-3 col-md-6">
               <!-- providing 'placement' as an empty string makes the tooltip appear over the
-              element in a suitable direction for the viewport - adding the keydown.enter event
-              stops the tooltip from being triggered by pressing enter while using the input field -->
+              element in a suitable direction for the viewport -->
               <label class="form-label" for="simpleQueryString">Keyword Search</label>
               <button class="tool-tip-button" [ngbTooltip]="keywordSearchTip" placement=""
                       triggers="click" tooltipClass="search-tips">
@@ -116,9 +115,7 @@
               </button>
               <input id="simpleQueryString" type="text" class="form-control"
                      placeholder="E.g. 'welder diesel+mechanic'" aria-label="Keyword Search"
-                     formControlName="simpleQueryString" (keydown.enter)="$event.preventDefault()"
-                     (keyup.enter)="apply()"
-                     >
+                     formControlName="simpleQueryString" (keyup.enter)="apply()">
             </div>
 
             <!-- STATUS -->

--- a/ui/admin-portal/src/app/components/search/define-search/define-search.component.scss
+++ b/ui/admin-portal/src/app/components/search/define-search/define-search.component.scss
@@ -173,6 +173,6 @@ $candidate-card-width: 375px;
 }
 
 // To make example search queries more visible
-#keyword-search-tip-list code {
+.search-tips-content code {
   color: #0cd5e4;
 }

--- a/ui/admin-portal/src/app/components/search/define-search/define-search.component.ts
+++ b/ui/admin-portal/src/app/components/search/define-search/define-search.component.ts
@@ -14,7 +14,16 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-import {Component, ElementRef, Input, OnChanges, OnInit, SimpleChanges, ViewChild} from '@angular/core';
+import {
+  AfterViewInit,
+  Component,
+  ElementRef,
+  Input,
+  OnChanges,
+  OnInit,
+  SimpleChanges,
+  ViewChild
+} from '@angular/core';
 
 import {Candidate, CandidateFilterByOpps, CandidateStatus, Gender, UnhcrStatus} from '../../../model/candidate';
 import {CandidateService} from '../../../services/candidate.service';
@@ -78,7 +87,7 @@ import {first} from "rxjs/operators";
   templateUrl: './define-search.component.html',
   styleUrls: ['./define-search.component.scss']
 })
-export class DefineSearchComponent implements OnInit, OnChanges {
+export class DefineSearchComponent implements OnInit, OnChanges, AfterViewInit {
   @ViewChild('modifiedDate', {static: true}) modifiedDatePicker: DateRangePickerComponent;
   @ViewChild('englishLanguage', {static: true}) englishLanguagePicker: LanguageLevelFormControlComponent;
   @ViewChild('otherLanguage', {static: true}) otherLanguagePicker: LanguageLevelFormControlComponent;
@@ -255,6 +264,19 @@ export class DefineSearchComponent implements OnInit, OnChanges {
       this.error = error;
     });
   }
+
+  // Stops Keyword Search tooltip from opening on keydown.enter in inputs
+  ngAfterViewInit() {
+    const inputs: NodeList = document.querySelectorAll('input')
+    inputs.forEach(input => {
+      input.addEventListener('keydown', (event: KeyboardEvent) => {
+        if (event.key === 'Enter') {
+          event.preventDefault();
+        }
+      })
+    })
+  }
+
 
   get simpleQueryString(): string {
     return this.searchForm.value.simpleQueryString;

--- a/ui/admin-portal/src/app/components/search/define-search/define-search.component.ts
+++ b/ui/admin-portal/src/app/components/search/define-search/define-search.component.ts
@@ -277,7 +277,6 @@ export class DefineSearchComponent implements OnInit, OnChanges, AfterViewInit {
     })
   }
 
-
   get simpleQueryString(): string {
     return this.searchForm.value.simpleQueryString;
   }


### PR DESCRIPTION
Also added a small amount of styling to align 'Referrer' tooltip with 'Keyword search': using inverted commas to examplify search queries is confusing, since they themselves can be used to enhance search queries — which is why we utilise <code> formatting to distinguish examples.


<img width="773" alt="Screenshot 2024-05-27 at 4 31 26 PM" src="https://github.com/Talent-Catalog/talentcatalog/assets/111261894/25c37cea-ac4e-4ead-aa9e-d9fe68772cdf">


👇

<img width="759" alt="Screenshot 2024-05-27 at 4 31 05 PM" src="https://github.com/Talent-Catalog/talentcatalog/assets/111261894/294b548f-2867-4977-9973-495307e44dab">
