### PR TITLE
1321 selectively send required preview fields for show candidates

### DIFF
--- a/server/src/main/java/org/tctalent/server/api/admin/CandidateBuilderSelector.java
+++ b/server/src/main/java/org/tctalent/server/api/admin/CandidateBuilderSelector.java
@@ -286,6 +286,7 @@ public class CandidateBuilderSelector {
 
     private DtoBuilder shortCandidateDto() {
         return new DtoBuilder()
+            .add("id")
             .add("candidateNumber")
             ;
     }

--- a/server/src/main/java/org/tctalent/server/api/admin/CandidateBuilderSelector.java
+++ b/server/src/main/java/org/tctalent/server/api/admin/CandidateBuilderSelector.java
@@ -196,13 +196,13 @@ public class CandidateBuilderSelector {
             .add("candidateAttachments", candidateAttachmentDto(userPropertyFilter, type))
             .add("taskAssignments", TaskDtoHelper.getTaskAssignmentDto(type))
             .add("candidateExams", examsDto())
+            .add("candidateOpportunities", candidateOpportunityDto(type))
             .add("miniIntakeCompletedDate")
             .add("fullIntakeCompletedDate")
             ;
 
             if (!DtoType.PREVIEW.equals(type)) {
                 builder
-                    .add("candidateOpportunities", candidateOpportunityDto())
                     .add("candidateProperties", candidatePropertyDto())
                     .add("shareableCv", candidateAttachmentDto(userPropertyFilter, type))
                     .add("shareableDoc", candidateAttachmentDto(userPropertyFilter, type))
@@ -256,26 +256,32 @@ public class CandidateBuilderSelector {
                 ;
     }
 
-    private DtoBuilder candidateOpportunityDto() {
-        return new DtoBuilder()
-                .add("id")
-                .add("sfId")
-            .add("candidate", shortCandidateDto())
-            .add("closingComments")
-            .add("closingCommentsForCandidate")
-            .add("employerFeedback")
+    private DtoBuilder candidateOpportunityDto(DtoType type) {
+        final DtoBuilder builder = new DtoBuilder()
+            .add("id")
+            .add("sfId")
             .add("jobOpp", jobDto())
+            .add("candidate", shortCandidateDto())
             .add("name")
+            .add("stage")
             .add("nextStep")
             .add("nextStepDueDate")
-            .add("lastActiveStage")
-            .add("stage")
-            .add("createdBy", userDto())
-            .add("createdDate")
-            .add("updatedBy", userDto())
-            .add("updatedDate")
-            .add("relocatingDependantIds")
             ;
+
+        if (!DtoType.PREVIEW.equals(type)) {
+            builder
+                .add("closingComments")
+                .add("closingCommentsForCandidate")
+                .add("employerFeedback")
+                .add("lastActiveStage")
+                .add("createdBy", userDto())
+                .add("createdDate")
+                .add("updatedBy", userDto())
+                .add("updatedDate")
+                .add("relocatingDependantIds")
+            ;
+        }
+        return builder;
     }
 
     private DtoBuilder shortCandidateDto() {

--- a/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.ts
+++ b/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.ts
@@ -467,7 +467,7 @@ export class ShowCandidatesComponent extends CandidateSourceBaseComponent implem
         //Run the saved list or saved search as stored on the server.
         this.performSearch(
           this.pageSize,
-          DtoType.FULL, // @todo will change to Previews in #1321
+          DtoType.PREVIEW,
           this.keyword,
           this.showClosedOpps).subscribe(() => {
             // Restore the selection prior to the search


### PR DESCRIPTION
This PR:

- selectively sends candidate opportunity preview data required to show-candidates
- fixes a data bug by including candidate id in short candidate dtos because this field is used in candidate-opps component for fetching chats