### PR TITLE
Hot fix throws and displays error when user attempts exports of search results > 3000 candidates

### DIFF
--- a/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.ts
+++ b/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.ts
@@ -624,6 +624,12 @@ export class ShowCandidatesComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   exportCandidates() {
+    if (this.results.totalElements > 3000) {
+      const csvError: string = "Spreadsheet exports are currently capped at 3,000 candidates — please " +
+        "contact a TC admin if if this limit will negatively impact your work."
+      this.error = csvError
+      throw new Error(csvError)
+    }
     this.exporting = true;
 
     //Create the appropriate request


### PR DESCRIPTION
![Screenshot 2024-05-28 at 4 52 13 PM](https://github.com/Talent-Catalog/talentcatalog/assets/111261894/4e8160ab-b8c2-4bbf-b8eb-44a375af0422)
