### PR TITLE
Any search requests with joined searches processed as elastic

### DIFF
--- a/server/src/main/java/org/tctalent/server/service/db/impl/SavedSearchServiceImpl.java
+++ b/server/src/main/java/org/tctalent/server/service/db/impl/SavedSearchServiceImpl.java
@@ -296,8 +296,11 @@ public class SavedSearchServiceImpl implements SavedSearchService {
 
         Set<Long> candidateIds = new HashSet<>();
         String simpleQueryString = searchRequest.getSimpleQueryString();
-        if (simpleQueryString != null && simpleQueryString.length() > 0) {
-            // This is an elasticsearch request
+        if (
+            (simpleQueryString != null && !simpleQueryString.isEmpty()) ||
+                !searchRequest.getSearchJoinRequests().isEmpty()
+        ) {
+            // This is an elasticsearch request OR is built on one or more other searches.
 
             // Combine any joined searches (which will all be processed as elastic)
             BoolQueryBuilder boolQueryBuilder = processElasticRequest(searchRequest,
@@ -944,7 +947,7 @@ public class SavedSearchServiceImpl implements SavedSearchService {
 
         // Not every base search will contain an elastic search term, since we're processing
         // joined regular searches here too — so we need a safe escape here
-        if (simpleQueryString != null && simpleQueryString.length() > 0) {
+        if (simpleQueryString != null && !simpleQueryString.isEmpty()) {
             // Create a simple query string builder from the given string
             SimpleQueryStringBuilder simpleQueryStringBuilder =
                 QueryBuilders.simpleQueryStringQuery(simpleQueryString);
@@ -1707,8 +1710,11 @@ public class SavedSearchServiceImpl implements SavedSearchService {
         addDefaultsToSearchCandidateRequest(searchRequest);
 
         String simpleQueryString = searchRequest.getSimpleQueryString();
-        if (simpleQueryString != null && simpleQueryString.length() > 0) {
-            // This is an elasticsearch request
+        if (
+            (simpleQueryString != null && !simpleQueryString.isEmpty()) ||
+                !searchRequest.getSearchJoinRequests().isEmpty()
+        ) {
+            // This is an elasticsearch request OR is built on one or more other searches.
 
             // Combine any joined searches (which will all be processed as elastic)
             BoolQueryBuilder boolQueryBuilder = processElasticRequest(searchRequest,


### PR DESCRIPTION
Call me an extremist but I think this is the solution! ES and regular search are fully aligned now: we could start processing the joined searches and back out of regular search and into ES if we encounter a Keyword Search term, but that seems wasteful and unnecessarily complicated.

While it has become redundant for now, I do think we should keep the code in regular search processing that would handle joined searches — it's not totally out the question that we would diverge from this approach in future. 

But I'd be interested to get the team's view on that.

Also implemented Intellij recommendation to use .isEmpty() on keyword search.