### PR TITLE
Reinstated clarified date-picker help text

### DIFF
--- a/ui/admin-portal/src/app/components/util/date-picker/date-picker.component.html
+++ b/ui/admin-portal/src/app/components/util/date-picker/date-picker.component.html
@@ -19,6 +19,9 @@
     <span>Clear</span>
   </div>
 </div>
+<small class="text-muted">
+  If exact day or month unknown, use '01' to approximate, e.g., '2020-07-<b>01</b>'.
+</small>
 <div class="alert alert-danger" *ngIf="error">
   {{error}}
 </div>


### PR DESCRIPTION
<img width="715" alt="Screenshot 2024-08-27 at 3 46 48 PM" src="https://github.com/user-attachments/assets/c59639f6-488a-491f-8e6e-5c0a20a336c9">
