### PR TITLE
1282 update optional columns in search and list view column selector

### DIFF
--- a/server/src/main/java/org/tctalent/server/configuration/SecurityConfiguration.java
+++ b/server/src/main/java/org/tctalent/server/configuration/SecurityConfiguration.java
@@ -264,6 +264,9 @@ public class SecurityConfiguration {
                 // PUT: CLEAR SELECTION SAVED SEARCHES
                 .requestMatchers(HttpMethod.PUT, "/api/admin/saved-search/clear-selection/*").hasAnyRole( "SYSTEMADMIN", "ADMIN", "PARTNERADMIN", "SEMILIMITED", "LIMITED", "READONLY")
 
+                // PUT: CLEAR SELECTION SAVED SEARCHES
+                .requestMatchers(HttpMethod.PUT, "/api/admin/saved-search/displayed-fields/*").hasAnyRole( "SYSTEMADMIN", "ADMIN", "PARTNERADMIN", "SEMILIMITED", "LIMITED", "READONLY")
+
                 // POST: EXPORT SAVE SELECTION SAVED SEARCHES
                 .requestMatchers(HttpMethod.POST, "/api/admin/saved-search-candidate/*/export/csv").hasAnyRole( "SYSTEMADMIN", "ADMIN", "PARTNERADMIN", "SEMILIMITED", "LIMITED", "READONLY")
 

--- a/ui/admin-portal/src/app/model/candidate-field-info.ts
+++ b/ui/admin-portal/src/app/model/candidate-field-info.ts
@@ -62,7 +62,8 @@ export class CandidateFieldInfo {
   getValue(candidate: Candidate): string {
     let value;
     // Need to format field with the candidate object not value
-    if (this.fieldPath === "ieltsScore" || this.fieldPath === "latestIntake" || this.fieldPath === "latestIntakeDate") {
+    if (this.fieldPath === "ieltsScore" || this.fieldPath === "frenchAssessmentScoreNclc" ||
+      this.fieldPath === "latestIntake" || this.fieldPath === "latestIntakeDate") {
       value = candidate;
     } else {
       value = this.getUnformattedValue(candidate);

--- a/ui/admin-portal/src/app/services/authorization.service.ts
+++ b/ui/admin-portal/src/app/services/authorization.service.ts
@@ -109,6 +109,22 @@ export class AuthorizationService {
   }
 
   /**
+   * True if the currently logged-in user is permitted to see candidate contact details
+   */
+  canViewCandidateContact(): boolean {
+    let result: boolean = false;
+    if (this.isSourcePartner() || this.isJobCreator()) {
+      switch (this.getLoggedInRole()) {
+        case Role.systemadmin:
+        case Role.admin:
+        case Role.partneradmin:
+          result = true;
+      }
+    }
+    return result;
+  }
+
+  /**
    * True if the logged-in user work for the source partner that is currently managing the
    * given candidate
    * @param candidate
@@ -411,7 +427,7 @@ export class AuthorizationService {
    * @param candidateSource Candidate source - ie SavedList or SavedSearch
    * @return true if can be edited, false if source is null
    */
-  canEditCandidateSource(candidateSource: CandidateSource) {
+    canEditCandidateSource(candidateSource: CandidateSource) {
     let editable = false;
     if (candidateSource) {
       if (this.isCandidateSourceMine(candidateSource)) {

--- a/ui/admin-portal/src/app/services/candidate-field.service.ts
+++ b/ui/admin-portal/src/app/services/candidate-field.service.ts
@@ -118,8 +118,12 @@ export class CandidateFieldService {
       new CandidateFieldInfo("Partner", "user.partner.abbreviation", null,
         null, null, true),
       new CandidateFieldInfo("Phone", "phone", null,
-        null, null, true),
-      new CandidateFieldInfo("Referrer", "regoReferrerParam", null,
+        null, this.isCandidateContactViewable, true),
+      new CandidateFieldInfo("Whatsapp", "whatsapp", null,
+        null, this.isCandidateContactViewable, true),
+      new CandidateFieldInfo("Email", "user.email", null,
+        null, this.isCandidateContactViewable, true),
+    new CandidateFieldInfo("Referrer", "regoReferrerParam", null,
         null, null, true),
       new CandidateFieldInfo("Status", "status", null,
         this.titleCaseFormatter, null, true),
@@ -234,6 +238,13 @@ export class CandidateFieldService {
    */
   isCountryViewable = (): boolean => {
     return this.authService.canViewCandidateCountry()
+  }
+
+  /**
+   * Regarding funny syntax, see above comments for isCandidateNameViewable
+   */
+  isCandidateContactViewable = (): boolean => {
+    return this.authService.canViewCandidateContact()
   }
 
   isAnAdmin(): boolean {

--- a/ui/admin-portal/src/app/services/candidate-field.service.ts
+++ b/ui/admin-portal/src/app/services/candidate-field.service.ts
@@ -155,7 +155,11 @@ export class CandidateFieldService {
       new CandidateFieldInfo("Latest Intake", "latestIntake", this.intakeDatesTooltip,
       this.intakeTypeFormatter, null, false),
       new CandidateFieldInfo("Latest Intake Date", "latestIntakeDate", null,
-      this.intakeDateFormatter, null, false)
+      this.intakeDateFormatter, null, false),
+      new CandidateFieldInfo("Survey Type", "surveyType.name", null,
+        null, null, true),
+      new CandidateFieldInfo("Survey Comment", "surveyComment", null,
+        null, null, true)
       // REMOVED THIS COLUMN FOR NOW, AS IT ISN'T SORTABLE. INSTEAD ADDED TASKS MONITOR.
       // new CandidateFieldInfo("Tasks Status", "taskAssignments", null,
       //   this.getOverallTasksStatus, null),

--- a/ui/admin-portal/src/app/services/candidate-field.service.ts
+++ b/ui/admin-portal/src/app/services/candidate-field.service.ts
@@ -46,12 +46,19 @@ export class CandidateFieldService {
   private intakeTypeFormatter = (value) => {
     return this.getIntakesCompleted(value);
   }
+
   private intakeDateFormatter = (value) => {
     return this.getLatestIntakeDates(value);
   }
-  private getIeltsScoreType = (value) => {
+
+  private ieltsScoreFormatter = (value) => {
     return this.getIeltsScore(value);
   }
+
+  private nclcScoreFormatter = (value) => {
+    return this.getNclcScore(value);
+  }
+
   private getOverallTasksStatus = (value) => {
     return this.getTasksStatus(value);
   }
@@ -136,8 +143,10 @@ export class CandidateFieldService {
       new CandidateFieldInfo("Highest Level of Edu", "maxEducationLevel.level", null,
         this.levelGetNameFormatter, null, true),
       new CandidateFieldInfo("IELTS Score", "ieltsScore", null,
-        this.getIeltsScoreType, null, true),
-      new CandidateFieldInfo("Legal status", "residenceStatus", null,
+        this.ieltsScoreFormatter, null, true),
+      new CandidateFieldInfo("NCLC Score", "frenchAssessmentScoreNclc", null,
+        this.nclcScoreFormatter, null, true),
+    new CandidateFieldInfo("Legal status", "residenceStatus", null,
         this.residenceStatusFormatter, null, true),
       new CandidateFieldInfo("Dependants", "numberDependants", null,
         null, null, true),
@@ -285,6 +294,15 @@ export class CandidateFieldService {
       } else {
         score = candidate?.ieltsScore + ' (Est)'
       }
+    }
+    return score;
+  }
+
+  getNclcScore(candidate: Candidate): string {
+    let score: string = null;
+    if (candidate?.frenchAssessmentScoreNclc != null) {
+      // todo - add check for type of score (e.g. TEF, TCF, etc.) when available - see #768
+      score = candidate?.frenchAssessmentScoreNclc + ' (Est)'
     }
     return score;
   }


### PR DESCRIPTION
This PR:

- Adds email and whatsapp as selectable fields
- Restricts email, whatsapp and phone column selectability to partner admins and above
- Adds Nclc estimate scores as a selectable field
- Adds survey type and comment as selectable fields