### PR TITLE
1327 update default columns to show intake latest replace updated date col

### DIFF
--- a/ui/admin-portal/src/app/components/util/candidate-search-card/candidate-search-card.component.html
+++ b/ui/admin-portal/src/app/components/util/candidate-search-card/candidate-search-card.component.html
@@ -108,7 +108,8 @@
         <ng-template ngbNavContent>
           <app-candidate-general-tab
             [candidate]="candidate"
-            [editable]="false">
+            [editable]="false"
+            [adminUser]="isAnAdmin()">>
           </app-candidate-general-tab>
         </ng-template>
       </ng-container>
@@ -119,7 +120,8 @@
         <ng-template ngbNavContent>
           <app-candidate-experience-tab
             [candidate]="candidate"
-            [editable]="false">
+            [editable]="false"
+            [adminUser]="isAnAdmin()">
           </app-candidate-experience-tab>
         </ng-template>
       </ng-container>
@@ -130,7 +132,8 @@
         <ng-template ngbNavContent>
           <app-candidate-education-tab
             [candidate]="candidate"
-            [editable]="false">
+            [editable]="false"
+            [adminUser]="isAnAdmin()">
           </app-candidate-education-tab>
         </ng-template>
       </ng-container>
@@ -148,7 +151,7 @@
       </ng-container>
 
       <!-- TASKS -->
-      <ng-container ngbNavItem="tasks">
+      <ng-container ngbNavItem="tasks" *ngIf="canViewPrivateInfo()">
         <a ngbNavLink>Tasks</a>
         <ng-template ngbNavContent>
           <app-candidate-task-tab
@@ -159,7 +162,7 @@
       </ng-container>
 
       <!-- NOTES -->
-      <ng-container ngbNavItem="notes">
+      <ng-container ngbNavItem="notes" *ngIf="canViewPrivateInfo()">
         <a ngbNavLink>Notes</a>
         <ng-template ngbNavContent>
           <app-candidate-history-tab

--- a/ui/admin-portal/src/app/components/util/candidate-search-card/candidate-search-card.component.ts
+++ b/ui/admin-portal/src/app/components/util/candidate-search-card/candidate-search-card.component.ts
@@ -20,7 +20,8 @@ import {
   EventEmitter,
   Input,
   OnInit,
-  Output, SimpleChanges,
+  Output,
+  SimpleChanges,
   ViewChild
 } from '@angular/core';
 import {Candidate} from '../../../model/candidate';
@@ -164,6 +165,10 @@ export class CandidateSearchCardComponent implements OnInit, AfterViewChecked {
    */
   getCandidateOppForJobSource(): CandidateOpportunity {
     return this.candidate.candidateOpportunities.find(o => o.jobOpp.id === this.candidateSource.sfJobOpp?.id);
+  }
+
+  isAnAdmin(): boolean {
+    return this.authService.isAnAdmin();
   }
 
 }

--- a/ui/admin-portal/src/app/services/candidate-field.service.ts
+++ b/ui/admin-portal/src/app/services/candidate-field.service.ts
@@ -74,7 +74,7 @@ export class CandidateFieldService {
     "user.lastName",
     "status",
     "latestIntake",
-    "updatedDate",
+    "ieltsScore",
     "nationality.name",
     "country.name",
     "user.partner.abbreviation",


### PR DESCRIPTION
- They can only see the Additional Information section (that includes updated date) under the General tab IF they are an admin user. So showing that section doesn't neccessarily replace the Updated column on default.

- Also in order to show the Additional Information section in search card I had to add a missing 'adminUser' input which that section requires in order to show that component. In fact there was a few missing inputs on tab sections. I fixed this up and matched the tab permission inputs (adminUser) on all tabs and now the permissions are the same for the search card and the view.

However there are two auth methods used for permissions:

- isAdminUser which just checks for admin role

- canViewPrivateInformation this checks for admin role but also that the partner matches the candidate partner (or if default partner can view all as long as admin). **Is this the better auth method to use instead of isAdminUser now we are adding partners?**