### PR TITLE
FIX: Add thymeleaf library

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -140,7 +140,7 @@ dependencies {
 
     // Temp to update spring thymeleaf as indepdendent unit until all spring is done.
     implementation("org.thymeleaf:thymeleaf-spring6:3.1.2.RELEASE")
-
+    implementation("org.thymeleaf:thymeleaf:3.1.2.RELEASE")
 
     // Caching
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'


### PR DESCRIPTION
The spring6 thymeleaf lib has an internal dependency that requires an update to avoid getting a MethodNotFound exception.
This PR is putting that update in specifically and outside spring-managed until the spring3 upgrade progresses.