### PR TITLE
handle expired jwt token errors in web socket connects

### DIFF
--- a/server/src/main/java/org/tctalent/server/configuration/WebSocketConfig2.java
+++ b/server/src/main/java/org/tctalent/server/configuration/WebSocketConfig2.java
@@ -96,7 +96,7 @@ public class WebSocketConfig2 implements WebSocketMessageBrokerConfigurer {
             }
 
             private void handleInvalidToken() {
-                throw new ExpiredTokenException(JwtTokenProvider.EXPIRED_OR_INVALID_JWT_TOKEN_MSG);
+                throw new ExpiredTokenException(JwtTokenProvider.EXPIRED_OR_INVALID_TOKEN_MSG);
             }
 
         });

--- a/server/src/main/java/org/tctalent/server/configuration/WebSocketConfig2.java
+++ b/server/src/main/java/org/tctalent/server/configuration/WebSocketConfig2.java
@@ -96,7 +96,6 @@ public class WebSocketConfig2 implements WebSocketMessageBrokerConfigurer {
             }
 
             private void handleInvalidToken() {
-//                throw new MessagingException(JwtTokenProvider.EXPIRED_OR_INVALID_JWT_TOKEN_MSG);
                 throw new ExpiredTokenException(JwtTokenProvider.EXPIRED_OR_INVALID_JWT_TOKEN_MSG);
             }
 

--- a/server/src/main/java/org/tctalent/server/exception/ExpiredTokenException.java
+++ b/server/src/main/java/org/tctalent/server/exception/ExpiredTokenException.java
@@ -22,6 +22,10 @@ public class ExpiredTokenException extends ServiceException {
         super("expired_password_token", "The reset password token has expired");
     }
 
+    public ExpiredTokenException(String message) {
+        super("expired_password_token", message);
+    }
+
     public ExpiredTokenException(Throwable cause) {
         super("expired_password_token", "The reset password token has expired", cause);
     }

--- a/server/src/main/java/org/tctalent/server/security/JwtTokenProvider.java
+++ b/server/src/main/java/org/tctalent/server/security/JwtTokenProvider.java
@@ -49,7 +49,7 @@ import org.tctalent.server.model.db.Role;
 @Slf4j
 public class JwtTokenProvider implements InitializingBean {
 
-    public static final String EXPIRED_OR_INVALID_JWT_TOKEN_MSG = "Expired or invalid JWT token";
+    public static final String EXPIRED_OR_INVALID_TOKEN_MSG = "Expired or invalid JWT token";
 
     @Value("${jwt.secret}")
     private String jwtSecretBase64;

--- a/server/src/main/java/org/tctalent/server/security/JwtTokenProvider.java
+++ b/server/src/main/java/org/tctalent/server/security/JwtTokenProvider.java
@@ -72,8 +72,7 @@ public class JwtTokenProvider implements InitializingBean {
         Date expiryDate = new Date(now.getTime() + jwtExpirationInMs);
         String subject = "";
 
-        if (authentication.getPrincipal() instanceof TcUserDetails) {
-            TcUserDetails user = (TcUserDetails) authentication.getPrincipal();
+        if (authentication.getPrincipal() instanceof TcUserDetails user) {
             subject = user.getUsername();
 
             //Candidates can stay logged in forever

--- a/server/src/main/java/org/tctalent/server/security/JwtTokenProvider.java
+++ b/server/src/main/java/org/tctalent/server/security/JwtTokenProvider.java
@@ -49,6 +49,8 @@ import org.tctalent.server.model.db.Role;
 @Slf4j
 public class JwtTokenProvider implements InitializingBean {
 
+    public static final String EXPIRED_OR_INVALID_JWT_TOKEN_MSG = "Expired or invalid JWT token";
+
     @Value("${jwt.secret}")
     private String jwtSecretBase64;
 

--- a/ui/admin-portal/src/app/app.constants.ts
+++ b/ui/admin-portal/src/app/app.constants.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2024 Talent Beyond Boundaries.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+export const ERROR_MESSAGES = {
+  EXPIRED_OR_INVALID_JWT: 'Expired or invalid JWT token'
+};

--- a/ui/admin-portal/src/app/services/chat.service.ts
+++ b/ui/admin-portal/src/app/services/chat.service.ts
@@ -8,6 +8,7 @@ import {Message} from "@stomp/stompjs";
 import {map, share, shareReplay, takeUntil, tap} from "rxjs/operators";
 import {RxStompConfig} from "@stomp/rx-stomp";
 import {AuthenticationService} from "./authentication.service";
+import {ERROR_MESSAGES} from "../app.constants";
 
 @Injectable({
   providedIn: 'root'
@@ -205,8 +206,27 @@ export class ChatService implements OnDestroy {
       let stompConfig = this.getRxStompConfig();
       this.rxStompService.configure(stompConfig);
       this.rxStompService.activate();
+      this.configureErrorHandling();
       this.stompServiceConfigured = true;
     }
+  }
+
+  private configureErrorHandling(): void {
+    this.rxStompService.stompErrors$
+    .pipe(
+      takeUntil(this.destroyStompSubscriptions$)
+    )
+    .subscribe((error) => {
+      if (error.headers && error.headers.message &&
+        error.headers.message.includes(ERROR_MESSAGES.EXPIRED_OR_INVALID_JWT)) {
+        this.handleExpiredOrInvalidToken();
+      }
+    });
+  }
+
+  private handleExpiredOrInvalidToken(): void {
+    console.log('Expired or invalid JWT  - logging out');
+    this.authenticationService.logout();
   }
 
   /**

--- a/ui/candidate-portal/src/app/app.constants.ts
+++ b/ui/candidate-portal/src/app/app.constants.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2024 Talent Beyond Boundaries.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+export const ERROR_MESSAGES = {
+  EXPIRED_OR_INVALID_JWT: 'Expired or invalid JWT token'
+};

--- a/ui/candidate-portal/src/app/services/chat.service.ts
+++ b/ui/candidate-portal/src/app/services/chat.service.ts
@@ -226,7 +226,7 @@ export class ChatService implements OnDestroy {
 
   private handleExpiredOrInvalidToken(): void {
     console.log('Expired or invalid JWT  - logging out');
-    // this.authenticationService.logout();
+    this.authenticationService.logout();
   }
 
   /**

--- a/ui/candidate-portal/src/app/services/chat.service.ts
+++ b/ui/candidate-portal/src/app/services/chat.service.ts
@@ -8,6 +8,7 @@ import {Message} from "@stomp/stompjs";
 import {map, share, shareReplay, takeUntil, tap} from "rxjs/operators";
 import {RxStompConfig} from "@stomp/rx-stomp";
 import {AuthenticationService} from "./authentication.service";
+import {ERROR_MESSAGES} from "../app.constants";
 
 @Injectable({
   providedIn: 'root'
@@ -205,8 +206,27 @@ export class ChatService implements OnDestroy {
       let stompConfig = this.getRxStompConfig();
       this.rxStompService.configure(stompConfig);
       this.rxStompService.activate();
+      this.configureErrorHandling();
       this.stompServiceConfigured = true;
     }
+  }
+
+  private configureErrorHandling(): void {
+    this.rxStompService.stompErrors$
+    .pipe(
+      takeUntil(this.destroyStompSubscriptions$)
+    )
+    .subscribe((error) => {
+      if (error.headers && error.headers.message &&
+        error.headers.message.includes(ERROR_MESSAGES.EXPIRED_OR_INVALID_JWT)) {
+        this.handleExpiredOrInvalidToken();
+      }
+    });
+  }
+
+  private handleExpiredOrInvalidToken(): void {
+    console.log('Expired or invalid JWT  - logging out');
+    // this.authenticationService.logout();
   }
 
   /**


### PR DESCRIPTION
This PR:

- Updates the Spring web socket configuration with handling of expired JWT tokens during Stomp connect attempts
- Adds error handling in the Angular chat service to take appropriate action upon expired JWT tokens
- Introduces an app.constants.ts file in the app directory for error messages and other constants
- Replicates the expired token handling in the candidate portal for consistency, though candidate tokens don't expire
- Resolves 1 IntelliJ warning in JwtTokenProvider
