### PR TITLE
Do not trigger tc-build action on merge to staging

### DIFF
--- a/.github/workflows/tc-build.yml
+++ b/.github/workflows/tc-build.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - '*'
+      - '!staging'
 
 jobs:
   build:


### PR DESCRIPTION
This PR:

- Disables the tc-build action from triggering on merging changes to staging. 

The build is already covered in the tc-test-build-deploy action, so this PR prevents the build from running twice when pushing changes to staging.