### PR TITLE
1281 pressing escape to close column selector modal in search and list view displays an error

### DIFF
--- a/ui/admin-portal/src/app/components/candidates/show/candidate-source-base.ts
+++ b/ui/admin-portal/src/app/components/candidates/show/candidate-source-base.ts
@@ -22,11 +22,9 @@ import {ModalDismissReasons, NgbModal} from "@ng-bootstrap/ng-bootstrap";
 import {CandidateFieldService} from "../../../services/candidate-field.service";
 import {Directive, Input} from "@angular/core";
 import {
-  CandidateSource, canEditSource,
+  CandidateSource,
   defaultReviewStatusFilter,
-  DtoType,
-  isMine,
-  isStarredByMe
+  DtoType
 } from "../../../model/base";
 import {CandidateFieldInfo} from "../../../model/candidate-field-info";
 import {SearchResults} from "../../../model/search-results";
@@ -43,7 +41,6 @@ import {isSavedList, SavedListGetRequest} from "../../../model/saved-list";
 import {Observable, throwError} from "rxjs";
 import {catchError, tap} from "rxjs/operators";
 import {AuthorizationService} from "../../../services/authorization.service";
-import {AuthenticationService} from "../../../services/authentication.service";
 
 @Directive()
 export class CandidateSourceBaseComponent {
@@ -65,7 +62,6 @@ export class CandidateSourceBaseComponent {
 
   constructor(
     protected authorizationService: AuthorizationService,
-    protected authenticationService: AuthenticationService,
     protected candidateSourceResultsCacheService: CandidateSourceResultsCacheService,
     protected candidateSourceCandidateService: CandidateSourceCandidateService,
     protected candidateFieldService: CandidateFieldService,

--- a/ui/admin-portal/src/app/components/candidates/show/candidate-source-base.ts
+++ b/ui/admin-portal/src/app/components/candidates/show/candidate-source-base.ts
@@ -20,7 +20,7 @@ import {
 
 import {ModalDismissReasons, NgbModal} from "@ng-bootstrap/ng-bootstrap";
 import {CandidateFieldService} from "../../../services/candidate-field.service";
-import {Input} from "@angular/core";
+import {Directive, Input} from "@angular/core";
 import {
   CandidateSource, canEditSource,
   defaultReviewStatusFilter,
@@ -45,6 +45,7 @@ import {catchError, tap} from "rxjs/operators";
 import {AuthorizationService} from "../../../services/authorization.service";
 import {AuthenticationService} from "../../../services/authentication.service";
 
+@Directive()
 export class CandidateSourceBaseComponent {
   error: any = null;
   longFormat: boolean;
@@ -60,7 +61,7 @@ export class CandidateSourceBaseComponent {
 
   @Input() candidateSource: CandidateSource;
 
-  protected selectedFields: CandidateFieldInfo[] = [];
+  selectedFields: CandidateFieldInfo[] = [];
 
   constructor(
     protected authorizationService: AuthorizationService,
@@ -199,7 +200,7 @@ export class CandidateSourceBaseComponent {
     return !this.isReviewable();
   }
 
-  protected isReviewable(): boolean {
+  isReviewable(): boolean {
     return isSavedSearch(this.candidateSource)
       ? this.candidateSource.reviewable : false;
   }
@@ -228,63 +229,63 @@ export class CandidateSourceBaseComponent {
     }
   }
 
-  protected isCandidateNameViewable(): boolean {
+  isCandidateNameViewable(): boolean {
     return this.authorizationService.canViewCandidateName();
   }
 
-  protected isCountryViewable(): boolean {
+  isCountryViewable(): boolean {
     return this.authorizationService.canViewCandidateCountry();
   }
 
-  protected sourceType(): string {
+  sourceType(): string {
     return isSavedSearch(this.candidateSource) ? 'savedSearch' : 'list';
   }
 
-  protected isImportable(): boolean {
+  isImportable(): boolean {
     return isSavedList(this.candidateSource);
   }
 
-  protected isPublishable(): boolean {
+  isPublishable(): boolean {
     return isSavedList(this.candidateSource) && this.authorizationService.canPublishList();
   }
 
-  protected isStarred(): boolean {
+  isStarred(): boolean {
     return isStarredByMe(this.candidateSource?.users, this.authenticationService);
   }
 
-  protected isJobList(): boolean {
+  isJobList(): boolean {
     return isSavedList(this.candidateSource) && this.candidateSource.sfJobOpp != null;
   }
 
-  protected isShowStage(): boolean {
+  isShowStage(): boolean {
     return this.isJobList();
   }
 
-  protected isEditable(): boolean {
+  isEditable(): boolean {
     return canEditSource(this.candidateSource, this.authenticationService);
   }
 
-  protected isContentModifiable(): boolean {
+  isContentModifiable(): boolean {
     return !isSavedSearch(this.candidateSource);
   }
 
-  protected canAccessSalesforce(): boolean {
+  canAccessSalesforce(): boolean {
     return this.authorizationService.canAccessSalesforce();
   }
 
-  protected isSalesforceUpdatable(): boolean {
+  isSalesforceUpdatable(): boolean {
     return !isSavedSearch(this.candidateSource) && this.authorizationService.canUpdateSalesforce();
   }
 
-  protected canAssignTasks() {
+  canAssignTasks() {
     return this.authorizationService.canAssignTask();
   }
 
-  protected canResolveTasks(): boolean {
+  canResolveTasks(): boolean {
     return isSavedList(this.candidateSource) && this.authorizationService.canManageCandidateTasks();
   }
 
-  protected isShareable(): boolean {
+  isShareable(): boolean {
     let shareable: boolean = false;
 
     //Is shareable with me if it is not created by me.
@@ -297,7 +298,7 @@ export class CandidateSourceBaseComponent {
     return shareable;
   }
 
-  protected isGlobal(): boolean {
+  isGlobal(): boolean {
     return this.candidateSource.global;
   }
 

--- a/ui/admin-portal/src/app/components/candidates/show/candidate-source-base.ts
+++ b/ui/admin-portal/src/app/components/candidates/show/candidate-source-base.ts
@@ -209,4 +209,13 @@ export class CandidateSourceBaseComponent {
     });
   }
 
+  protected toggleSort(column: string) {
+    if (this.sortField === column) {
+      this.sortDirection = this.sortDirection === 'ASC' ? 'DESC' : 'ASC';
+    } else {
+      this.sortField = column;
+      this.sortDirection = 'ASC';
+    }
+  }
+
 }

--- a/ui/admin-portal/src/app/components/candidates/show/candidate-source-base.ts
+++ b/ui/admin-portal/src/app/components/candidates/show/candidate-source-base.ts
@@ -21,18 +21,42 @@ import {
 import {ModalDismissReasons, NgbModal} from "@ng-bootstrap/ng-bootstrap";
 import {CandidateFieldService} from "../../../services/candidate-field.service";
 import {Input} from "@angular/core";
-import {CandidateSource} from "../../../model/base";
+import {CandidateSource, defaultReviewStatusFilter, DtoType} from "../../../model/base";
 import {CandidateFieldInfo} from "../../../model/candidate-field-info";
+import {SearchResults} from "../../../model/search-results";
+import {Candidate} from "../../../model/candidate";
+import {
+  CachedSourceResults,
+  CandidateSourceResultsCacheService
+} from "../../../services/candidate-source-results-cache.service";
+import {
+  CandidateSourceCandidateService
+} from "../../../services/candidate-source-candidate.service";
+import {isSavedSearch, SavedSearchGetRequest} from "../../../model/saved-search";
+import {SavedListGetRequest} from "../../../model/saved-list";
+import {Observable, throwError} from "rxjs";
+import {catchError, tap} from "rxjs/operators";
 
 export class CandidateSourceBaseComponent {
   error: any = null;
   longFormat: boolean;
+
+  pageNumber: number;
+  pageSize: number;
+  results: SearchResults<Candidate>;
+  searching: boolean;
+  sortField: string;
+  sortDirection: string;
+  timestamp: number;
+  reviewStatusFilter: string[] = defaultReviewStatusFilter;
 
   @Input() candidateSource: CandidateSource;
 
   protected selectedFields: CandidateFieldInfo[] = [];
 
   constructor(
+    protected candidateSourceResultsCacheService: CandidateSourceResultsCacheService,
+    protected candidateSourceCandidateService: CandidateSourceCandidateService,
     protected candidateFieldService: CandidateFieldService,
     protected modalService: NgbModal
   ) {}
@@ -58,6 +82,126 @@ export class CandidateSourceBaseComponent {
   protected loadSelectedFields() {
     this.selectedFields = this.candidateFieldService
     .getCandidateSourceFields(this.candidateSource, this.longFormat);
+  }
+
+  protected checkCache(refresh: boolean, usePageNumber: boolean = true) {
+    this.results = null;
+    this.error = null;
+
+    //If already searching just exit.
+    if (this.searching) {
+      return;
+    }
+
+    this.searching = true;
+
+    let done = false;
+    if (!refresh) {
+
+      //Is there anything in cache?
+      //We only cache certain results
+      if (this.isCacheable()) {
+        const cached: CachedSourceResults =
+          this.candidateSourceResultsCacheService.getFromCache(this.candidateSource);
+        if (cached) {
+          //If we are not required to use the pageNumber (usePageNumber = false)
+          //we can take the pageNumber of whatever the cache has.
+          //If we have to use the page number, the pageNumber and size must match
+          //what is in the cache, or we can't use it.
+          done = !usePageNumber
+            || (cached.pageNumber === this.pageNumber && cached.pageSize === this.pageSize);
+          if (done) {
+            this.results = cached.results;
+            this.sortField = cached.sortFields[0];
+            this.sortDirection = cached.sortDirection;
+            this.reviewStatusFilter = []; // We don't cache reviewable sources
+            this.timestamp = cached.timestamp;
+            this.pageNumber = cached.pageNumber;
+            this.pageSize = cached.pageSize;
+            this.searching = false;
+          }
+        }
+      }
+    }
+    return done;
+  }
+
+  protected performSearch(
+    defaultPageSize: number = 12,
+    dtoType: DtoType = DtoType.FULL,
+    keyword: string = null,
+    showClosedOpps: boolean = false
+  ): Observable<SearchResults<Candidate>> {
+
+    this.searching = true;
+
+    // todo Is this the best place to do the defaulting?
+    //  Need do defaulting in search request, then pick up actual info from returned results.
+    //  Currently server sends back used page number and size but does not echo back sort info.
+    //  It should be changed to do so.
+    this.pageNumber = this.pageNumber || 1;
+    this.pageSize = this.pageSize || defaultPageSize;
+    this.sortField = this.sortField || 'id';
+    this.sortDirection = this.sortDirection || 'DESC';
+
+    //Create the appropriate request
+    let request;
+    let reviewable = false;
+    if (isSavedSearch(this.candidateSource)) {
+      reviewable = this.candidateSource.reviewable;
+      request = new SavedSearchGetRequest();
+    } else {
+      request = new SavedListGetRequest();
+    }
+    request.keyword = keyword;
+    request.showClosedOpps = showClosedOpps;
+    request.pageNumber = this.pageNumber - 1;
+    request.pageSize = this.pageSize;
+    request.sortFields = [this.sortField];
+    request.sortDirection = this.sortDirection;
+    request.dtoType = dtoType;
+    if (reviewable) {
+      request.reviewStatusFilter = this.reviewStatusFilter;
+    }
+
+    // Return the observable so the caller can subscribe to it
+    return this.candidateSourceCandidateService.searchPaged(this.candidateSource, request).pipe(
+      tap(results => {
+        this.results = results;
+        this.cacheResults();
+        this.searching = false;
+      }),
+      catchError(error => {
+        this.error = error;
+        this.searching = false;
+        return throwError(error);
+      })
+    );
+  }
+
+  private isCacheable(): boolean {
+    //Reviewable sources are not cacheable because the review filtering makes it too complicated.
+    return !this.isReviewable();
+  }
+
+  protected isReviewable(): boolean {
+    return isSavedSearch(this.candidateSource)
+      ? this.candidateSource.reviewable : false;
+  }
+
+  protected cacheResults() {
+    this.timestamp = Date.now();
+
+    //We only cache certain results, and we don't cache filter keyword searches
+    this.candidateSourceResultsCacheService.cache(this.candidateSource, {
+      id: this.candidateSource.id,
+      pageNumber: this.pageNumber,
+      pageSize: this.pageSize,
+      sortFields: [this.sortField],
+      sortDirection: this.sortDirection,
+      results: this.results,
+      timestamp: this.timestamp
+    });
   }
 
 }

--- a/ui/admin-portal/src/app/components/candidates/show/candidate-source-base.ts
+++ b/ui/admin-portal/src/app/components/candidates/show/candidate-source-base.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2024 Talent Beyond Boundaries.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+import {
+  CandidateColumnSelectorComponent
+} from "../../util/candidate-column-selector/candidate-column-selector.component";
+
+import {ModalDismissReasons, NgbModal} from "@ng-bootstrap/ng-bootstrap";
+import {CandidateFieldService} from "../../../services/candidate-field.service";
+import {Input} from "@angular/core";
+import {CandidateSource} from "../../../model/base";
+import {CandidateFieldInfo} from "../../../model/candidate-field-info";
+
+export class CandidateSourceBaseComponent {
+  error: any = null;
+  longFormat: boolean;
+
+  @Input() candidateSource: CandidateSource;
+
+  protected selectedFields: CandidateFieldInfo[] = [];
+
+  constructor(
+    protected candidateFieldService: CandidateFieldService,
+    protected modalService: NgbModal
+  ) {}
+
+  onSelectColumns() {
+    //Initialize with current configuration
+    //Output is new configuration
+    const modal = this.modalService.open(CandidateColumnSelectorComponent);
+    modal.componentInstance.setSourceAndFormat(this.candidateSource, this.longFormat);
+
+    modal.result
+    .then(
+      () => this.loadSelectedFields()
+    )
+    .catch(
+      error => {
+        if (error !== ModalDismissReasons.ESC) {
+          this.error = error;
+        }
+      });
+  }
+
+  protected loadSelectedFields() {
+    this.selectedFields = this.candidateFieldService
+    .getCandidateSourceFields(this.candidateSource, this.longFormat);
+  }
+
+}

--- a/ui/admin-portal/src/app/components/candidates/show/candidate-source-base.ts
+++ b/ui/admin-portal/src/app/components/candidates/show/candidate-source-base.ts
@@ -145,24 +145,8 @@ export class CandidateSourceBaseComponent {
     this.sortDirection = this.sortDirection || 'DESC';
 
     //Create the appropriate request
-    let request;
-    let reviewable = false;
-    if (isSavedSearch(this.candidateSource)) {
-      reviewable = this.candidateSource.reviewable;
-      request = new SavedSearchGetRequest();
-    } else {
-      request = new SavedListGetRequest();
-    }
-    request.keyword = keyword;
-    request.showClosedOpps = showClosedOpps;
-    request.pageNumber = this.pageNumber - 1;
-    request.pageSize = this.pageSize;
-    request.sortFields = [this.sortField];
-    request.sortDirection = this.sortDirection;
+    const request = this.createSearchRequest(keyword, showClosedOpps);
     request.dtoType = dtoType;
-    if (reviewable) {
-      request.reviewStatusFilter = this.reviewStatusFilter;
-    }
 
     // Return the observable so the caller can subscribe to it
     return this.candidateSourceCandidateService.searchPaged(this.candidateSource, request).pipe(
@@ -177,6 +161,27 @@ export class CandidateSourceBaseComponent {
         return throwError(error);
       })
     );
+  }
+
+  createSearchRequest(keyword: string = null, showClosedOpps: boolean = false) {
+    let request;
+    if (isSavedSearch(this.candidateSource)) {
+      const reviewable = this.candidateSource.reviewable;
+      request = new SavedSearchGetRequest();
+      if (reviewable) {
+        request.reviewStatusFilter = this.reviewStatusFilter;
+      }
+    } else {
+      request = new SavedListGetRequest();
+      request.keyword = keyword;
+      request.showClosedOpps = showClosedOpps;
+    }
+    request.pageNumber = this.pageNumber - 1;
+    request.pageSize = this.pageSize;
+    request.sortFields = [this.sortField];
+    request.sortDirection = this.sortDirection;
+
+    return request;
   }
 
   private isCacheable(): boolean {

--- a/ui/admin-portal/src/app/components/candidates/show/returns/candidate-source-results.component.ts
+++ b/ui/admin-portal/src/app/components/candidates/show/returns/candidate-source-results.component.ts
@@ -90,13 +90,8 @@ export class CandidateSourceResultsComponent extends CandidateSourceBaseComponen
     }
   }
 
-  toggleSort(column) {
-    if (this.sortField === column) {
-      this.sortDirection = this.sortDirection === 'ASC' ? 'DESC' : 'ASC';
-    } else {
-      this.sortField = column;
-      this.sortDirection = 'ASC';
-    }
+  toggleSort(column: string) {
+    super.toggleSort(column);
     this.search(true);
   }
 

--- a/ui/admin-portal/src/app/components/candidates/show/returns/candidate-source-results.component.ts
+++ b/ui/admin-portal/src/app/components/candidates/show/returns/candidate-source-results.component.ts
@@ -26,6 +26,7 @@ import {AuthorizationService} from '../../../../services/authorization.service';
 import {CandidateFieldService} from "../../../../services/candidate-field.service";
 import {NgbModal} from "@ng-bootstrap/ng-bootstrap";
 import {CandidateSourceBaseComponent} from "../candidate-source-base";
+import {AuthenticationService} from "../../../../services/authentication.service";
 
 @Component({
   selector: 'app-candidate-source-results',
@@ -41,14 +42,17 @@ export class CandidateSourceResultsComponent extends CandidateSourceBaseComponen
   @Output() editSource = new EventEmitter<CandidateSource>();
 
   constructor(
-      private authService: AuthorizationService,
       private router: Router,
+      protected authorizationService: AuthorizationService,
+      protected authenticationService: AuthenticationService,
       protected candidateSourceResultsCacheService: CandidateSourceResultsCacheService,
       protected candidateSourceCandidateService: CandidateSourceCandidateService,
       protected candidateFieldService: CandidateFieldService,
       protected modalService: NgbModal
     ) {
       super(
+        authorizationService,
+        authenticationService,
         candidateSourceResultsCacheService,
         candidateSourceCandidateService,
         candidateFieldService,
@@ -95,7 +99,7 @@ export class CandidateSourceResultsComponent extends CandidateSourceBaseComponen
     this.search(true);
   }
 
-  //Pass toggle watch up to BrowseCandidateSourcesComponent for it to
+  //Pass toggle starred up to BrowseCandidateSourcesComponent for it to
   //do the update and refresh its copy of the candidate source details
   // (which is passed through to all contained components)
   onToggleStarred(source: CandidateSource) {
@@ -127,18 +131,6 @@ export class CandidateSourceResultsComponent extends CandidateSourceBaseComponen
 
   onRefreshRequest() {
     this.search(true);
-  }
-
-  isCandidateNameViewable(): boolean {
-    return this.authService.canViewCandidateName();
-  }
-
-  isCountryViewable(): boolean {
-    return this.authService.canViewCandidateCountry();
-  }
-
-  canAccessSalesforce(): boolean {
-    return this.authService.canAccessSalesforce();
   }
 
 }

--- a/ui/admin-portal/src/app/components/candidates/show/returns/candidate-source-results.component.ts
+++ b/ui/admin-portal/src/app/components/candidates/show/returns/candidate-source-results.component.ts
@@ -44,7 +44,6 @@ export class CandidateSourceResultsComponent extends CandidateSourceBaseComponen
   constructor(
       private router: Router,
       protected authorizationService: AuthorizationService,
-      protected authenticationService: AuthenticationService,
       protected candidateSourceResultsCacheService: CandidateSourceResultsCacheService,
       protected candidateSourceCandidateService: CandidateSourceCandidateService,
       protected candidateFieldService: CandidateFieldService,
@@ -52,7 +51,6 @@ export class CandidateSourceResultsComponent extends CandidateSourceBaseComponen
     ) {
       super(
         authorizationService,
-        authenticationService,
         candidateSourceResultsCacheService,
         candidateSourceCandidateService,
         candidateFieldService,

--- a/ui/admin-portal/src/app/components/candidates/show/returns/candidate-source-results.component.ts
+++ b/ui/admin-portal/src/app/components/candidates/show/returns/candidate-source-results.component.ts
@@ -30,24 +30,19 @@ import {CandidateSourceCandidateService} from '../../../../services/candidate-so
 import {SavedListGetRequest} from '../../../../model/saved-list';
 import {AuthorizationService} from '../../../../services/authorization.service';
 import {CandidateSourceService} from '../../../../services/candidate-source.service';
-import {CandidateFieldInfo} from "../../../../model/candidate-field-info";
 import {CandidateFieldService} from "../../../../services/candidate-field.service";
-import {
-  CandidateColumnSelectorComponent
-} from "../../../util/candidate-column-selector/candidate-column-selector.component";
-import {ModalDismissReasons, NgbModal} from "@ng-bootstrap/ng-bootstrap";
+import {NgbModal} from "@ng-bootstrap/ng-bootstrap";
+import {CandidateSourceBaseComponent} from "../candidate-source-base";
 
 @Component({
   selector: 'app-candidate-source-results',
   templateUrl: './candidate-source-results.component.html',
   styleUrls: ['./candidate-source-results.component.scss']
 })
-export class CandidateSourceResultsComponent implements OnInit, OnChanges {
-  error: null;
+export class CandidateSourceResultsComponent extends CandidateSourceBaseComponent implements OnInit, OnChanges {
   pageNumber: number;
   pageSize: number;
   results: SearchResults<Candidate>;
-  @Input() candidateSource: CandidateSource;
   @Input() showSourceDetails = true;
   @Output() toggleStarred = new EventEmitter<CandidateSource>();
   @Output() toggleWatch = new EventEmitter<CandidateSource>();
@@ -55,7 +50,6 @@ export class CandidateSourceResultsComponent implements OnInit, OnChanges {
   @Output() deleteSource = new EventEmitter<CandidateSource>();
   @Output() editSource = new EventEmitter<CandidateSource>();
   searching: boolean;
-  selectedFields: CandidateFieldInfo[] = [];
   sortField: string;
   sortDirection: string;
   timestamp: number;
@@ -63,16 +57,19 @@ export class CandidateSourceResultsComponent implements OnInit, OnChanges {
 constructor(
     private authService: AuthorizationService,
     private candidateService: CandidateService,
-    private candidateFieldService: CandidateFieldService,
     private candidateSourceService: CandidateSourceService,
     private candidateSourceCandidateService: CandidateSourceCandidateService,
-    private modalService: NgbModal,
     private router: Router,
     private savedSearchService: SavedSearchService,
-    private candidateSourceResultsCacheService: CandidateSourceResultsCacheService
-  ) { };
+    private candidateSourceResultsCacheService: CandidateSourceResultsCacheService,
+    protected candidateFieldService: CandidateFieldService,
+    protected modalService: NgbModal
+  ) {
+    super(candidateFieldService, modalService);
+};
 
   ngOnInit() {
+    this.longFormat = false;
   }
 
   ngOnChanges(changes: SimpleChanges): void {
@@ -82,11 +79,6 @@ constructor(
       this.loadSelectedFields();
       this.search(false);
     }
-  }
-
-  private loadSelectedFields() {
-    this.selectedFields = this.candidateFieldService
-      .getCandidateSourceFields(this.candidateSource, false);
   }
 
   onOpenSource() {
@@ -244,24 +236,6 @@ constructor(
 
   onRefreshRequest() {
     this.search(true);
-  }
-
-  onSelectColumns() {
-    //Initialize with current configuration
-    //Output is new configuration
-    const modal = this.modalService.open(CandidateColumnSelectorComponent);
-    modal.componentInstance.setSourceAndFormat(this.candidateSource, false);
-
-    modal.result
-      .then(
-        () => this.loadSelectedFields()
-      )
-      .catch(
-        error => {
-          if (error !== ModalDismissReasons.ESC) {
-            this.error = error;
-          }
-        });
   }
 
   isCandidateNameViewable(): boolean {

--- a/ui/admin-portal/src/app/components/candidates/show/returns/candidate-source-results.component.ts
+++ b/ui/admin-portal/src/app/components/candidates/show/returns/candidate-source-results.component.ts
@@ -16,8 +16,6 @@
 
 import {Component, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChanges} from '@angular/core';
 import {getCandidateSourceNavigation} from '../../../../model/saved-search';
-import {CandidateService} from '../../../../services/candidate.service';
-import {SavedSearchService} from '../../../../services/saved-search.service';
 import {Router} from '@angular/router';
 import {
   CandidateSourceResultsCacheService
@@ -25,7 +23,6 @@ import {
 import {CandidateSource, DtoType} from '../../../../model/base';
 import {CandidateSourceCandidateService} from '../../../../services/candidate-source-candidate.service';
 import {AuthorizationService} from '../../../../services/authorization.service';
-import {CandidateSourceService} from '../../../../services/candidate-source.service';
 import {CandidateFieldService} from "../../../../services/candidate-field.service";
 import {NgbModal} from "@ng-bootstrap/ng-bootstrap";
 import {CandidateSourceBaseComponent} from "../candidate-source-base";
@@ -45,10 +42,7 @@ export class CandidateSourceResultsComponent extends CandidateSourceBaseComponen
 
   constructor(
       private authService: AuthorizationService,
-      private candidateService: CandidateService,
-      private candidateSourceService: CandidateSourceService,
       private router: Router,
-      private savedSearchService: SavedSearchService,
       protected candidateSourceResultsCacheService: CandidateSourceResultsCacheService,
       protected candidateSourceCandidateService: CandidateSourceCandidateService,
       protected candidateFieldService: CandidateFieldService,

--- a/ui/admin-portal/src/app/components/candidates/show/returns/candidate-source-results.component.ts
+++ b/ui/admin-portal/src/app/components/candidates/show/returns/candidate-source-results.component.ts
@@ -26,7 +26,6 @@ import {AuthorizationService} from '../../../../services/authorization.service';
 import {CandidateFieldService} from "../../../../services/candidate-field.service";
 import {NgbModal} from "@ng-bootstrap/ng-bootstrap";
 import {CandidateSourceBaseComponent} from "../candidate-source-base";
-import {AuthenticationService} from "../../../../services/authentication.service";
 
 @Component({
   selector: 'app-candidate-source-results',

--- a/ui/admin-portal/src/app/components/candidates/show/returns/candidate-source-results.component.ts
+++ b/ui/admin-portal/src/app/components/candidates/show/returns/candidate-source-results.component.ts
@@ -35,7 +35,7 @@ import {CandidateFieldService} from "../../../../services/candidate-field.servic
 import {
   CandidateColumnSelectorComponent
 } from "../../../util/candidate-column-selector/candidate-column-selector.component";
-import {NgbModal} from "@ng-bootstrap/ng-bootstrap";
+import {ModalDismissReasons, NgbModal} from "@ng-bootstrap/ng-bootstrap";
 
 @Component({
   selector: 'app-candidate-source-results',
@@ -254,10 +254,14 @@ constructor(
 
     modal.result
       .then(
-        () => this.loadSelectedFields(),
-        error => this.error = error
+        () => this.loadSelectedFields()
       )
-      .catch();
+      .catch(
+        error => {
+          if (error !== ModalDismissReasons.ESC) {
+            this.error = error;
+          }
+        });
   }
 
   isCandidateNameViewable(): boolean {

--- a/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.html
+++ b/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.html
@@ -73,7 +73,7 @@
         <button class="btn btn-link" *ngIf="isEditable() && !isDefaultSavedSearch()" (click)="doEditSource()">
           <i class="fas fa-edit" title="Rename"></i>
         </button>
-        <button class="btn btn-link" (click)="doSelectColumns()">
+        <button class="btn btn-link" (click)="onSelectColumns()">
           <i class="fas fa-columns" title="Select columns to display"></i>
         </button>
         <button class="btn btn-link" *ngIf="canAssignTasks()" (click)="assignTasks()">

--- a/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.ts
+++ b/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.ts
@@ -34,12 +34,7 @@ import {
 } from '../../../model/candidate';
 import {CandidateService} from '../../../services/candidate.service';
 import {SearchResults} from '../../../model/search-results';
-import {
-  ModalDismissReasons,
-  NgbModal,
-  NgbOffcanvas,
-  NgbOffcanvasRef
-} from '@ng-bootstrap/ng-bootstrap';
+import {NgbModal, NgbOffcanvasRef} from '@ng-bootstrap/ng-bootstrap';
 import {
   CreateFromDefaultSavedSearchRequest,
   SavedSearchService
@@ -74,13 +69,11 @@ import {
   Status
 } from '../../../model/base';
 import {
-  CachedSourceResults,
   CandidateSourceResultsCacheService
 } from '../../../services/candidate-source-results-cache.service';
 import {FormBuilder, FormGroup} from '@angular/forms';
 import {User} from '../../../model/user';
 import {AuthorizationService} from '../../../services/authorization.service';
-import {UserService} from '../../../services/user.service';
 import {SelectListComponent, TargetListSelection} from '../../list/select/select-list.component';
 import {
   ContentUpdateType,
@@ -109,10 +102,6 @@ import {Location} from '@angular/common';
 import {copyToClipboard} from '../../../util/clipboard';
 import {SavedListService} from '../../../services/saved-list.service';
 import {ConfirmationComponent} from '../../util/confirm/confirmation.component';
-import {
-  CandidateColumnSelectorComponent
-} from '../../util/candidate-column-selector/candidate-column-selector.component';
-import {CandidateFieldInfo} from '../../../model/candidate-field-info';
 import {CandidateFieldService} from '../../../services/candidate-field.service';
 import {EditCandidateStatusComponent} from "../view/status/edit-candidate-status.component";
 import {
@@ -220,7 +209,6 @@ export class ShowCandidatesComponent extends CandidateSourceBaseComponent implem
               private fb: FormBuilder,
               private candidateService: CandidateService,
               private candidateSourceService: CandidateSourceService,
-              private userService: UserService,
               private savedSearchService: SavedSearchService,
               private savedListCandidateService: SavedListCandidateService,
               private savedListService: SavedListService,
@@ -231,7 +219,6 @@ export class ShowCandidatesComponent extends CandidateSourceBaseComponent implem
               private authenticationService: AuthenticationService,
               private publishedDocColumnService: PublishedDocColumnService,
               public salesforceService: SalesforceService,
-              private offcanvasService: NgbOffcanvas,
               protected candidateSourceResultsCacheService: CandidateSourceResultsCacheService,
               protected candidateSourceCandidateService: CandidateSourceCandidateService,
               protected candidateFieldService: CandidateFieldService,

--- a/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.ts
+++ b/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.ts
@@ -34,7 +34,12 @@ import {
 } from '../../../model/candidate';
 import {CandidateService} from '../../../services/candidate.service';
 import {SearchResults} from '../../../model/search-results';
-import {NgbModal, NgbOffcanvas, NgbOffcanvasRef} from '@ng-bootstrap/ng-bootstrap';
+import {
+  ModalDismissReasons,
+  NgbModal,
+  NgbOffcanvas,
+  NgbOffcanvasRef
+} from '@ng-bootstrap/ng-bootstrap';
 import {
   CreateFromDefaultSavedSearchRequest,
   SavedSearchService
@@ -1603,10 +1608,13 @@ export class ShowCandidatesComponent implements OnInit, OnChanges, OnDestroy {
 
     modal.result
       .then(
-        () => this.loadSelectedFields(),
-        error => this.error = error
+        () => this.loadSelectedFields()
       )
-      .catch();
+      .catch(error => {
+        if (error !== ModalDismissReasons.ESC) {
+          this.error = error;
+        }
+      });
   }
 
   isCandidateNameViewable() {

--- a/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.ts
+++ b/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.ts
@@ -503,13 +503,8 @@ export class ShowCandidatesComponent extends CandidateSourceBaseComponent implem
     this.doSearch(true);
   }
 
-  toggleSort(column) {
-    if (this.sortField === column) {
-      this.sortDirection = this.sortDirection === 'ASC' ? 'DESC' : 'ASC';
-    } else {
-      this.sortField = column;
-      this.sortDirection = 'ASC';
-    }
+  toggleSort(column: string) {
+    super.toggleSort(column);
     this.doSearch(true);
   }
 

--- a/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.ts
+++ b/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.ts
@@ -215,16 +215,18 @@ export class ShowCandidatesComponent extends CandidateSourceBaseComponent implem
               private localStorageService: LocalStorageService,
               private location: Location,
               private router: Router,
-              private authService: AuthorizationService,
-              private authenticationService: AuthenticationService,
               private publishedDocColumnService: PublishedDocColumnService,
               public salesforceService: SalesforceService,
+              protected authorizationService: AuthorizationService,
+              protected authenticationService: AuthenticationService,
               protected candidateSourceResultsCacheService: CandidateSourceResultsCacheService,
               protected candidateSourceCandidateService: CandidateSourceCandidateService,
               protected candidateFieldService: CandidateFieldService,
               protected modalService: NgbModal,
   ) {
     super(
+      authorizationService,
+      authenticationService,
       candidateSourceResultsCacheService,
       candidateSourceCandidateService,
       candidateFieldService,
@@ -755,18 +757,6 @@ export class ShowCandidatesComponent extends CandidateSourceBaseComponent implem
     return this.targetListName && this.targetListName.length > 0;
   }
 
-  isContentModifiable(): boolean {
-    return !isSavedSearch(this.candidateSource);
-  }
-
-  isSalesforceUpdatable(): boolean {
-    return !isSavedSearch(this.candidateSource) && this.authService.canUpdateSalesforce();
-  }
-
-  canResolveTasks(): boolean {
-    return isSavedList(this.candidateSource) && this.authService.canManageCandidateTasks();
-  }
-
   isSavedList(): boolean {
     return !isSavedSearch(this.candidateSource);
   }
@@ -775,51 +765,6 @@ export class ShowCandidatesComponent extends CandidateSourceBaseComponent implem
     //Not supported for saved searches because swapping an empty selection on a search could
     //potentially end up selecting huge numbers of candidates - up to the whole database.
     return !isSavedSearch(this.candidateSource);
-  }
-
-  sourceType(): string {
-    return isSavedSearch(this.candidateSource) ? 'savedSearch' : 'list';
-  }
-
-  isShareable(): boolean {
-    let shareable: boolean = false;
-
-    //Is shareable with me if it is not created by me.
-    if (this.candidateSource) {
-        //was it created by me?
-        if (!isMine(this.candidateSource, this.authenticationService)) {
-          shareable = true;
-        }
-    }
-    return shareable;
-  }
-
-  isGlobal(): boolean {
-    return this.candidateSource.global;
-  }
-
-  isImportable(): boolean {
-    return isSavedList(this.candidateSource);
-  }
-
-  isPublishable(): boolean {
-    return isSavedList(this.candidateSource) && this.authService.canPublishList();
-  }
-
-  isStarred(): boolean {
-    return isStarredByMe(this.candidateSource?.users, this.authenticationService);
-  }
-
-  isJobList(): boolean {
-    return isSavedList(this.candidateSource) && this.candidateSource.sfJobOpp != null;
-  }
-
-  isShowStage(): boolean {
-    return this.isJobList();
-  }
-
-  isEditable(): boolean {
-    return canEditSource(this.candidateSource, this.authenticationService);
   }
 
   onSelectionChange(candidate: Candidate, selected: boolean) {
@@ -1730,11 +1675,6 @@ export class ShowCandidatesComponent extends CandidateSourceBaseComponent implem
     }
   }
 
-  canAssignTasks() {
-    return this.authService.canAssignTask();
-  }
-
-
   /**
    * Get candidate stage in opportunity matching current job
     * @param candidate Candidate who opportunities we need to search
@@ -1759,10 +1699,6 @@ export class ShowCandidatesComponent extends CandidateSourceBaseComponent implem
    */
   getCandidateOppForThisJob(candidate: Candidate): CandidateOpportunity {
     return candidate.candidateOpportunities.find(o => o.jobOpp.id === this.candidateSource.sfJobOpp?.id);
-  }
-
-  canAccessSalesforce(): boolean {
-    return this.authService.canAccessSalesforce();
   }
 
   closeSelectedOpportunities() {

--- a/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.ts
+++ b/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.ts
@@ -223,7 +223,6 @@ export class ShowCandidatesComponent extends CandidateSourceBaseComponent implem
   ) {
     super(
       authorizationService,
-      authenticationService,
       candidateSourceResultsCacheService,
       candidateSourceCandidateService,
       candidateFieldService,


### PR DESCRIPTION
This PR:

- Allows escape key pressing to close column select modal
- Factors out common methods in show-candidates and candidate-source-results to candidate-source-base