### PR TITLE
Deleted simple front-end CandidateFilterByOpps code, commented out the rest

### DIFF
--- a/server/src/main/java/org/tctalent/server/repository/db/CandidateSpecification.java
+++ b/server/src/main/java/org/tctalent/server/repository/db/CandidateSpecification.java
@@ -39,7 +39,7 @@ import org.springframework.lang.Nullable;
 import org.tctalent.server.model.db.Candidate;
 import org.tctalent.server.model.db.CandidateAttachment;
 import org.tctalent.server.model.db.CandidateEducation;
-import org.tctalent.server.model.db.CandidateFilterByOpps;
+//import org.tctalent.server.model.db.CandidateFilterByOpps;
 import org.tctalent.server.model.db.CandidateJobExperience;
 import org.tctalent.server.model.db.CandidateLanguage;
 import org.tctalent.server.model.db.CandidateOccupation;
@@ -410,67 +410,68 @@ public class CandidateSpecification {
 
             }
 
-            //CANDIDATE OPPORTUNITIES
-            final CandidateFilterByOpps candidateFilterByOpps = request.getCandidateFilterByOpps();
-            if (candidateFilterByOpps != null) {
-               Boolean anyOpps = candidateFilterByOpps.getAnyOpps();
-               Boolean closedOpps = candidateFilterByOpps.getClosedOpps();
-               Boolean relocatedOpps = candidateFilterByOpps.getRelocatedOpps();
-
-                //This is the where clause we are constructing
-                /*
-                   where 0 <
-                   (select count(*) from candidate_opportunity
-                   where candidate_id = candidate.id)
-
-                   - Plus possible other where clauses - eg "and closed = false"
-                */
-                //This "conjunction predicate" will AND together all the where clauses we add to it.
-                Predicate oppsWhereClauses = builder.conjunction();
-
-                //Create the Select subquery which will return the opportunity count as a Long
-                Subquery<Long> sq = query.subquery(Long.class);
-                Root<CandidateOpportunity> opp = sq.from(CandidateOpportunity.class);
-
-                //This where clause is always there: candidate_id = candidate.id
-                oppsWhereClauses.getExpressions().add(
-                    builder.equal(opp.get("candidate").get("id"), candidate.get("id")));
-
-                boolean countMustBeNonZero = true;
-                if (anyOpps != null) {
-                    //The "AnyOpp" request doesn't add any other clauses.
-                    //It just changes whether we are testing that the count of opportunities should
-                    //or should not equal zero. ie are we looking for candidates with some opp or
-                    //no opps.
-                    countMustBeNonZero = anyOpps;
-                } else {
-                    if (closedOpps != null) {
-                        boolean closedClauseValue = closedOpps;
-                        //Add the where clause "closed = true" or "closed = false"
-                        oppsWhereClauses.getExpressions().add(
-                            builder.equal(opp.get("closed"), closedClauseValue));
-                    }
-                    if (relocatedOpps != null) {
-                        //Add the where clause checking whether the integer value associated with
-                        //opps stage is before (ie less than) the relocated stage or not.
-                        //ie the clause is effectively "stage < relocated" or "stage >= relocated"
-                        int relocatedStageOrder = CandidateOpportunityStage.relocated.ordinal();
-                        Predicate relocatedPredicate = relocatedOpps ?
-                            builder.greaterThanOrEqualTo(opp.get("stageOrder"), relocatedStageOrder) :
-                            builder.lessThan(opp.get("stageOrder"), relocatedStageOrder);
-                        oppsWhereClauses.getExpressions().add(relocatedPredicate);
-                    }
-                }
-
-                //Do the subquery select - ie do the opportunity count, by "and-ing" together all
-                //the where clauses we have added to oppsConjunction
-                sq.select(builder.count(opp)).where(oppsWhereClauses);
-
-                conjunction.getExpressions().add(
-                    //Check for zero or non-zero opportunity count depending on the above logic.
-                    countMustBeNonZero ? builder.greaterThan(sq, 0L) : builder.equal(sq, 0L)
-                );
-            }
+//            // CANDIDATE OPPORTUNITIES
+//            // Previously used in candidate search, removed Jun '24 - preserved for now in case of reinstatement elsewhere.
+//            final CandidateFilterByOpps candidateFilterByOpps = request.getCandidateFilterByOpps();
+//            if (candidateFilterByOpps != null) {
+//               Boolean anyOpps = candidateFilterByOpps.getAnyOpps();
+//               Boolean closedOpps = candidateFilterByOpps.getClosedOpps();
+//               Boolean relocatedOpps = candidateFilterByOpps.getRelocatedOpps();
+//
+//                //This is the where clause we are constructing
+//                /*
+//                   where 0 <
+//                   (select count(*) from candidate_opportunity
+//                   where candidate_id = candidate.id)
+//
+//                   - Plus possible other where clauses - eg "and closed = false"
+//                */
+//                //This "conjunction predicate" will AND together all the where clauses we add to it.
+//                Predicate oppsWhereClauses = builder.conjunction();
+//
+//                //Create the Select subquery which will return the opportunity count as a Long
+//                Subquery<Long> sq = query.subquery(Long.class);
+//                Root<CandidateOpportunity> opp = sq.from(CandidateOpportunity.class);
+//
+//                //This where clause is always there: candidate_id = candidate.id
+//                oppsWhereClauses.getExpressions().add(
+//                    builder.equal(opp.get("candidate").get("id"), candidate.get("id")));
+//
+//                boolean countMustBeNonZero = true;
+//                if (anyOpps != null) {
+//                    //The "AnyOpp" request doesn't add any other clauses.
+//                    //It just changes whether we are testing that the count of opportunities should
+//                    //or should not equal zero. ie are we looking for candidates with some opp or
+//                    //no opps.
+//                    countMustBeNonZero = anyOpps;
+//                } else {
+//                    if (closedOpps != null) {
+//                        boolean closedClauseValue = closedOpps;
+//                        //Add the where clause "closed = true" or "closed = false"
+//                        oppsWhereClauses.getExpressions().add(
+//                            builder.equal(opp.get("closed"), closedClauseValue));
+//                    }
+//                    if (relocatedOpps != null) {
+//                        //Add the where clause checking whether the integer value associated with
+//                        //opps stage is before (ie less than) the relocated stage or not.
+//                        //ie the clause is effectively "stage < relocated" or "stage >= relocated"
+//                        int relocatedStageOrder = CandidateOpportunityStage.relocated.ordinal();
+//                        Predicate relocatedPredicate = relocatedOpps ?
+//                            builder.greaterThanOrEqualTo(opp.get("stageOrder"), relocatedStageOrder) :
+//                            builder.lessThan(opp.get("stageOrder"), relocatedStageOrder);
+//                        oppsWhereClauses.getExpressions().add(relocatedPredicate);
+//                    }
+//                }
+//
+//                //Do the subquery select - ie do the opportunity count, by "and-ing" together all
+//                //the where clauses we have added to oppsConjunction
+//                sq.select(builder.count(opp)).where(oppsWhereClauses);
+//
+//                conjunction.getExpressions().add(
+//                    //Check for zero or non-zero opportunity count depending on the above logic.
+//                    countMustBeNonZero ? builder.greaterThan(sq, 0L) : builder.equal(sq, 0L)
+//                );
+//            }
 
             return conjunction;
         };

--- a/server/src/main/java/org/tctalent/server/request/candidate/SearchCandidateRequest.java
+++ b/server/src/main/java/org/tctalent/server/request/candidate/SearchCandidateRequest.java
@@ -26,7 +26,7 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 import org.springframework.data.domain.Sort;
-import org.tctalent.server.model.db.CandidateFilterByOpps;
+//import org.tctalent.server.model.db.CandidateFilterByOpps;
 import org.tctalent.server.model.db.CandidateStatus;
 import org.tctalent.server.model.db.Gender;
 import org.tctalent.server.model.db.ReviewStatus;
@@ -143,8 +143,10 @@ public class SearchCandidateRequest extends PagedSearchRequest {
      *     <li>closedOpps</li>
      *     <li>relocatedOpps</li>
      * </ul>
+     *
+     * Previously used in candidate search, removed Jun '24 - preserved in case of reinstatement elsewhere.
      */
-    private CandidateFilterByOpps candidateFilterByOpps;
+//    private CandidateFilterByOpps candidateFilterByOpps;
 
     public SearchCandidateRequest() {
         super(Sort.Direction.DESC, new String[]{"id"});

--- a/server/src/main/java/org/tctalent/server/service/db/impl/SavedSearchServiceImpl.java
+++ b/server/src/main/java/org/tctalent/server/service/db/impl/SavedSearchServiceImpl.java
@@ -75,7 +75,7 @@ import org.tctalent.server.exception.InvalidRequestException;
 import org.tctalent.server.exception.InvalidSessionException;
 import org.tctalent.server.exception.NoSuchObjectException;
 import org.tctalent.server.model.db.Candidate;
-import org.tctalent.server.model.db.CandidateFilterByOpps;
+//import org.tctalent.server.model.db.CandidateFilterByOpps;
 import org.tctalent.server.model.db.CandidateStatus;
 import org.tctalent.server.model.db.Country;
 import org.tctalent.server.model.db.EducationLevel;
@@ -1573,17 +1573,18 @@ public class SavedSearchServiceImpl implements SavedSearchService {
             savedSearch.setMiniIntakeCompleted(request.getMiniIntakeCompleted());
             savedSearch.setFullIntakeCompleted(request.getFullIntakeCompleted());
 
-            //Save Boolean filters corresponding to enum name
-            final CandidateFilterByOpps candidateFilterByOpps = request.getCandidateFilterByOpps();
-            if (candidateFilterByOpps == null) {
-                savedSearch.setAnyOpps(null);
-                savedSearch.setClosedOpps(null);
-                savedSearch.setRelocatedOpps(null);
-            } else {
-                savedSearch.setAnyOpps(candidateFilterByOpps.getAnyOpps());
-                savedSearch.setClosedOpps(candidateFilterByOpps.getClosedOpps());
-                savedSearch.setRelocatedOpps(candidateFilterByOpps.getRelocatedOpps());
-            }
+//            // Previously used in candidate search, removed Jun '24 - preserved in case of reinstatement elsewhere.
+//            // Save Boolean filters corresponding to enum name
+//            final CandidateFilterByOpps candidateFilterByOpps = request.getCandidateFilterByOpps();
+//            if (candidateFilterByOpps == null) {
+//                savedSearch.setAnyOpps(null);
+//                savedSearch.setClosedOpps(null);
+//                savedSearch.setRelocatedOpps(null);
+//            } else {
+//                savedSearch.setAnyOpps(candidateFilterByOpps.getAnyOpps());
+//                savedSearch.setClosedOpps(candidateFilterByOpps.getClosedOpps());
+//                savedSearch.setRelocatedOpps(candidateFilterByOpps.getRelocatedOpps());
+//            }
         }
     }
 
@@ -1645,9 +1646,10 @@ public class SavedSearchServiceImpl implements SavedSearchService {
         searchCandidateRequest.setMiniIntakeCompleted(search.getMiniIntakeCompleted());
         searchCandidateRequest.setFullIntakeCompleted(search.getFullIntakeCompleted());
 
-        CandidateFilterByOpps candidateFilterByOpps = CandidateFilterByOpps.mapToEnum(
-            search.getAnyOpps(), search.getClosedOpps(), search.getRelocatedOpps());
-        searchCandidateRequest.setCandidateFilterByOpps(candidateFilterByOpps);
+        // Previously used in candidate search, removed Jun '24 - preserved in case of reinstatement elsewhere.
+//        CandidateFilterByOpps candidateFilterByOpps = CandidateFilterByOpps.mapToEnum(
+//            search.getAnyOpps(), search.getClosedOpps(), search.getRelocatedOpps());
+//        searchCandidateRequest.setCandidateFilterByOpps(candidateFilterByOpps);
 
         List<SearchJoinRequest> searchJoinRequests = new ArrayList<>();
         for (SearchJoin searchJoin : search.getSearchJoins()) {

--- a/ui/admin-portal/src/app/MockData/MockSavedSearch.ts
+++ b/ui/admin-portal/src/app/MockData/MockSavedSearch.ts
@@ -3,7 +3,6 @@ import {ExportColumn} from "../model/saved-list";
 import {OpportunityIds} from "../model/opportunity";
 import {MockUser} from "./MockUser";
 import {MockSavedJoin} from "./MockSavedJoin";
-import {CandidateFilterByOpps} from "../model/candidate";
 
 export class MockSavedSearch implements SavedSearch {
   defaultSearch: boolean = true;
@@ -78,7 +77,6 @@ export class MockSavedSearch implements SavedSearch {
   includeDraftAndDeleted: boolean = true;
   searchJoins: MockSavedJoin[];
   exclusionListId: number = 1;
-  candidateFilterByOpps: CandidateFilterByOpps = CandidateFilterByOpps.openOpps;
   miniIntakeCompleted: boolean = true;
   fullIntakeCompleted: boolean = false;
 

--- a/ui/admin-portal/src/app/components/search/define-search/define-search.component.html
+++ b/ui/admin-portal/src/app/components/search/define-search/define-search.component.html
@@ -487,20 +487,6 @@
               </span>
             </ng-template>
 
-            <!-- CANDIDATE OPPS -->
-            <div class="col-md-4">
-              <label class="form-label" for="gender">Candidate Job Opportunity Cases</label>
-              <ng-select
-                id="opps"
-                [items]="candidateFilterByOppsOptions"
-                [searchable]="false"
-                placeholder="Select"
-                bindLabel="stringValue"
-                bindValue="key"
-                formControlName="candidateFilterByOpps">
-              </ng-select>
-            </div>
-
             <!-- EXCLUSION LIST -->
             <div class="col-md-4">
               <label class="form-label" for="exclusion">Exclusion list</label>

--- a/ui/admin-portal/src/app/components/search/define-search/define-search.component.ts
+++ b/ui/admin-portal/src/app/components/search/define-search/define-search.component.ts
@@ -25,7 +25,7 @@ import {
   ViewChild
 } from '@angular/core';
 
-import {Candidate, CandidateFilterByOpps, CandidateStatus, Gender, UnhcrStatus} from '../../../model/candidate';
+import {Candidate, CandidateStatus, Gender, UnhcrStatus} from '../../../model/candidate';
 import {CandidateService} from '../../../services/candidate.service';
 import {Country} from '../../../model/country';
 import {CountryService} from '../../../services/country.service';
@@ -125,7 +125,6 @@ export class DefineSearchComponent implements OnInit, OnChanges, AfterViewInit {
 
   candidateStatusOptions: EnumOption[] = enumOptions(CandidateStatus);
   genderOptions: EnumOption[] = enumOptions(Gender);
-  candidateFilterByOppsOptions: EnumOption[] = enumOptions(CandidateFilterByOpps);
   selectedCandidate: Candidate;
   englishLanguageModel: LanguageLevelFormControlModel;
   otherLanguageModel: LanguageLevelFormControlModel;
@@ -198,7 +197,6 @@ export class DefineSearchComponent implements OnInit, OnChanges, AfterViewInit {
       regoReferrerParam: [null],
       statusesDisplay: [[]],
       surveyTypes: [[]],
-      candidateFilterByOpps: [null],
       exclusionListId: [null],
       unhcrStatusesDisplay: [[]],
       includeUploadedFiles: [false]}, {validator: this.validateDuplicateSearches('savedSearchId')});

--- a/ui/admin-portal/src/app/model/candidate.ts
+++ b/ui/admin-portal/src/app/model/candidate.ts
@@ -403,20 +403,15 @@ export enum CandidateStatus {
   withdrawn = "withdrawn (inactive)"
 }
 
-export enum CandidateFilterByOpps {
-  someOpps = "Some cases",
-
-  noOpps = "No cases",
-
-  openOpps = "Some open cases",
-
-  closedOpps = "Some closed cases",
-
-  preRelocationOpps = "Some cases not yet at relocated stage - ie 'live' cases",
-
-  postRelocationOpps = "Some cases at the relocated or later stage"
-
-}
+// Previously used in candidate search, removed Jun '24 - preserved for now in case of reinstatement elsewhere.
+// export enum CandidateFilterByOpps {
+//   someOpps = "Some cases",
+//   noOpps = "No cases",
+//   openOpps = "Some open cases",
+//   closedOpps = "Some closed cases",
+//   preRelocationOpps = "Some cases not yet at relocated stage - ie 'live' cases",
+//   postRelocationOpps = "Some cases at the relocated or later stage"
+// }
 
 export interface CandidateOpportunityParams extends OpportunityProgressParams {
   closingComments?: string;

--- a/ui/admin-portal/src/app/model/search-candidate-request.ts
+++ b/ui/admin-portal/src/app/model/search-candidate-request.ts
@@ -15,7 +15,6 @@
  */
 
 import {SavedSearchJoin} from './saved-search';
-import {CandidateFilterByOpps} from "./candidate";
 
 export interface SearchCandidateRequest {
   simpleQueryString?: string;
@@ -58,7 +57,6 @@ export interface SearchCandidateRequest {
   includeDraftAndDeleted?: boolean;
   searchJoins?: SavedSearchJoin[];
   exclusionListId?: number;
-  candidateFilterByOpps?: CandidateFilterByOpps;
   miniIntakeCompleted?: boolean;
   fullIntakeCompleted?: boolean;
   unhcrStatuses?: string[];

--- a/ui/candidate-portal/src/app/model/candidate.ts
+++ b/ui/candidate-portal/src/app/model/candidate.ts
@@ -393,20 +393,15 @@ export enum CandidateStatus {
   withdrawn = "withdrawn (inactive)"
 }
 
-export enum CandidateFilterByOpps {
-  someOpps = "Some cases",
-
-  noOpps = "No cases",
-
-  openOpps = "Some open cases",
-
-  closedOpps = "Some closed cases",
-
-  preRelocationOpps = "Some cases not yet at relocated stage - ie 'live' cases",
-
-  postRelocationOpps = "Some cases at the relocated or later stage"
-
-}
+// Previously used in candidate search, removed Jun '24 - preserved in case of reinstatement elsewhere.
+// export enum CandidateFilterByOpps {
+//   someOpps = "Some cases",
+//   noOpps = "No cases",
+//   openOpps = "Some open cases",
+//   closedOpps = "Some closed cases",
+//   preRelocationOpps = "Some cases not yet at relocated stage - ie 'live' cases",
+//   postRelocationOpps = "Some cases at the relocated or later stage"
+// }
 
 export interface CandidateOpportunityParams extends OpportunityProgressParams {
   closingComments?: string;

--- a/ui/candidate-portal/src/app/model/search-candidate-request.ts
+++ b/ui/candidate-portal/src/app/model/search-candidate-request.ts
@@ -15,7 +15,6 @@
  */
 
 import {SavedSearchJoin} from './saved-search';
-import {CandidateFilterByOpps} from "./candidate";
 
 export interface SearchCandidateRequest {
   simpleQueryString?: string;
@@ -58,5 +57,4 @@ export interface SearchCandidateRequest {
   includeDraftAndDeleted?: boolean;
   searchJoins?: SavedSearchJoin[];
   exclusionListId?: number;
-  candidateFilterByOpps?: CandidateFilterByOpps;
 }


### PR DESCRIPTION
I've made a new issue for rehoming the recruitment pipeline stats - my inclination is we don't delete the more complex code until that's resolved.

I'll make it an action item in the new issue to revisit and delete the commented-out code, as well as removing the DB field from saved_search, if we decide to do away with it altogether.