### PR TITLE
Add optional minimalData option to search requests.

### DIFF
--- a/server/src/main/java/org/tctalent/server/api/admin/CandidateSavedListAdminApi.java
+++ b/server/src/main/java/org/tctalent/server/api/admin/CandidateSavedListAdminApi.java
@@ -71,7 +71,7 @@ public class CandidateSavedListAdminApi implements IManyToManyApi<SearchSavedLis
             long candidateId, @Valid SearchSavedListRequest request)
             throws NoSuchObjectException {
         List<SavedList> savedLists = savedListService.search(candidateId, request);
-        DtoBuilder builder = builderSelector.selectBuilder();
+        DtoBuilder builder = builderSelector.selectBuilder(request.getMinimalData());
         return builder.buildList(savedLists);
     }
 }

--- a/server/src/main/java/org/tctalent/server/api/admin/SavedListAdminApi.java
+++ b/server/src/main/java/org/tctalent/server/api/admin/SavedListAdminApi.java
@@ -46,7 +46,6 @@ import org.tctalent.server.request.list.UpdateSavedListInfoRequest;
 import org.tctalent.server.request.search.UpdateSharingRequest;
 import org.tctalent.server.service.db.CandidateSavedListService;
 import org.tctalent.server.service.db.CandidateService;
-import org.tctalent.server.service.db.SalesforceService;
 import org.tctalent.server.service.db.SavedListService;
 import org.tctalent.server.util.dto.DtoBuilder;
 
@@ -58,17 +57,14 @@ public class SavedListAdminApi implements
     private final CandidateService candidateService;
     private final SavedListService savedListService;
     private final CandidateSavedListService candidateSavedListService;
-    private final SalesforceService salesforceService;
     private final SavedListBuilderSelector builderSelector = new SavedListBuilderSelector();
 
     @Autowired
     public SavedListAdminApi(SavedListService savedListService,
-        CandidateService candidateService, CandidateSavedListService candidateSavedListService,
-        SalesforceService salesforceService) {
+        CandidateService candidateService, CandidateSavedListService candidateSavedListService) {
         this.candidateService = candidateService;
         this.savedListService = savedListService;
         this.candidateSavedListService = candidateSavedListService;
-        this.salesforceService = salesforceService;
     }
 
     /*
@@ -129,7 +125,7 @@ public class SavedListAdminApi implements
     public @NotNull List<Map<String, Object>> search(
             @Valid SearchSavedListRequest request) {
         List<SavedList> savedLists = savedListService.listSavedLists(request);
-        DtoBuilder builder = builderSelector.selectBuilder();
+        DtoBuilder builder = builderSelector.selectBuilder(request.getMinimalData());
         return builder.buildList(savedLists);
     }
 

--- a/server/src/main/java/org/tctalent/server/api/admin/SavedListBuilderSelector.java
+++ b/server/src/main/java/org/tctalent/server/api/admin/SavedListBuilderSelector.java
@@ -16,10 +16,10 @@
 
 package org.tctalent.server.api.admin;
 
+import javax.validation.constraints.NotNull;
+import org.springframework.lang.Nullable;
 import org.tctalent.server.model.db.TaskDtoHelper;
 import org.tctalent.server.util.dto.DtoBuilder;
-
-import javax.validation.constraints.NotNull;
 
 /**
  * Utility for selecting a SavedList DTO builder
@@ -31,7 +31,24 @@ public class SavedListBuilderSelector {
         = new ExportColumnsBuilderSelector();
 
     public @NotNull DtoBuilder selectBuilder() {
-        return savedListDto();
+        return selectBuilder(null);
+    }
+
+    public @NotNull DtoBuilder selectBuilder(@Nullable Boolean minimalData) {
+        DtoBuilder dtoBuilder;
+        if (minimalData != null && minimalData) {
+            dtoBuilder = minimalSavedListDto();
+        } else {
+            dtoBuilder = savedListDto();
+        }
+        return dtoBuilder;
+    }
+
+    private DtoBuilder minimalSavedListDto() {
+        return new DtoBuilder()
+            .add("id")
+            .add("name")
+            ;
     }
 
     private DtoBuilder savedListDto() {

--- a/server/src/main/java/org/tctalent/server/request/PagedSearchRequest.java
+++ b/server/src/main/java/org/tctalent/server/request/PagedSearchRequest.java
@@ -23,15 +23,23 @@ import lombok.ToString;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
+import org.springframework.lang.Nullable;
 
 /**
- * Request that includes paging and sorting fields.
+ * Request that may include paging and sorting fields.
  */
 @Getter
 @Setter
 @ToString
 @NoArgsConstructor
 public class PagedSearchRequest {
+
+    /**
+     * If non-null and true, means that only minimal data is required to be returned for each
+     * search result.
+     */
+    @Nullable
+    private Boolean minimalData;
     private Integer pageSize;
     private Integer pageNumber;
     private Sort.Direction sortDirection;

--- a/ui/admin-portal/src/app/components/candidates/view/view-candidate.component.ts
+++ b/ui/admin-portal/src/app/components/candidates/view/view-candidate.component.ts
@@ -137,9 +137,10 @@ export class ViewCandidateComponent extends MainSidePanelBase implements OnInit 
   }
 
   private loadLists() {
-    /*load all our non fixed lists */
+    /*load all our non-fixed lists */
     this.loading = true;
     const request: SearchSavedListRequest = {
+      minimalData: true, //We just need the names and ids of the lists
       owned: true,
       shared: true,
       global: true,

--- a/ui/admin-portal/src/app/model/base.ts
+++ b/ui/admin-portal/src/app/model/base.ts
@@ -202,6 +202,7 @@ export interface PostJobToSlackResponse {
 }
 
 export class PagedSearchRequest {
+  minimalData?: boolean;
   pageSize?: number;
   pageNumber?: number;
   sortFields?: string[];


### PR DESCRIPTION
Implemented Saved List fetches from the full candidate display where we only need saved list names and ids. This not only reduces the data sent in the response request but also avoids fetching a lot of unnecessary data and additional  database queries.