### PR TITLE
Do not trigger tc-build-action on pushes to master

### DIFF
--- a/.github/workflows/tc-build.yml
+++ b/.github/workflows/tc-build.yml
@@ -8,6 +8,7 @@ on:
     branches:
       - '*'
       - '!staging'
+      - '!master'
 
 jobs:
   build:


### PR DESCRIPTION
This PR:

- bypasses the tc-build-action on pushes to the master branch. 

This is because the tc-prod-build-deploy action already executes a build. This change prevents an unnecessary duplicate build in the pipeline.
