### PR TITLE
**REVIEW #1123 FIRST** CP emoji and reaction pickers refactoring

### DIFF
--- a/ui/candidate-portal/src/app/components/chat/create-update-post/create-update-post.component.html
+++ b/ui/candidate-portal/src/app/components/chat/create-update-post/create-update-post.component.html
@@ -41,7 +41,7 @@
         <button
           id="emojiBtn"
           [ngClass]="!this.emojiPickerVisible ? 'custom-emoji-btn' : 'custom-emoji-btn-menu-open'"
-          (click)="onClickEmojiBtn()">
+          (click)="toggleEmojiPicker()">
           <fa-icon icon="face-smile" size="xs"></fa-icon>
         </button>
       </div>
@@ -66,4 +66,4 @@
   [perLine]="8"
 ></emoji-mart>
 
-<div *ngIf="emojiPickerVisible" class="overlay"></div>
+<div *ngIf="emojiPickerVisible" class="overlay" (click)="toggleEmojiPicker()"></div>

--- a/ui/candidate-portal/src/app/components/chat/create-update-post/create-update-post.component.ts
+++ b/ui/candidate-portal/src/app/components/chat/create-update-post/create-update-post.component.ts
@@ -14,7 +14,7 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-import {Component, ElementRef, Input, OnInit, ViewChild} from '@angular/core';
+import {Component, Input, OnInit} from '@angular/core';
 import {FormBuilder, FormGroup, Validators} from "@angular/forms";
 import {RxStompService} from "../../../services/rx-stomp.service";
 import {JobChat, Post} from "../../../model/chat";
@@ -30,8 +30,6 @@ import {FileSelectorComponent} from "../../util/file-selector/file-selector.comp
 })
 export class CreateUpdatePostComponent implements OnInit {
   @Input() chat: JobChat;
-
-  @ViewChild('editorPickerSpan') editorPickerSpan: ElementRef;
 
   error: any;
   saving: any;
@@ -124,10 +122,10 @@ export class CreateUpdatePostComponent implements OnInit {
     this.quillEditorRef.setSelection(index + 2, 0);
   }
 
-  // Toggles the emoji picker on and off using the button on the editor toolbar, refocuses the caret.
-  public onClickEmojiBtn() {
+  // Toggles the emoji picker on or off and focuses the caret.
+  public toggleEmojiPicker() {
     this.emojiPickerVisible = !this.emojiPickerVisible;
-    // If closing the picker, focus the caret in editor.
+    // When closing, focus the caret in editor.
     if(!this.emojiPickerVisible) {
       const index: number = this.quillEditorRef.selection.savedRange.index;
       this.quillEditorRef.setSelection(index, 0);

--- a/ui/candidate-portal/src/app/components/chat/view-chat-posts/view-chat-posts.component.html
+++ b/ui/candidate-portal/src/app/components/chat/view-chat-posts/view-chat-posts.component.html
@@ -16,7 +16,6 @@
          (click)="selectCurrent(post)"
          [ngClass]="{'current': currentPost?.id == post.id}">
       <app-view-post
-        [currentPost] ="currentPost"
         [post]="post">
       </app-view-post>
     </div>

--- a/ui/candidate-portal/src/app/components/chat/view-chat-posts/view-chat-posts.component.ts
+++ b/ui/candidate-portal/src/app/components/chat/view-chat-posts/view-chat-posts.component.ts
@@ -1,6 +1,5 @@
 import {
   Component,
-  HostListener,
   Input,
   OnChanges,
   OnDestroy,
@@ -71,46 +70,4 @@ export class ViewChatPostsComponent extends PostsComponentBase
     }
   }
 
-// Ensures that reaction and editor emoji pickers are not open at the same time, and that clicks
-  // anywhere on the DOM outside an open picker will close that picker. Reaction pickers are
-  // attached to instances of ViewPostComponent (reacting to posts) and the editor picker is
-  // attached to the Quill toolbar (writing posts).
-  @HostListener('document:click', ['$event'])
-  documentClick(event) {
-    // Identify the post with an open reaction picker, if any
-    const postWithOpenPicker =
-        this.viewPostComponents.find(
-            (post) => post.reactionPickerVisible)
-
-    // Check if any picker is open
-    if(this.editor.emojiPickerVisible || postWithOpenPicker != null) {
-
-      // Generate value to check if click was within any emoji picker
-      const sectionClass: string =
-          event.target.closest('section') ?
-              event.target.closest('section').classList[0] : "";
-
-      // Generate value to check if click was on an emoji picker toggle button (smiley emoji icon)
-      const clickedElementId: string =
-        event.target.closest('button') ?
-          event.target.closest('button').id : "";
-
-      if (clickedElementId.includes('reactionBtn') && this.editor.emojiPickerVisible) {
-        // If click was on reaction picker toggle button, close the editor picker
-        this.editor.emojiPickerVisible = false
-      } else if (clickedElementId.includes('emojiBtn') && postWithOpenPicker != null) {
-        // If click was on editor picker toggle button, close the post reaction picker
-        postWithOpenPicker.reactionPickerVisible = false;
-      }
-      else if (!sectionClass.includes('emoji') &&
-          !clickedElementId.includes('reactionBtn') &&
-          !clickedElementId.includes('emojiBtn')) {
-        // If click was not on any emoji picker toggle button or emoji picker, close any open picker
-        this.editor.emojiPickerVisible = false;
-        if (postWithOpenPicker) {
-          postWithOpenPicker.reactionPickerVisible = false;
-        }
-      }
-    }
-  }
 }

--- a/ui/candidate-portal/src/app/components/chat/view-post/view-post.component.html
+++ b/ui/candidate-portal/src/app/components/chat/view-post/view-post.component.html
@@ -10,7 +10,7 @@
     id="reactionBtn"
     [ngClass]="!this.reactionPickerVisible ?
     'reaction-btn' : 'reaction-btn-selected'"
-    (click)="onClickReactionBtn()">
+    (click)="toggleReactionPicker()">
       <fa-icon id="reactionBtnSmiley" icon="face-smile" size="xs"></fa-icon>+
     </button>
     <button
@@ -41,4 +41,4 @@
   [autoFocus]="true"
 ></emoji-mart>
 
-<div *ngIf="reactionPickerVisible" class="overlay"></div>
+<div *ngIf="reactionPickerVisible" class="overlay" (click)="toggleReactionPicker()"></div>

--- a/ui/candidate-portal/src/app/components/chat/view-post/view-post.component.html
+++ b/ui/candidate-portal/src/app/components/chat/view-post/view-post.component.html
@@ -6,17 +6,14 @@
   <p class="content" *ngIf="post?.content" [ngClass]="{'html':isHtml(post.content), 'text':!isHtml(post.content)}" [innerHtml]="post.content"></p>
 
   <div class="d-flex flex-row-reverse flex-wrap">
-    <button
-    id="reactionBtn"
-    [ngClass]="!this.reactionPickerVisible ?
-    'reaction-btn' : 'reaction-btn-selected'"
-    (click)="toggleReactionPicker()">
+    <button id="reactionBtn"
+            [ngClass]="!this.reactionPickerVisible ? 'reaction-btn' : 'reaction-btn-selected'"
+            (click)="toggleReactionPicker()">
       <fa-icon id="reactionBtnSmiley" icon="face-smile" size="xs"></fa-icon>+
     </button>
-    <button
-    class="modify-reaction-btn"
-    *ngFor="let reaction of post.reactions"
-    (click)="onSelectReaction(reaction)">
+    <button class="modify-reaction-btn"
+            *ngFor="let reaction of post.reactions"
+            (click)="onSelectReaction(reaction)">
       <span [ngbTooltip]="reactionToolTip">
         {{reaction.emoji}} {{reaction.users.length}}
       </span>

--- a/ui/candidate-portal/src/app/components/chat/view-post/view-post.component.ts
+++ b/ui/candidate-portal/src/app/components/chat/view-post/view-post.component.ts
@@ -35,7 +35,6 @@ export class ViewPostComponent implements OnInit {
   }
 
   @Input() post: ChatPost;
-  @Input() currentPost: ChatPost;
 
   @ViewChild('thisPost') thisPost: ElementRef;
 
@@ -53,9 +52,10 @@ export class ViewPostComponent implements OnInit {
     return UserService.userToString(user, false, false);
   }
 
-  // Toggles the picker on and off — if on, focuses the scroll bar on its post
-  public onClickReactionBtn() {
+  // Toggles the picker on and off, focuses the scroll bar on this post if reaction button clicked.
+  public toggleReactionPicker() {
     this.reactionPickerVisible = !this.reactionPickerVisible;
+    // Scrolls entire post into view when picker has been toggled on by reaction button
     if(this.reactionPickerVisible) {
       setTimeout(() => {
         this.thisPost.nativeElement.scrollIntoView({behavior: 'smooth'});
@@ -84,29 +84,5 @@ export class ViewPostComponent implements OnInit {
                             this.post.reactions = updatedReactions
                           })
   }
-
-  // Below commented-out methods and class property were closing unwanted emoji pickers.
-  // Leaving them here as they're likely to be useful for future styling and functionality.
-  // Used in conjunction with @Input currentPost.
-
-  // isCurrentPost: boolean = false;
-
-  // ngOnChanges(changes: SimpleChanges) {
-  //   for (const propName in changes) {
-  //     if (changes.hasOwnProperty(propName)) {
-  //       switch (propName) {
-  //         case 'currentPost': {
-  //           this.setIsCurrentPost(
-  //             changes.currentPost.currentValue
-  //           )
-  //         }
-  //       }
-  //     }
-  //   }
-  // }
-  //
-  // private setIsCurrentPost(currentPost: ChatPost) {
-  //   this.isCurrentPost = currentPost === this.post;
-  // }
 
 }


### PR DESCRIPTION
Just some tidying and simplification. Admin Portal and Candidate Portal are implemented slightly differently, and I was able to get rid from the CP of some of the code I had duplicated between them.

Chiefly there's a bit of complex logic on the AP to avoid two pickers being open at once, but that's not an issue on the CP because for mobile view I preferred a centred picker over an overlay. Whenever the overlay is clicked (i.e. outside the picker), it closes. So I don't need any logic to handle more than one picker being open!