### PR TITLE
temporarily disable gatling tests

### DIFF
--- a/.github/workflows/tc-gatling-tests.yml
+++ b/.github/workflows/tc-gatling-tests.yml
@@ -9,6 +9,11 @@ on:
 
 jobs:
   run-tests:
+    # This job is intentionally disabled because the Gatling Tests are currently failing.
+    # The 'if: false' condition effectively prevents this job from running under any circumstances.
+    # This will remain in place until the SDET has a chance to review and set appropriate performance
+    # test benchmarks and a spin-up/tear-down perf environment is in place.
+    if: false # this attribute disables the job
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
This PR:

- Temporarily disables the Gatling Tests action from running.

This will remain in place until @EhsanEhrari can review and set suitable performance benchmarks, and a spin-up/tear-down perf environment is in place where perf tests can be run in isolation.