### PR TITLE
1210 issue with cv download for candidate

### DIFF
--- a/server/src/main/java/org/tctalent/server/api/admin/CandidateAdminApi.java
+++ b/server/src/main/java/org/tctalent/server/api/admin/CandidateAdminApi.java
@@ -16,6 +16,7 @@
 
 package org.tctalent.server.api.admin;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.tomcat.util.http.fileupload.IOUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.Resource;
@@ -34,6 +35,7 @@ import org.springframework.web.reactive.function.client.WebClientException;
 import org.tctalent.server.exception.ExportFailedException;
 import org.tctalent.server.exception.NoSuchObjectException;
 import org.tctalent.server.exception.SalesforceException;
+import org.tctalent.server.logging.LogBuilder;
 import org.tctalent.server.model.db.Candidate;
 import org.tctalent.server.request.candidate.CandidateEmailOrPhoneSearchRequest;
 import org.tctalent.server.request.candidate.CandidateEmailSearchRequest;
@@ -74,6 +76,7 @@ import java.util.Map;
 
 @RestController()
 @RequestMapping("/api/admin/candidate")
+@Slf4j
 public class CandidateAdminApi {
 
     private final CandidateService candidateService;
@@ -251,6 +254,12 @@ public class CandidateAdminApi {
     @PostMapping(value = "{id}/cv.pdf")
     public void downloadCandidateCVPdf(@RequestBody DownloadCvRequest request, HttpServletResponse response)
             throws IOException {
+
+        LogBuilder.builder(log)
+            .candidateId(request.getCandidateId())
+            .action("downloadCandidateCVPdf")
+            .message("Downloading CV for candidate")
+            .logInfo();
 
         Candidate candidate = candidateService.getCandidate(request.getCandidateId());
         String name = candidate.getUser().getDisplayName()+"-"+ "CV";

--- a/server/src/main/java/org/tctalent/server/logging/LogBuilder.java
+++ b/server/src/main/java/org/tctalent/server/logging/LogBuilder.java
@@ -88,6 +88,20 @@ public class LogBuilder {
   }
 
   /**
+   * Adds the candidate ID to the log fields if the candidate ID is not null.
+   *
+   * @param candidateId the candidate ID
+   * @return the current {@code LogBuilder} instance for chaining
+   */
+  public LogBuilder candidateId(Long candidateId) {
+    if (candidateId == null) {
+      return this;
+    }
+    addField(LogField.CANDIDATE_ID, candidateId.toString());
+    return this;
+  }
+
+  /**
    * Adds the list ID to the log fields if the list ID is not null.
    *
    * @param listId the list ID

--- a/server/src/main/java/org/tctalent/server/logging/LogField.java
+++ b/server/src/main/java/org/tctalent/server/logging/LogField.java
@@ -51,7 +51,7 @@ import lombok.RequiredArgsConstructor;
 public enum LogField {
 
   USER_ID("uid", 100),
-  CANDIDATE_NUMBER("cn", 101),
+  CANDIDATE_ID("cid", 101),
   JOB_ID("jid", 102),
   LIST_ID("lid", 103),
   SEARCH_ID("sid", 104),

--- a/server/src/main/java/org/tctalent/server/service/db/util/PdfHelper.java
+++ b/server/src/main/java/org/tctalent/server/service/db/util/PdfHelper.java
@@ -20,6 +20,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.UnsupportedEncodingException;
 import java.util.regex.Pattern;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -47,6 +48,7 @@ import org.xhtmlrenderer.pdf.ITextRenderer;
  */
 @Service
 @Slf4j
+@RequiredArgsConstructor
 public class PdfHelper {
 
     @Value("${server.url}")
@@ -56,11 +58,6 @@ public class PdfHelper {
     private static final Pattern NULL_BYTE_PATTERN = Pattern.compile("\\x00");
 
     private final TemplateEngine pdfTemplateEngine;
-
-    @Autowired
-    public PdfHelper(TemplateEngine pdfTemplateEngine) {
-        this.pdfTemplateEngine = pdfTemplateEngine;
-    }
 
     public Resource generatePdf(Candidate candidate, Boolean showName, Boolean showContact){
         try {

--- a/server/src/main/java/org/tctalent/server/service/db/util/PdfHelper.java
+++ b/server/src/main/java/org/tctalent/server/service/db/util/PdfHelper.java
@@ -28,6 +28,7 @@ import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Service;
 import org.tctalent.server.exception.PdfGenerationException;
 import org.tctalent.server.model.db.Candidate;
+import org.tctalent.server.util.html.StringSanitizer;
 import org.thymeleaf.TemplateEngine;
 import org.thymeleaf.context.Context;
 import org.w3c.tidy.Tidy;
@@ -62,6 +63,8 @@ public class PdfHelper {
     public Resource generatePdf(Candidate candidate, Boolean showName, Boolean showContact){
         try {
 
+            cleanCandidateJobDescriptions(candidate);
+
             Context context = new Context();
             context.setVariable("candidate", candidate);
             context.setVariable("showName", showName);
@@ -88,6 +91,14 @@ public class PdfHelper {
            throw new PdfGenerationException(e.getMessage());
         }
 
+    }
+
+    private static void cleanCandidateJobDescriptions(Candidate candidate) {
+        candidate.getCandidateJobExperiences().forEach(jobExperience ->
+            jobExperience.setDescription(
+                StringSanitizer.replaceLsepWithBr(jobExperience.getDescription())
+            )
+        );
     }
 
     private static String convertToXhtml(String html) throws UnsupportedEncodingException {

--- a/server/src/main/java/org/tctalent/server/service/db/util/PdfHelper.java
+++ b/server/src/main/java/org/tctalent/server/service/db/util/PdfHelper.java
@@ -19,11 +19,10 @@ package org.tctalent.server.service.db.util;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Service;
@@ -51,9 +50,6 @@ import org.xhtmlrenderer.pdf.ITextRenderer;
 @Slf4j
 @RequiredArgsConstructor
 public class PdfHelper {
-
-    @Value("${server.url}")
-    private String serverUrl;
 
     private static final String UTF_8 = "UTF-8";
     private static final Pattern NULL_BYTE_PATTERN = Pattern.compile("\\x00");
@@ -111,10 +107,11 @@ public class PdfHelper {
         tidy.setInputEncoding(UTF_8);
         tidy.setOutputEncoding(UTF_8);
         tidy.setXHTML(true);
-        ByteArrayInputStream inputStream = new ByteArrayInputStream(html.getBytes(UTF_8));
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(html.getBytes(
+            StandardCharsets.UTF_8));
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         tidy.parseDOM(inputStream, outputStream);
-        return outputStream.toString(UTF_8);
+        return outputStream.toString(StandardCharsets.UTF_8);
     }
 
     private Resource createPdf(String xHtml) throws Exception {

--- a/server/src/main/java/org/tctalent/server/service/db/util/PdfHelper.java
+++ b/server/src/main/java/org/tctalent/server/service/db/util/PdfHelper.java
@@ -28,6 +28,7 @@ import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Service;
 import org.tctalent.server.exception.PdfGenerationException;
+import org.tctalent.server.logging.LogBuilder;
 import org.tctalent.server.model.db.Candidate;
 import org.tctalent.server.util.html.StringSanitizer;
 import org.thymeleaf.TemplateEngine;
@@ -86,7 +87,12 @@ public class PdfHelper {
             outputStream.close();
             return new ByteArrayResource(outputStream.toByteArray());
 
-        } catch (Exception e){
+        } catch (Exception e) {
+            LogBuilder.builder(log)
+                .action("generatePdf")
+                .message("Error generating PDF")
+                .logError(e);
+
            throw new PdfGenerationException(e.getMessage());
         }
 

--- a/server/src/main/java/org/tctalent/server/service/db/util/PdfHelper.java
+++ b/server/src/main/java/org/tctalent/server/service/db/util/PdfHelper.java
@@ -60,6 +60,14 @@ public class PdfHelper {
 
     private final TemplateEngine pdfTemplateEngine;
 
+    /**
+     * Generates a PDF for a candidate.
+     *
+     * @param candidate the candidate data
+     * @param showName whether to show the candidate's name
+     * @param showContact whether to show the candidate's contact information
+     * @return the generated PDF as a Resource
+     */
     public Resource generatePdf(Candidate candidate, Boolean showName, Boolean showContact){
         try {
 
@@ -76,16 +84,8 @@ public class PdfHelper {
             // Remove any null bytes to avoid an invalid XML character (Unicode: 0x0) error
             xHtml = NULL_BYTE_PATTERN.matcher(xHtml).replaceAll("");
 
-            ITextRenderer renderer = new ITextRenderer();
-
-            renderer.setDocumentFromString(xHtml, "classpath:pdf/");
-            renderer.layout();
-
             // And finally, we create the PDF:
-            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-            renderer.createPDF(outputStream);
-            outputStream.close();
-            return new ByteArrayResource(outputStream.toByteArray());
+            return createPdf(xHtml);
 
         } catch (Exception e) {
             LogBuilder.builder(log)
@@ -115,6 +115,17 @@ public class PdfHelper {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         tidy.parseDOM(inputStream, outputStream);
         return outputStream.toString(UTF_8);
+    }
+
+    private Resource createPdf(String xHtml) throws Exception {
+        ITextRenderer renderer = new ITextRenderer();
+        renderer.setDocumentFromString(xHtml, "classpath:pdf/");
+        renderer.layout();
+
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+            renderer.createPDF(outputStream);
+            return new ByteArrayResource(outputStream.toByteArray());
+        }
     }
 
 }

--- a/server/src/main/java/org/tctalent/server/service/db/util/PdfHelper.java
+++ b/server/src/main/java/org/tctalent/server/service/db/util/PdfHelper.java
@@ -53,6 +53,8 @@ public class PdfHelper {
     private String serverUrl;
 
     private static final String UTF_8 = "UTF-8";
+    private static final Pattern NULL_BYTE_PATTERN = Pattern.compile("\\x00");
+
     private final TemplateEngine pdfTemplateEngine;
 
     @Autowired
@@ -74,7 +76,7 @@ public class PdfHelper {
             String xHtml = convertToXhtml(renderedHtmlContent);
 
             // Remove any null bytes to avoid an invalid XML character (Unicode: 0x0) error
-            xHtml = Pattern.compile("\\x00").matcher(xHtml).replaceAll("");
+            xHtml = NULL_BYTE_PATTERN.matcher(xHtml).replaceAll("");
 
             ITextRenderer renderer = new ITextRenderer();
 

--- a/server/src/main/java/org/tctalent/server/util/html/StringSanitizer.java
+++ b/server/src/main/java/org/tctalent/server/util/html/StringSanitizer.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2024 Talent Beyond Boundaries.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.util.html;
+
+
+/**
+ * Utility class for sanitizing strings by handling special characters.
+ * <p>
+ * Currently, this class provides methods to remove or replace Line Separator (LSEP) characters.
+ * In the future, it may be extended to handle other special characters as well.
+ * </p>
+ */
+public class StringSanitizer {
+
+  private static final String LSEP = "\u2028";
+
+  /**
+   * Removes any Line Separator (LSEP) characters from the given string.
+   *
+   * @param input the input string
+   * @return a string with any LSEP characters removed, or null if input was null
+   */
+  public static String removeLsep(String input) {
+    if (input == null) {
+      return null;
+    }
+    // Unicode code point for LSEP is \u2028
+    return input.replace(LSEP, "");
+  }
+
+  /**
+   * Replaces any Line Separator (LSEP) characters in the given string with a {@code <br>} tag.
+   *
+   * @param input the input string
+   * @return a string with any LSEP characters replaced with {@code <br>} tags, or null if input was null
+   */
+  public static String replaceLsepWithBr(String input) {
+    if (input == null) {
+      return null;
+    }
+    // Unicode code point for LSEP is \u2028
+    return input.replace(LSEP, "<br>");
+  }
+
+}


### PR DESCRIPTION
This PR:

- Resolves an issue with PDF generation not working for candidate profiles that have LSEP characters in their job experience descriptions

Also:

- Tidies up a few IntelliJ warnings in related classes
- Improves general logging for CV download requests
- Uses try-with-resources for byte array i/o streams

