### PR TITLE
configure a 5-minute time to live for all cache entries

### DIFF
--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -48,6 +48,8 @@ spring:
 
   cache:
     type: redis
+    redis:
+        time-to-live: 300000
 
   redis:
     host: ${REDIS_HOST:localhost}


### PR DESCRIPTION
This PR configures a time to live value of 5 minutes for all cache entries.