### PR TITLE
create log builder to log common monitoring data such as user ids

### DIFF
--- a/server/src/main/java/org/tctalent/server/api/admin/CandidateStatAdminApi.java
+++ b/server/src/main/java/org/tctalent/server/api/admin/CandidateStatAdminApi.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections.CollectionUtils;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -31,6 +32,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.tctalent.server.exception.InvalidSessionException;
 import org.tctalent.server.exception.NoSuchObjectException;
+import org.tctalent.server.logging.LogBuilder;
 import org.tctalent.server.model.db.Candidate;
 import org.tctalent.server.model.db.Country;
 import org.tctalent.server.model.db.Gender;
@@ -48,6 +50,7 @@ import org.tctalent.server.util.dto.DtoBuilder;
 @RestController()
 @RequestMapping("/api/admin/candidate/stat")
 @RequiredArgsConstructor
+@Slf4j
 public class CandidateStatAdminApi {
 
     private final CandidateService candidateService;
@@ -75,6 +78,14 @@ public class CandidateStatAdminApi {
         //Check whether the requested data to report on is from a set of candidates
         Set<Long> candidateIds = null;
         if (request.getListId() != null) {
+
+            LogBuilder.builder(log)
+                .user(authService.getLoggedInUser())
+                .listId(request.getListId())
+                .action("Get all stats")
+                .message("Getting all stats for list with id: " + request.getListId())
+                .logInfo();
+
             //Get candidates from list
             SavedList list = savedListService.get(request.getListId());
             Set<Candidate> candidates = list.getCandidates();
@@ -85,6 +96,14 @@ public class CandidateStatAdminApi {
             }
 
         } else if (request.getSearchId() != null) {
+
+            LogBuilder.builder(log)
+                .user(authService.getLoggedInUser())
+                .searchId(request.getSearchId())
+                .action("Get all stats")
+                .message("Getting all stats for search with id: " + request.getSearchId())
+                .logInfo();
+
             //Get candidates from search
             candidateIds = savedSearchService.searchCandidates(request.getSearchId());
         }
@@ -104,6 +123,14 @@ public class CandidateStatAdminApi {
         for (StatReport statReport: statReports) {
             dto.add(statDto().buildReport(statReport));
         }
+
+        LogBuilder.builder(log)
+            .user(authService.getLoggedInUser())
+            .listId(request.getListId())
+            .searchId(request.getSearchId())
+            .action("Get all stats")
+            .message("Returning all stats")
+            .logInfo();
 
         return dto;
     }

--- a/server/src/main/java/org/tctalent/server/api/portal/BrandingPortalApi.java
+++ b/server/src/main/java/org/tctalent/server/api/portal/BrandingPortalApi.java
@@ -17,13 +17,13 @@
 package org.tctalent.server.api.portal;
 
 import java.util.Map;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.tctalent.server.logging.LogBuilder;
 import org.tctalent.server.model.db.BrandingInfo;
 import org.tctalent.server.service.db.BrandingService;
 import org.tctalent.server.util.dto.DtoBuilder;
@@ -33,8 +33,8 @@ import org.tctalent.server.util.dto.DtoBuilder;
  */
 @RestController()
 @RequestMapping("/api/portal/branding")
+@Slf4j
 public class BrandingPortalApi {
-    private static final Logger log = LoggerFactory.getLogger(BrandingPortalApi.class);
 
     private final BrandingService brandingService;
 
@@ -52,7 +52,10 @@ public class BrandingPortalApi {
         @RequestParam(value = "p", required = false) final String partnerAbbreviation) {
 
         if (partnerAbbreviation != null) {
-            log.info("Branding Info fetched with partner query param: 'p=" + partnerAbbreviation + "'");
+            LogBuilder.builder(log)
+                .action("Get branding info")
+                .message("Branding Info fetched with partner query param: 'p=" + partnerAbbreviation + "'")
+                .logInfo();
         }
         BrandingInfo info = brandingService.getBrandingInfo(partnerAbbreviation);
         return brandingInfoDto().build(info);

--- a/server/src/main/java/org/tctalent/server/logging/LogBuilder.java
+++ b/server/src/main/java/org/tctalent/server/logging/LogBuilder.java
@@ -24,19 +24,43 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.tctalent.server.model.db.User;
 
+/**
+ * The {@code LogBuilder} class is used to construct log messages with standardised fields
+ * and log them using SLF4J. The fields are specified using the {@link LogField} enum and are
+ * included in the log messages based on their sort order.
+ *
+ * @author sadatmalik
+ */
 public class LogBuilder {
   private final Logger logger;
   private final Map<LogField, String> logFields;
 
+  /**
+   * Constructs a new {@code LogBuilder} with the specified {@link Logger}.
+   *
+   * @param logger the SLF4J logger to use for logging
+   */
   private LogBuilder(Logger logger) {
     this.logger = logger;
     this.logFields = new EnumMap<>(LogField.class);
   }
 
+  /**
+   * Creates a new {@code LogBuilder} instance with the specified {@link Logger}.
+   *
+   * @param logger the SLF4J logger to use for logging
+   * @return a new instance of {@code LogBuilder}
+   */
   public static LogBuilder builder(Logger logger) {
     return new LogBuilder(logger);
   }
 
+  /**
+   * Adds the user ID to the log fields if the user is present.
+   *
+   * @param loggedInUser an {@link Optional} containing the logged-in user
+   * @return the current {@code LogBuilder} instance for chaining
+   */
   public LogBuilder user(Optional<User> loggedInUser) {
     loggedInUser
         .map(User::getId)
@@ -45,6 +69,12 @@ public class LogBuilder {
     return this;
   }
 
+  /**
+   * Adds the list ID to the log fields if the list ID is not null.
+   *
+   * @param listId the list ID
+   * @return the current {@code LogBuilder} instance for chaining
+   */
   public LogBuilder listId(Long listId) {
     if (listId == null) {
       return this;
@@ -53,6 +83,12 @@ public class LogBuilder {
     return this;
   }
 
+  /**
+   * Adds the search ID to the log fields if the search ID is not null.
+   *
+   * @param searchId the search ID
+   * @return the current {@code LogBuilder} instance for chaining
+   */
   public LogBuilder searchId(Long searchId) {
     if (searchId == null) {
       return this;
@@ -61,6 +97,12 @@ public class LogBuilder {
     return this;
   }
 
+  /**
+   * Adds the job ID to the log fields if the job ID is not null.
+   *
+   * @param jobId the job ID
+   * @return the current {@code LogBuilder} instance for chaining
+   */
   public LogBuilder jobId(Long jobId) {
     if (jobId == null) {
       return this;
@@ -69,6 +111,12 @@ public class LogBuilder {
     return this;
   }
 
+  /**
+   * Adds the action to the log fields if the action is not null.
+   *
+   * @param action the action
+   * @return the current {@code LogBuilder} instance for chaining
+   */
   public LogBuilder action(String action) {
     if (action == null) {
       return this;
@@ -77,6 +125,12 @@ public class LogBuilder {
     return this;
   }
 
+  /**
+   * Adds the message to the log fields if the message is not null.
+   *
+   * @param message the message
+   * @return the current {@code LogBuilder} instance for chaining
+   */
   public LogBuilder message(String message) {
     if (message == null) {
       return this;
@@ -85,28 +139,49 @@ public class LogBuilder {
     return this;
   }
 
-  private void addField(LogField field, String value) {
-    logFields.put(field, value);
-  }
-
+  /**
+   * Logs the constructed message at the INFO level.
+   */
   public void logInfo() {
     logger.info(buildLogMessage());
   }
 
+  /**
+   * Logs the constructed message at the ERROR level.
+   */
   public void logError() {
     logger.error(buildLogMessage());
   }
 
+  /**
+   * Logs the constructed message at the DEBUG level.
+   */
   public void logDebug() {
     logger.debug(buildLogMessage());
   }
 
+  /**
+   * Constructs the log message by sorting the log fields based on their sort order
+   * and concatenating them into a single string.
+   *
+   * @return the constructed log message
+   */
   private String buildLogMessage() {
     return logFields.entrySet().stream()
         .filter(entry -> entry.getValue() != null)
         .sorted(Map.Entry.comparingByKey(Comparator.comparingInt(LogField::getSortOrder)))
         .map(entry -> entry.getKey().getLabel() + ": " + entry.getValue())
         .collect(Collectors.joining(" | "));
+  }
+
+  /**
+   * Adds a field to the log fields map.
+   *
+   * @param field the log field
+   * @param value the value of the log field
+   */
+  private void addField(LogField field, String value) {
+    logFields.put(field, value);
   }
 
 }

--- a/server/src/main/java/org/tctalent/server/logging/LogBuilder.java
+++ b/server/src/main/java/org/tctalent/server/logging/LogBuilder.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2024 Talent Beyond Boundaries.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.logging;
+
+import java.util.Comparator;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.TreeMap;
+import org.slf4j.Logger;
+import org.tctalent.server.model.db.User;
+
+public class LogBuilder {
+  private final Logger logger;
+  private final Map<LogField, String> logFields;
+
+  private LogBuilder(Logger logger) {
+    this.logger = logger;
+    this.logFields = new EnumMap<>(LogField.class);
+  }
+
+  public static LogBuilder builder(Logger logger) {
+    return new LogBuilder(logger);
+  }
+
+  public LogBuilder user(Optional<User> loggedInUser) {
+    loggedInUser
+        .map(User::getId)
+        .map(Object::toString)
+        .ifPresent(userId -> addField(LogField.USER_ID, userId));
+    return this;
+  }
+
+  public LogBuilder listId(Long listId) {
+    if (listId == null) {
+      return this;
+    }
+    addField(LogField.LIST_ID, listId.toString());
+    return this;
+  }
+
+  public LogBuilder searchId(Long searchId) {
+    if (searchId == null) {
+      return this;
+    }
+    addField(LogField.SEARCH_ID, searchId.toString());
+    return this;
+  }
+
+  public LogBuilder jobId(Long jobId) {
+    if (jobId == null) {
+      return this;
+    }
+    addField(LogField.JOB_ID, jobId.toString());
+    return this;
+  }
+
+  public LogBuilder action(String action) {
+    if (action == null) {
+      return this;
+    }
+    addField(LogField.ACTION, action);
+    return this;
+  }
+
+  public LogBuilder message(String message) {
+    if (message == null) {
+      return this;
+    }
+    addField(LogField.MESSAGE, message);
+    return this;
+  }
+
+  private void addField(LogField field, String value) {
+    logFields.put(field, value);
+  }
+
+  public void logInfo() {
+    logger.info(buildLogMessage());
+  }
+
+  public void logError() {
+    logger.error(buildLogMessage());
+  }
+
+  public void logDebug() {
+    logger.debug(buildLogMessage());
+  }
+
+  private String buildLogMessage() {
+    StringBuilder sb = new StringBuilder();
+
+    // Sort log fields based on sortOrder
+    TreeMap<LogField, String> sortedLogFields =
+        new TreeMap<>(Comparator.comparingInt(LogField::getSortOrder));
+
+    sortedLogFields.putAll(logFields);
+
+    sortedLogFields.forEach((field, value) -> {
+      if (value != null) {
+        sb.append(field.getLabel()).append(": ").append(value).append(" | ");
+      }
+    });
+
+    // Remove the trailing " | " if present
+    if (!sb.isEmpty()) {
+      sb.setLength(sb.length() - 3);
+    }
+
+    return sb.toString();
+  }
+
+}

--- a/server/src/main/java/org/tctalent/server/logging/LogBuilder.java
+++ b/server/src/main/java/org/tctalent/server/logging/LogBuilder.java
@@ -20,7 +20,7 @@ import java.util.Comparator;
 import java.util.EnumMap;
 import java.util.Map;
 import java.util.Optional;
-import java.util.TreeMap;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.tctalent.server.model.db.User;
 
@@ -102,26 +102,11 @@ public class LogBuilder {
   }
 
   private String buildLogMessage() {
-    StringBuilder sb = new StringBuilder();
-
-    // Sort log fields based on sortOrder
-    TreeMap<LogField, String> sortedLogFields =
-        new TreeMap<>(Comparator.comparingInt(LogField::getSortOrder));
-
-    sortedLogFields.putAll(logFields);
-
-    sortedLogFields.forEach((field, value) -> {
-      if (value != null) {
-        sb.append(field.getLabel()).append(": ").append(value).append(" | ");
-      }
-    });
-
-    // Remove the trailing " | " if present
-    if (!sb.isEmpty()) {
-      sb.setLength(sb.length() - 3);
-    }
-
-    return sb.toString();
+    return logFields.entrySet().stream()
+        .filter(entry -> entry.getValue() != null)
+        .sorted(Map.Entry.comparingByKey(Comparator.comparingInt(LogField::getSortOrder)))
+        .map(entry -> entry.getKey().getLabel() + ": " + entry.getValue())
+        .collect(Collectors.joining(" | "));
   }
 
 }

--- a/server/src/main/java/org/tctalent/server/logging/LogField.java
+++ b/server/src/main/java/org/tctalent/server/logging/LogField.java
@@ -19,9 +19,37 @@ package org.tctalent.server.logging;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+/**
+ * The {@code LogField} enum represents the fields that can be included in a log message.
+ * Each field has a label and a sort order, which is used to determine the order in which
+ * the fields are included in the log message.
+ * <p>
+ * The following are the available log fields:
+ *
+ * <ul>
+ *     <li>USER_ID - User ID field</li>
+ *     <li>CANDIDATE_NUMBER - Candidate number field</li>
+ *     <li>JOB_ID - Job ID field</li>
+ *     <li>LIST_ID - List ID field</li>
+ *     <li>SEARCH_ID - Search ID field</li>
+ *     <li>ACTION - Action field</li>
+ *     <li>MESSAGE - Message field</li>
+ * </ul>
+ *
+ * Each field has a corresponding label and sort order.
+ * <p>
+ * Example usage:
+ * <pre>
+ *     LogField.USER_ID.getLabel();  // returns "uid"
+ *     LogField.USER_ID.getSortOrder();  // returns 100
+ * </pre>
+ *
+ * @author sadatmalik
+ */
 @Getter
 @RequiredArgsConstructor
 public enum LogField {
+
   USER_ID("uid", 100),
   CANDIDATE_NUMBER("cn", 101),
   JOB_ID("jid", 102),
@@ -30,6 +58,13 @@ public enum LogField {
   ACTION("action", 105),
   MESSAGE("msg", 106);
 
+  /**
+   * The label of the log field, used as a prefix in log messages.
+   */
   private final String label;
+
+  /**
+   * The sort order of the log field, used to determine the order of fields in log messages.
+   */
   private final Integer sortOrder;
 }

--- a/server/src/main/java/org/tctalent/server/logging/LogField.java
+++ b/server/src/main/java/org/tctalent/server/logging/LogField.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2024 Talent Beyond Boundaries.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.logging;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum LogField {
+  USER_ID("uid", 100),
+  CANDIDATE_NUMBER("cn", 101),
+  JOB_ID("jid", 102),
+  LIST_ID("lid", 103),
+  SEARCH_ID("sid", 104),
+  ACTION("action", 105),
+  MESSAGE("msg", 106);
+
+  private final String label;
+  private final Integer sortOrder;
+}

--- a/server/src/test/java/org/tctalent/server/api/admin/CandidateStatAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/CandidateStatAdminApiTest.java
@@ -22,6 +22,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
@@ -146,7 +147,7 @@ class CandidateStatAdminApiTest extends ApiTestBase {
         .andExpect(jsonPath("$[0].rows[2].label", is("female")))
         .andExpect(jsonPath("$[0].rows[2].value", is(2588)));
 
-    verify(authService).getLoggedInUser();
+    verify(authService, atLeastOnce()).getLoggedInUser();
     verify(candidateService).computeGenderStats(any(), any(), any());
   }
 
@@ -184,7 +185,7 @@ class CandidateStatAdminApiTest extends ApiTestBase {
         .andExpect(jsonPath("$[1].rows[2].label", is("2016-06-14")))
         .andExpect(jsonPath("$[1].rows[2].value", is(1)));
 
-    verify(authService).getLoggedInUser();
+    verify(authService, atLeastOnce()).getLoggedInUser();
     verify(candidateService).computeRegistrationStats(any(), any(), any());
   }
 
@@ -222,7 +223,7 @@ class CandidateStatAdminApiTest extends ApiTestBase {
         .andExpect(jsonPath("$[2].rows[2].label", is("Teacher")))
         .andExpect(jsonPath("$[2].rows[2].value", is(777)));
 
-    verify(authService).getLoggedInUser();
+    verify(authService, atLeastOnce()).getLoggedInUser();
     verify(candidateService).computeRegistrationOccupationStats(any(), any(), any());
   }
 
@@ -260,7 +261,7 @@ class CandidateStatAdminApiTest extends ApiTestBase {
         .andExpect(jsonPath("$[3].rows[2].label", is("1951")))
         .andExpect(jsonPath("$[3].rows[2].value", is(1)));
 
-    verify(authService).getLoggedInUser();
+    verify(authService, atLeastOnce()).getLoggedInUser();
     verify(candidateService, times(3)).computeBirthYearStats(any(), any(), any(), any());
   }
 
@@ -296,7 +297,7 @@ class CandidateStatAdminApiTest extends ApiTestBase {
         .andExpect(jsonPath("$[6].rows[1].label", is("Has link")))
         .andExpect(jsonPath("$[6].rows[1].value", is(10)));
 
-    verify(authService).getLoggedInUser();
+    verify(authService, atLeastOnce()).getLoggedInUser();
     verify(candidateService).computeLinkedInExistsStats(any(), any(), any());
   }
 
@@ -334,7 +335,7 @@ class CandidateStatAdminApiTest extends ApiTestBase {
         .andExpect(jsonPath("$[7].rows[2].label", is("2016-06-14")))
         .andExpect(jsonPath("$[7].rows[2].value", is(1)));
 
-    verify(authService).getLoggedInUser();
+    verify(authService, atLeastOnce()).getLoggedInUser();
     verify(candidateService).computeLinkedInStats(any(), any(), any());
   }
 
@@ -372,7 +373,7 @@ class CandidateStatAdminApiTest extends ApiTestBase {
         .andExpect(jsonPath("$[8].rows[2].label", is("No")))
         .andExpect(jsonPath("$[8].rows[2].value", is(1)));
 
-    verify(authService).getLoggedInUser();
+    verify(authService, atLeastOnce()).getLoggedInUser();
     verify(candidateService).computeUnhcrRegisteredStats(any(), any(), any());
   }
 
@@ -412,7 +413,7 @@ class CandidateStatAdminApiTest extends ApiTestBase {
         .andExpect(jsonPath("$[9].rows[3].label", is("RegisteredStatusUnknown")))
         .andExpect(jsonPath("$[9].rows[3].value", is(1)));
 
-    verify(authService).getLoggedInUser();
+    verify(authService, atLeastOnce()).getLoggedInUser();
     verify(candidateService).computeUnhcrStatusStats(any(), any(), any());
   }
 
@@ -448,7 +449,7 @@ class CandidateStatAdminApiTest extends ApiTestBase {
         .andExpect(jsonPath("$[10].rows[1].label", is("Syria")))
         .andExpect(jsonPath("$[10].rows[1].value", is(14852)));
 
-    verify(authService).getLoggedInUser();
+    verify(authService, atLeastOnce()).getLoggedInUser();
     verify(candidateService, times(5)).computeNationalityStats(any(), any(), any(), any(), any());
   }
 
@@ -484,7 +485,7 @@ class CandidateStatAdminApiTest extends ApiTestBase {
         .andExpect(jsonPath("$[15].rows[1].label", is("Jordan")))
         .andExpect(jsonPath("$[15].rows[1].value", is(4396)));
 
-    verify(authService).getLoggedInUser();
+    verify(authService, atLeastOnce()).getLoggedInUser();
     verify(candidateService, times(3)).computeSourceCountryStats(any(), any(), any(), any());
   }
 
@@ -526,7 +527,7 @@ class CandidateStatAdminApiTest extends ApiTestBase {
         .andExpect(jsonPath("$[18].rows[4].label", is("autonomousEmployment")))
         .andExpect(jsonPath("$[18].rows[4].value", is(5000)));
 
-    verify(authService).getLoggedInUser();
+    verify(authService, atLeastOnce()).getLoggedInUser();
     verify(candidateService, times(5)).computeStatusStats(any(), any(), any(), any(), any());
   }
 
@@ -564,7 +565,7 @@ class CandidateStatAdminApiTest extends ApiTestBase {
         .andExpect(jsonPath("$[23].rows[2].label", is("Accountant")))
         .andExpect(jsonPath("$[23].rows[2].value", is(3000)));
 
-    verify(authService).getLoggedInUser();
+    verify(authService, atLeastOnce()).getLoggedInUser();
     verify(candidateService, times(3)).computeOccupationStats(any(), any(), any(), any());
   }
 
@@ -602,7 +603,7 @@ class CandidateStatAdminApiTest extends ApiTestBase {
         .andExpect(jsonPath("$[26].rows[2].label", is("Accountant")))
         .andExpect(jsonPath("$[26].rows[2].value", is(3000)));
 
-    verify(authService).getLoggedInUser();
+    verify(authService, atLeastOnce()).getLoggedInUser();
     verify(candidateService, times(3)).computeMostCommonOccupationStats(any(), any(), any(), any());
   }
 
@@ -640,7 +641,7 @@ class CandidateStatAdminApiTest extends ApiTestBase {
         .andExpect(jsonPath("$[29].rows[2].label", is("Doctoral Degree")))
         .andExpect(jsonPath("$[29].rows[2].value", is(3000)));
 
-    verify(authService).getLoggedInUser();
+    verify(authService, atLeastOnce()).getLoggedInUser();
     verify(candidateService, times(3)).computeMaxEducationStats(any(), any(), any(), any());
   }
 
@@ -678,7 +679,7 @@ class CandidateStatAdminApiTest extends ApiTestBase {
         .andExpect(jsonPath("$[32].rows[2].label", is("French")))
         .andExpect(jsonPath("$[32].rows[2].value", is(3000)));
 
-    verify(authService).getLoggedInUser();
+    verify(authService, atLeastOnce()).getLoggedInUser();
     verify(candidateService, times(3)).computeLanguageStats(any(), any(), any(), any());
   }
 
@@ -714,7 +715,7 @@ class CandidateStatAdminApiTest extends ApiTestBase {
         .andExpect(jsonPath("$[35].rows[1].label", is("uncle fred")))
         .andExpect(jsonPath("$[35].rows[1].value", is(2000)));
 
-    verify(authService).getLoggedInUser();
+    verify(authService, atLeastOnce()).getLoggedInUser();
     verify(candidateService, times(3)).computeReferrerStats(any(), any(), any(), any(), any());
   }
 
@@ -752,7 +753,7 @@ class CandidateStatAdminApiTest extends ApiTestBase {
         .andExpect(jsonPath("$[38].rows[2].label", is("NGO")))
         .andExpect(jsonPath("$[38].rows[2].value", is(3000)));
 
-    verify(authService).getLoggedInUser();
+    verify(authService, atLeastOnce()).getLoggedInUser();
     verify(candidateService, times(5)).computeSurveyStats(any(), any(), any(), any(), any());
   }
 
@@ -790,7 +791,7 @@ class CandidateStatAdminApiTest extends ApiTestBase {
         .andExpect(jsonPath("$[43].rows[2].label", is("Elementary Proficiency")))
         .andExpect(jsonPath("$[43].rows[2].value", is(3000)));
 
-    verify(authService).getLoggedInUser();
+    verify(authService, atLeastOnce()).getLoggedInUser();
     verify(candidateService, times(6)).computeSpokenLanguageLevelStats(any(), any(), any(), any(), any());
   }
 


### PR DESCRIPTION
This PR:

- adds a logging package to the project with a log builder for standardised log generation
- applies the log builder to the candidate stats admin and branding portal APIs

A future PR will apply the log builder to all classes.
