### PR TITLE
Tightened SF link validation and added informative error to job intake

### DIFF
--- a/server/src/main/java/org/tctalent/server/api/admin/SalesforceAdminApi.java
+++ b/server/src/main/java/org/tctalent/server/api/admin/SalesforceAdminApi.java
@@ -65,6 +65,12 @@ public class SalesforceAdminApi {
       if (sfId != null) {
         opp = salesforceService.findOpportunity(sfId);
       }
+    } else {
+      throw new IllegalArgumentException("Please ensure that your URL points to a valid Salesforce "
+          + "opportunity and is the longer version containing the word 'Opportunity', which can be "
+          + "obtained by navigating to the record itself and copying from your browser's address "
+          + "bar, e.g.: "
+          + "https://talentbeyondboundaries.lightning.force.com/lightning/r/Opportunity/006Uu000004qo4rIAA/view");
     }
     return opportunityDto().build(opp);
   }

--- a/server/src/main/java/org/tctalent/server/api/admin/SalesforceAdminApi.java
+++ b/server/src/main/java/org/tctalent/server/api/admin/SalesforceAdminApi.java
@@ -65,12 +65,6 @@ public class SalesforceAdminApi {
       if (sfId != null) {
         opp = salesforceService.findOpportunity(sfId);
       }
-    } else {
-      throw new IllegalArgumentException("Please ensure that your URL points to a valid Salesforce "
-          + "opportunity and is the longer version containing the word 'Opportunity', which can be "
-          + "obtained by navigating to the record itself and copying from your browser's address "
-          + "bar, e.g.: "
-          + "https://talentbeyondboundaries.lightning.force.com/lightning/r/Opportunity/006Uu000004qo4rIAA/view");
     }
     return opportunityDto().build(opp);
   }

--- a/ui/admin-portal/src/app/components/util/sf-joblink/sf-joblink.component.html
+++ b/ui/admin-portal/src/app/components/util/sf-joblink/sf-joblink.component.html
@@ -27,11 +27,11 @@ MODEL - use of subclassing FormComponentBase to inherit common standard form fun
     <input type="text" class="form-control" formControlName="sfJoblink">
   </div>
   <div *ngIf="isInvalid(form.controls.sfJoblink)" class="alert alert-danger">
-    Doesn't look like a Salesforce Job opportunity link to me!
-    <br/>
-    Copy and paste from Salesforce.
+    Your link must be the <em>full version</em> of a URL pointing to a valid Salesforce opportunity.
+    Navigate to the record and copy-paste from your browser's address bar, e.g.:
+    https://talentbeyondboundaries.lightning.force.com/lightning/r/<b>Opportunity</b>/006Uu000004qo4rIAA/view
   </div>
   <div *ngIf="form.controls.sfJoblink.pending">
-    <i class="fas fa-spinner fa-spin"></i>Waiting validation from Salesforce...
+    <i class="fas fa-spinner fa-spin"></i>Waiting for validation from Salesforce...
   </div>
 </form>

--- a/ui/admin-portal/src/app/model/base.ts
+++ b/ui/admin-portal/src/app/model/base.ts
@@ -121,12 +121,12 @@ export enum SearchOppsBy {
  * Any validation method needs to use BOTH the SF sandbox and prod patterns below, combining them as OR options using a pipe: Validators.pattern(`${salesforceUrlPattern}|${salesforceSandboxUrlPattern}`)
  */
 export const salesforceUrlPattern: string =
-  'https://talentbeyondboundaries.lightning.force.com/' +
-  '.*/[\\w]+/[\\w]{15,}[^\\w]?.*';
+  'https://talentbeyondboundaries.lightning.force.com/lightning/r/' +
+  '[\\w]+/[\\w]{15,}[^\\w]?.*';
 
 export const salesforceSandboxUrlPattern: string =
-  'https://talentbeyondboundaries--sfstaging.sandbox.lightning.force.com/' +
-    '.*/[\\w]+/[\\w]{15,}[^\\w]?.*';
+  'https://talentbeyondboundaries--sfstaging.sandbox.lightning.force.com/lightning/r/' +
+    '[\\w]+/[\\w]{15,}[^\\w]?.*';
 
 export const salesforceUrlRegExp: RegExp = new RegExp(salesforceUrlPattern);
 


### PR DESCRIPTION
I think this covers the scenario that produced our bug, without getting bogged down in the details.

<img width="1434" alt="Screenshot 2024-06-03 at 3 06 47 PM" src="https://github.com/Talent-Catalog/talentcatalog/assets/111261894/0218dc51-c4cb-4243-892d-121eb6a6d026">
