### PR TITLE
Added informative error to SF link validation

### DIFF
--- a/server/src/main/java/org/tctalent/server/api/admin/SalesforceAdminApi.java
+++ b/server/src/main/java/org/tctalent/server/api/admin/SalesforceAdminApi.java
@@ -65,6 +65,12 @@ public class SalesforceAdminApi {
       if (sfId != null) {
         opp = salesforceService.findOpportunity(sfId);
       }
+    } else {
+      throw new IllegalArgumentException("Please ensure that your URL points to a valid Salesforce "
+          + "opportunity and is the longer version containing the word 'Opportunity', which can be "
+          + "obtained by navigating to the record itself and copying from your browser's address "
+          + "bar, e.g.: "
+          + "https://talentbeyondboundaries.lightning.force.com/lightning/r/Opportunity/006Uu000004qo4rIAA/view");
     }
     return opportunityDto().build(opp);
   }


### PR DESCRIPTION
<img width="1435" alt="Screenshot 2024-06-03 at 12 53 32 PM" src="https://github.com/Talent-Catalog/talentcatalog/assets/111261894/c5927e46-f911-45a5-9c1e-ec24a6dec9f0">
