### PR TITLE
1252 search by candidate number has become unworkably slow

### DIFF
--- a/server/src/main/java/org/tctalent/server/api/admin/CandidateAdminApi.java
+++ b/server/src/main/java/org/tctalent/server/api/admin/CandidateAdminApi.java
@@ -16,6 +16,12 @@
 
 package org.tctalent.server.api.admin;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import javax.servlet.http.HttpServletResponse;
+import javax.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.tomcat.util.http.fileupload.IOUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -67,13 +73,6 @@ import org.tctalent.server.service.db.SavedSearchService;
 import org.tctalent.server.service.db.UserService;
 import org.tctalent.server.util.dto.DtoBuilder;
 
-import javax.servlet.http.HttpServletResponse;
-import javax.validation.Valid;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.List;
-import java.util.Map;
-
 @RestController()
 @RequestMapping("/api/admin/candidate")
 @Slf4j
@@ -115,28 +114,40 @@ public class CandidateAdminApi {
     @PostMapping("findbyemail")
     public Map<String, Object> findByCandidateEmail(@RequestBody CandidateEmailSearchRequest request) {
         Page<Candidate> candidates = candidateService.searchCandidates(request);
-        DtoBuilder builder = builderSelector.selectBuilder();
+
+        //Use a minimal DTO builder - we only need candidate number and name returned so we don't
+        //need to fetch more data from the database than that.
+        DtoBuilder builder = builderSelector.selectBuilder(true);
         return builder.buildPage(candidates);
     }
 
     @PostMapping("findbyemailorphone")
     public Map<String, Object> findByCandidateEmailOrPhone(@RequestBody CandidateEmailOrPhoneSearchRequest request) {
         Page<Candidate> candidates = candidateService.searchCandidates(request);
-        DtoBuilder builder = builderSelector.selectBuilder();
+
+        //Use a minimal DTO builder - we only need candidate number and name returned so we don't
+        //need to fetch more data from the database than that.
+        DtoBuilder builder = builderSelector.selectBuilder(true);
         return builder.buildPage(candidates);
     }
 
     @PostMapping("findbynumberorname")
     public Map<String, Object> findByCandidateNumberOrName(@RequestBody CandidateNumberOrNameSearchRequest request) {
         Page<Candidate> candidates = candidateService.searchCandidates(request);
-        DtoBuilder builder = builderSelector.selectBuilder();
+
+        //Use a minimal DTO builder - we only need candidate number and name returned so we don't
+        //need to fetch more data from the database than that.
+        DtoBuilder builder = builderSelector.selectBuilder(true);
         return builder.buildPage(candidates);
     }
 
     @PostMapping("findbyexternalid")
     public Map<String, Object> findByCandidateExternalId(@RequestBody CandidateExternalIdSearchRequest request) {
         Page<Candidate> candidates = candidateService.searchCandidates(request);
-        DtoBuilder builder = builderSelector.selectBuilder();
+
+        //Use a minimal DTO builder - we only need candidate number and name returned so we don't
+        //need to fetch more data from the database than that.
+        DtoBuilder builder = builderSelector.selectBuilder(true);
         return builder.buildPage(candidates);
     }
 

--- a/server/src/main/java/org/tctalent/server/api/admin/CandidateBuilderSelector.java
+++ b/server/src/main/java/org/tctalent/server/api/admin/CandidateBuilderSelector.java
@@ -98,6 +98,15 @@ public class CandidateBuilderSelector {
 
     @NonNull
     public DtoBuilder selectBuilder() {
+        return selectBuilder(false);
+    }
+
+    @NonNull
+    public DtoBuilder selectBuilder(boolean minimal) {
+        if (minimal) {
+            return minimalCandidateDto();
+        }
+
         User user = userService.getLoggedInUser();
         Partner partner = user == null ? null : user.getPartner();
 
@@ -216,6 +225,14 @@ public class CandidateBuilderSelector {
                 .add("updatedDate")
                 .add("partner", partnerDto())
                 ;
+    }
+
+    private DtoBuilder minimalCandidateDto() {
+        return new DtoBuilder()
+            .add("id")
+            .add("candidateNumber")
+            .add("user", userDto())
+            ;
     }
 
     private DtoBuilder userDto() {

--- a/server/src/main/java/org/tctalent/server/repository/db/CandidateRepository.java
+++ b/server/src/main/java/org/tctalent/server/repository/db/CandidateRepository.java
@@ -152,7 +152,26 @@ public interface CandidateRepository extends JpaRepository<Candidate, Long>, Jpa
             + sourceCountryRestriction)
     Page<Candidate> searchCandidateEmail(@Param("candidateEmail") String candidateEmail,
                                          @Param("userSourceCountries") Set<Country> userSourceCountries,
+
                                          Pageable pageable);
+    /**
+     * Note that we need to pass in a CandidateStatus.deleted constant in the
+     * "exclude" parameter because I haven't been able to just put
+     * CanadidateStatus.deleted constant directly into the query.
+     * Theoretically the fully qualified name should work eg
+     * " and c.status <> db.model.org.tctalent.server.CandidateStatus.deleted"
+     * See https://stackoverflow.com/questions/8217144/problems-with-making-a-query-when-using-enum-in-entity
+     * but Hibernate rejects that at run time with the following error:
+     * org.hibernate.hql.internal.ast.QuerySyntaxException: Invalid path
+     * - JC
+     */
+    @Query(" select distinct c from Candidate c "
+        + " where c.candidateNumber like :candidateNumber "
+        + excludeDeleted
+        + sourceCountryRestriction)
+    Page<Candidate> searchCandidateNumber(@Param("candidateNumber") String candidateNumber,
+        @Param("userSourceCountries") Set<Country> userSourceCountries,
+        Pageable pageable);
 
     @Query(" select c from Candidate c "
             + " join c.user u "

--- a/server/src/main/java/org/tctalent/server/service/db/impl/CandidateServiceImpl.java
+++ b/server/src/main/java/org/tctalent/server/service/db/impl/CandidateServiceImpl.java
@@ -460,21 +460,24 @@ public class CandidateServiceImpl implements CandidateService {
                 .orElseThrow(() -> new InvalidSessionException("Not logged in"));
 
         boolean searchForNumber = s.length() > 0 && Character.isDigit(s.charAt(0));
+        Set<Country> sourceCountries = userService.getDefaultSourceCountries(loggedInUser);
+
+        Page<Candidate> candidates;
 
         // Get candidate ids from Elasticsearch
         Set<Long> candidateIds;
         if (searchForNumber) {
-            candidateIds = elasticsearchService.findByNumberWithLimit(s);
+            candidates = candidateRepository.searchCandidateNumber(
+                s +'%', sourceCountries,
+                request.getPageRequestWithoutSort());
         } else {
             if (authService.hasAdminPrivileges(loggedInUser.getRole())) {
                 candidateIds = elasticsearchService.findByNameWithLimit(s);
+                candidates = fetchCandidates(request, candidateIds);
             } else {
                 return null;
             }
         }
-
-        // then fetch and return from the database
-        Page<Candidate> candidates = fetchCandidates(request, candidateIds);
 
         LogBuilder.builder(log)
             .user(authService.getLoggedInUser())


### PR DESCRIPTION
This change does two things:
1. Hopefully speeds up search for candidate by partial matches of things like name, number etc by fetching and returning minimal DTO data
2. Reinstates Postgres implementation of partial candidate number search (using text wildcard % in search). The expectation is that the move to Elastic search was unnecessary because the reason for slowness had nothing to do with the wild card search. 