### PR TITLE
1370 screen real estate on search and list full screen views

### DIFF
--- a/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.html
+++ b/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.html
@@ -31,11 +31,25 @@
     {{error}}
   </div>
 
-  <div>
-    <app-candidate-source-description
-      [candidateSource]="candidateSource"
-    >
-    </app-candidate-source-description>
+  <!--Toggle description -->
+  <div class="mb-3">
+    <a class="link" (click)="showDescription = !showDescription">
+      <ng-container *ngIf="!showDescription">
+        <i class="fas fa-caret-up"></i> Show description
+      </ng-container>
+      <ng-container *ngIf="showDescription">
+        <i class="fas fa-caret-right"></i> Hide description
+      </ng-container>
+    </a>
+  </div>
+
+  <div [hidden]="!showDescription">
+    <div>
+      <app-candidate-source-description
+        [candidateSource]="candidateSource"
+      >
+      </app-candidate-source-description>
+    </div>
   </div>
 
   <div class="results-area">

--- a/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.html
+++ b/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.html
@@ -23,7 +23,7 @@
 
   <nav aria-label="breadcrumb" class="breadcrumb-container" [hidden]="!showBreadcrumb">
     <h3 class="breadcrumb-heading">
-        {{getBreadcrumb()}}
+      <i *ngIf="isSubmissionList()" class="fas fa-rectangle-list"></i> {{getBreadcrumb()}}
     </h3>
   </nav>
 

--- a/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.html
+++ b/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.html
@@ -21,11 +21,72 @@
 
   <ng-content></ng-content>
 
-  <nav aria-label="breadcrumb" class="breadcrumb-container" [hidden]="!showBreadcrumb">
-    <h3 class="breadcrumb-heading">
-      <i *ngIf="isSubmissionList()" class="fas fa-rectangle-list"></i> {{getBreadcrumb()}}
-    </h3>
-  </nav>
+  <div class="d-flex justify-content-between align-items-center">
+
+    <h2>
+      <!-- Submission list / list / search icon-->
+      <ng-container *ngIf="isSubmissionList(); else savedListOrSearch">
+        <i class="fas fa-rectangle-list"></i>
+      </ng-container>
+      <ng-template #savedListOrSearch>
+        <i *ngIf="isSavedList(); else savedSearch" class="fas fa-list"></i>
+      </ng-template>
+      <ng-template #savedSearch>
+        <i *ngIf="isSavedSearch()" class="fas fa-search"></i>
+      </ng-template>
+
+      {{getBreadcrumb()}} <!-- Todo : Rename this? We simply want the list name or search name -->
+
+      <span class="small text-muted">
+        {{candidateSource.id}}
+        <!-- Icons -->
+        <a target="_blank" [routerLink]="['./']" class="link-primary">
+          <i class="fas fa-external-link-alt is-link" title="Show candidate in new tab"></i>
+        </a>
+        -
+        <a target="_blank" *ngIf="!isDefaultSavedSearch()" (click)="doCopyLink()" class="link-info">
+          <i class="fas fa-link" title="Copy shareable link"></i>
+        </a>
+        <a target="_blank" (click)="doToggleStarred()" class="link-info">
+          <i *ngIf="isStarred()" class="fas fa-star starred" title="Unstar"></i>
+          <i *ngIf="!isStarred()" class="far fa-star notstarred" title="Star"></i>
+        </a>
+        <a target="_blank" *ngIf="isSavedList()" (click)="doCopySource()" class="link-info">
+          <i class="fas fa-clone" title="Copy"></i>
+        </a>
+        <a target="_blank" *ngIf="hasSavedSearchSource()" (click)="doShowSearch()" class="link-info">
+          <i class="fas fa-search" title="Show Search"></i>
+        </a>
+        <a target="_blank" *ngIf="isEditable() && !isDefaultSavedSearch()" (click)="doEditSource()" class="link-info">
+          <i class="fas fa-edit" title="Rename"></i>
+        </a>
+        <a target="_blank" *ngIf="isEditable()" (click)="onSelectColumns()" class="link-info">
+          <i class="fas fa-columns" title="Select columns to display"></i>
+        </a>
+        <a target="_blank" *ngIf="canAssignTasks()" (click)="assignTasks()" class="link-info">
+          <i class="fas fa-tasks" title="Assign/show tasks"></i>
+        </a>
+        <a target="_blank" *ngIf="!isDefaultSavedSearch()" (click)="doRunStats()" class="link-info">
+          <i class="fas fa-chart-bar" title="Run stats"></i>
+        </a>
+        <a target="_blank" *ngIf="candidateSource?.sfJobOpp" [routerLink]="['/job',candidateSource.sfJobOpp.id]" class="link-info">
+          <i class="fa-solid fa-briefcase" title="Associated Job"></i>
+        </a>
+        <a target="_blank" *ngIf="salesforceService.joblink(candidateSource) && canAccessSalesforce()" (click)="doShowSalesforceLink()" class="link-info">
+          <i class="fab fa-salesforce" title="Associated Job Opportunity on Salesforce"></i>
+        </a>
+        <a target="_blank" *ngIf="isSavedList()" (click)="doShowListFolder()" class="link-info">
+          <i class="fab fa-google-drive" title="Create/show Google folder"></i>
+        </a>
+        <a target="_blank" *ngIf="hasPublishedDoc()" (click)="doShowPublishedDoc()" class="link-info">
+          <i class="fas fa-globe" title="Show published sheet"></i>
+        </a>
+        <a target="_blank" *ngIf="timestamp" (click)="doSearch(true)" class="link-info">
+          <i class="fas fa-sync" title="Refresh data"></i>
+        </a>
+        </span>
+    </h2>
+  </div>
 
   <div class="alert alert-danger" *ngIf="error">
     {{error}}
@@ -53,198 +114,8 @@
   </div>
 
   <div class="results-area">
-    <div class="d-flex text-muted align-items-baseline flex-wrap-reverse justify-content-end py-3">
 
-      <ngb-pagination *ngIf="!searching"
-                      [boundaryLinks]="true"
-                      [pageSize]="pageSize"
-                      [collectionSize]="results?.totalElements"
-                      [(page)]="pageNumber"
-                      [maxSize]="5"
-                      [ellipses]="true"
-                      [rotate]="true"
-                      (pageChange)="doSearch(true)">
-      </ngb-pagination>
-
-<!--      Icons -->
-      <div class="d-flex flex-grow-1 space-evenly">
-        <button class="btn btn-link" *ngIf="!isDefaultSavedSearch()" (click)="doCopyLink()">
-          <i class="fas fa-link" title="Copy shareable link"></i>
-        </button>
-        <button class="btn btn-link" (click)="doToggleStarred()">
-          <i *ngIf="isStarred()" class="fas fa-star starred" title="Unstar"></i>
-          <i *ngIf="!isStarred()" class="far fa-star notstarred" title="Star"></i>
-        </button>
-        <button class="btn btn-link" *ngIf="isSavedList()" (click)="doCopySource()">
-          <i class="fas fa-clone" title="Copy"></i>
-        </button>
-        <button class="btn btn-link" *ngIf="hasSavedSearchSource()" (click)="doShowSearch()">
-          <i class="fas fa-search" title="Show Search"></i>
-        </button>
-        <button class="btn btn-link" *ngIf="isEditable() && !isDefaultSavedSearch()" (click)="doEditSource()">
-          <i class="fas fa-edit" title="Rename"></i>
-        </button>
-        <button class="btn btn-link" *ngIf="isEditable()" (click)="onSelectColumns()">
-          <i class="fas fa-columns" title="Select columns to display"></i>
-        </button>
-        <button class="btn btn-link" *ngIf="canAssignTasks()" (click)="assignTasks()">
-          <i class="fas fa-tasks" title="Assign/show tasks"></i>
-        </button>
-        <button class="btn btn-link" *ngIf="!isDefaultSavedSearch()" (click)="doRunStats()">
-          <i class="fas fa-chart-bar" title="Run stats"></i>
-        </button>
-        <button class="btn btn-link" *ngIf="candidateSource?.sfJobOpp"
-           [routerLink]="['/job',candidateSource.sfJobOpp.id]">
-          <i class="fa-solid fa-briefcase" title="Associated Job"></i>
-        </button>
-        <button class="btn btn-link"
-                *ngIf="salesforceService.joblink(candidateSource) && canAccessSalesforce()"
-                (click)="doShowSalesforceLink()">
-            <i class="fab fa-salesforce" title="Associated Job Opportunity on Salesforce"></i>
-        </button>
-        <button class="btn btn-link" *ngIf="isSavedList()" (click)="doShowListFolder()">
-          <i class="fab fa-google-drive" title="Create/show Google folder"></i>
-        </button>
-        <button class="btn btn-link" *ngIf="hasPublishedDoc()" (click)="doShowPublishedDoc()">
-          <i class="fas fa-globe" title="Show published sheet"></i>
-        </button>
-        <button class="btn btn-link" *ngIf="timestamp" (click)="doSearch(true)">
-          <i class="fas fa-sync" title="Refresh data"></i>
-        </button>
-      </div>
-
-<!--    Results summary-->
-      <div class="text-end">
-        <span>{{results?.totalElements}} candidates returned</span><br/>
-        <span class="small">Timestamp {{timestamp | date: 'customDateTime'}}</span>
-      </div>
-    </div>
-
-<!--    Buttons -->
-    <div class="d-flex justify-content-between">
-
-      <div class="d-flex flex-wrap buttons-spacing flex-fill align-content-between">
-        <button class="btn btn-sm btn-secondary" [disabled]="!isSelection()"
-                (click)="saveSelection()" title="Save Selection">
-          <i class="fas fa-spinner fa-spin" *ngIf=savingSelection></i>
-          <i class="fas fa-user-check"></i> to
-          <i class="fas fa-list"></i>
-        </button>
-
-        <button *ngIf="isSavedList()" class="btn btn-sm btn-secondary" [disabled]="!isSelection()"
-                (click)="copyEmails()" title="Copy emails of selected candidates">
-          <i class="fas fa-user-check"></i> to
-          <i class="fa fa-envelope"></i>
-        </button>
-
-        <button *ngIf="canUpdateStatuses()" class="btn btn-sm btn-secondary" [disabled]="!isSelection()"
-                (click)="updateStatusOfSelection()" title="Update Statuses of Selection">
-          <i class="fas fa-spinner fa-spin" *ngIf=updatingStatuses></i>
-          <i class="fas fa-user-check"></i>
-          Status change
-        </button>
-
-        <button class="btn btn-sm btn-secondary" [disabled]="!isSelection()"
-                (click)="clearSelection()"
-                title="Clear Selection">
-          Clear <i class="fas fa-user-check"></i>
-        </button>
-
-        <button *ngIf="isSwapSelectionSupported()" class="btn btn-sm btn-secondary"
-                (click)="swapSelection()"
-                title="Swap Selection. Selected becomes unselected and vice versa.">
-          <i class="fas fa-sync"></i><i class="fas fa-user-check"></i>
-        </button>
-
-        <button class="btn btn-sm btn-secondary" *ngIf="!isSubmissionList() && isContentModifiable()"
-                [disabled]="!isSelection()"
-                (click)="removeSelectedCandidatesFromList()"
-                title="Remove selected candidates from list">
-          Remove <i class="fas fa-user-check"></i>
-        </button>
-
-        <button class="btn btn-sm btn-secondary" *ngIf="isSubmissionList() && isSalesforceUpdatable()"
-                [disabled]="!isSelection()"
-                (click)="closeSelectedOpportunities()"
-                title="Close selected candidate cases. Not removed from list but hidden unless 'Show closed cases' checkbox is checked.">
-          <i class="fas fa-spinner fa-spin" *ngIf=closing></i>
-          Remove (Close) <i class="fas fa-user-check"></i>
-        </button>
-
-        <button  *ngIf="isImportable()" class="btn btn-sm btn-secondary" (click)="importCandidates()"
-                 title="Import candidates">
-          <i class="fas fa-spinner fa-spin" *ngIf=importing></i>
-          Import <i class="fas fa-file-excel"></i>
-        </button>
-
-        <button *ngIf="!isSavedList() && isExportable()" class="btn btn-sm btn-secondary"
-                (click)="exportCandidates()"
-                title="Export candidates">
-          <i class="fas fa-spinner fa-spin" *ngIf=exporting></i>
-          Export <i class="fas fa-file-excel"></i>
-        </button>
-
-        <button *ngIf="isPublishable()" class="btn btn-sm btn-secondary" (click)="modifyExportColumns()"
-                title="Publish candidates to be shared externally - eg with employers">
-          <i class="fas fa-spinner fa-spin" *ngIf=publishing></i>
-          Publish <i class="fas fa-globe"></i>
-        </button>
-
-        <button  *ngIf= "hasPublishedDoc() && isContentModifiable()
-                      && salesforceService.joblink(candidateSource)"
-                 class="btn btn-sm btn-secondary" (click)="importEmployerFeedback()"
-                 title="Import employer feedback from published list">
-          <i class="fas fa-spinner fa-spin" *ngIf=importingFeedback></i>
-          Feedback <i class="fas fa-globe"></i>
-        </button>
-        <button *ngIf="isSubmissionList() && isSalesforceUpdatable()" class="btn btn-sm btn-secondary"
-                (click)="createUpdateSalesforce()"
-                title="Create or update selected candidate cases">
-          <i class="fas fa-spinner fa-spin" *ngIf=updating></i>
-          Update Case/s <i class="fa-solid fa-address-book"></i>
-        </button>
-
-        <button class="btn btn-sm btn-secondary" *ngIf="canResolveTasks()" [disabled]="!isSelection()"
-                (click)="resolveTaskAssignments()"
-                title="Resolve any outstanding tasks">
-          <i class="fas fa-spinner fa-spin" *ngIf=updatingTasks></i>
-          <i class="fas fa-user-check"></i> Resolve tasks
-        </button>
-      </div>
-
-      <div class="d-flex">
-        <div *ngIf="isContentModifiable()" class="flex-fill w-50 me-2">
-          <input id="quickNumberOrNameSearch"
-                 type="text" class="form-control" #input
-                 [ngbTypeahead]="doNumberOrNameSearch"
-                 [resultTemplate]="rt"
-                 [inputFormatter]="renderCandidateRow"
-                 [editable]="false"
-                 (selectItem)="selectCandidateToAdd($event, input)"
-                 placeholder="Add (name or #)..."/>
-          <ng-template #rt let-r="result" let-t="term">
-            <ngb-highlight [result]="renderCandidateRow(r)" [term]="t"></ngb-highlight>
-          </ng-template>
-          <div *ngIf=adding class="small text-info text-center mt-1">Adding candidate to list <i class="fas fa-spinner fa-spin" ></i></div>
-        </div>
-
-        <div *ngIf="isSavedList()" class="flex-fill w-50 mx-2">
-          <form [formGroup]="searchForm">
-            <div class="mb-3 mb-0 flex-fill">
-              <input type="text" class="form-control" placeholder="Search (name or #)..." aria-label="Search (name/number)..." formControlName="keyword"
-                     id="keyword" autofocus>
-            </div>
-            <div *ngIf="isJobList()" class="form-check-reverse">
-              <input [title]="showClosedOppsTip" type="checkbox" formControlName="showClosedOpps" id="showClosedOpps" class="form-check-input">
-              <label class="form-check-label" [title]="showClosedOppsTip" for="showClosedOpps">Show closed cases</label>
-            </div>
-          </form>
-        </div>
-      </div>
-
-    </div>
-
-<!--  List operation log - eg Save/Replace again, or Copied to list  -->
+    <!--  List operation log - eg Save/Replace again, or Copied to list  -->
     <div class="text-muted pt-0 mb-3" *ngIf="!searching">
       <div *ngIf="haveTargetList() && savedSelection" class="d-flex pt-1 align-items-center">
         <button class="btn btn-sm btn-outline-secondary me-2"
@@ -274,7 +145,7 @@
     </div>
 
 
-<!-- Review status -->
+    <!-- Review status -->
     <div *ngIf="isReviewable()">
       <label class="form-label" for="reviewStatuses">Don't show candidates reviewed as: </label>
       <form id="reviewStatuses" class="filter-form" [formGroup]="searchForm">
@@ -296,7 +167,7 @@
       </form>
     </div>
 
-<!--  Task selection - select just one task to focus on  -->
+    <!--  Task selection - select just one task to focus on  -->
     <div *ngIf="hasTasksAssigned()" class="mb-3">
       <ng-select [items]="tasksAssignedToList"
                  bindLabel="displayName"
@@ -304,6 +175,207 @@
                  (ngModelChange)="doSearch(true)"
                   placeholder="Tasks Monitor: Select a task that has been assigned to the list to monitor... (note: default task monitor will monitor all required tasks)">
       </ng-select>
+    </div>
+
+    <div class="d-flex text-muted align-items-baseline flex-wrap-reverse justify-content-sm-start py-3">
+      <ngb-pagination *ngIf="!searching"
+                      [boundaryLinks]="true"
+                      [pageSize]="pageSize"
+                      [collectionSize]="results?.totalElements"
+                      [(page)]="pageNumber"
+                      [maxSize]="5"
+                      [ellipses]="true"
+                      [rotate]="true"
+                      (pageChange)="doSearch(true)">
+      </ngb-pagination>
+
+      <!--      Icons -->  <!-- Todo remove these in a separate commit -->
+<!--      <div class="d-flex flex-grow-1 space-evenly">-->
+<!--                <button class="btn btn-link" *ngIf="!isDefaultSavedSearch()" (click)="doCopyLink()">-->
+<!--                  <i class="fas fa-link" title="Copy shareable link"></i>-->
+<!--                </button>-->
+<!--                <button class="btn btn-link" (click)="doToggleStarred()">-->
+<!--                  <i *ngIf="isStarred()" class="fas fa-star starred" title="Unstar"></i>-->
+<!--                  <i *ngIf="!isStarred()" class="far fa-star notstarred" title="Star"></i>-->
+<!--                </button>-->
+<!--                <button class="btn btn-link" *ngIf="isSavedList()" (click)="doCopySource()">-->
+<!--                  <i class="fas fa-clone" title="Copy"></i>-->
+<!--                </button>-->
+<!--                <button class="btn btn-link" *ngIf="hasSavedSearchSource()" (click)="doShowSearch()">-->
+<!--                  <i class="fas fa-search" title="Show Search"></i>-->
+<!--                </button>-->
+<!--                <button class="btn btn-link" *ngIf="isEditable() && !isDefaultSavedSearch()" (click)="doEditSource()">-->
+<!--                  <i class="fas fa-edit" title="Rename"></i>-->
+<!--                </button>-->
+<!--                <button class="btn btn-link" *ngIf="isEditable()" (click)="onSelectColumns()">-->
+<!--                  <i class="fas fa-columns" title="Select columns to display"></i>-->
+<!--                </button>-->
+<!--                <button class="btn btn-link" *ngIf="canAssignTasks()" (click)="assignTasks()">-->
+<!--                  <i class="fas fa-tasks" title="Assign/show tasks"></i>-->
+<!--                </button>-->
+<!--                <button class="btn btn-link" *ngIf="!isDefaultSavedSearch()" (click)="doRunStats()">-->
+<!--                  <i class="fas fa-chart-bar" title="Run stats"></i>-->
+<!--                </button>-->
+<!--                <button class="btn btn-link" *ngIf="candidateSource?.sfJobOpp"-->
+<!--                   [routerLink]="['/job',candidateSource.sfJobOpp.id]">-->
+<!--                  <i class="fa-solid fa-briefcase" title="Associated Job"></i>-->
+<!--                </button>-->
+<!--                <button class="btn btn-link"-->
+<!--                        *ngIf="salesforceService.joblink(candidateSource) && canAccessSalesforce()"-->
+<!--                        (click)="doShowSalesforceLink()">-->
+<!--                    <i class="fab fa-salesforce" title="Associated Job Opportunity on Salesforce"></i>-->
+<!--                </button>-->
+<!--                <button class="btn btn-link" *ngIf="isSavedList()" (click)="doShowListFolder()">-->
+<!--                  <i class="fab fa-google-drive" title="Create/show Google folder"></i>-->
+<!--                </button>-->
+<!--                <button class="btn btn-link" *ngIf="hasPublishedDoc()" (click)="doShowPublishedDoc()">-->
+<!--                  <i class="fas fa-globe" title="Show published sheet"></i>-->
+<!--                </button>-->
+<!--                <button class="btn btn-link" *ngIf="timestamp" (click)="doSearch(true)">-->
+<!--                  <i class="fas fa-sync" title="Refresh data"></i>-->
+<!--                </button>-->
+<!--      </div>-->
+
+      <!--    Results summary-->
+              <div class="d-flex flex-grow-1 justify-content-end">
+                      <div class="text-end">
+        <span>{{results?.totalElements}} candidates returned</span><br/>
+        <span class="small">Timestamp {{timestamp | date: 'customDateTime'}}</span>
+                        </div>
+      </div>
+    </div>
+
+    <div class="row">
+      <!-- First Group of Buttons (Left-aligned) -->
+      <div class="col-auto d-flex justify-content-start flex-wrap">
+        <div class="d-flex flex-wrap buttons-spacing align-content-between">
+          <button class="btn btn-sm btn-secondary me-2" [disabled]="!isSelection()"
+                  (click)="saveSelection()" title="Save selected candidates to a list">
+            <i class="fas fa-spinner fa-spin" *ngIf=savingSelection></i>
+            <i class="fas fa-user-check"></i> to
+            <i class="fas fa-list"></i>
+          </button>
+
+          <button *ngIf="isSavedList()" class="btn btn-sm btn-secondary me-2" [disabled]="!isSelection()"
+                  (click)="copyEmails()" title="Copy emails of selected candidates">
+            <i class="fas fa-user-check"></i> to
+            <i class="fa fa-envelope"></i>
+          </button>
+
+          <button *ngIf="canUpdateStatuses()" class="btn btn-sm btn-secondary me-2" [disabled]="!isSelection()"
+                  (click)="updateStatusOfSelection()" title="Update statuses of selected candidates">
+            <i class="fas fa-spinner fa-spin" *ngIf=updatingStatuses></i>
+            <i class="fas fa-user-check"></i>
+            Status change
+          </button>
+
+          <button class="btn btn-sm btn-secondary me-2" *ngIf="canResolveTasks()" [disabled]="!isSelection()"
+                  (click)="resolveTaskAssignments()"
+                  title="Resolve any outstanding tasks">
+            <i class="fas fa-spinner fa-spin" *ngIf=updatingTasks></i>
+            <i class="fas fa-user-check"></i> Resolve tasks
+          </button>
+
+          <button *ngIf="isSubmissionList() && isSalesforceUpdatable()" class="btn btn-sm btn-secondary me-2"
+                  (click)="createUpdateSalesforce()"
+                  title="Create or update selected candidate cases">
+            <i class="fas fa-spinner fa-spin" *ngIf=updating></i>
+            <i class="fas fa-user-check"></i> Update Case/s <i class="fa-solid fa-address-book"></i>
+          </button>
+
+          <button class="btn btn-sm btn-secondary me-2" *ngIf="!isSubmissionList() && isContentModifiable()"
+                  [disabled]="!isSelection()"
+                  (click)="removeSelectedCandidatesFromList()"
+                  title="Remove selected candidates from list">
+            <i class="fas fa-user-check"></i> Remove
+          </button>
+
+          <button class="btn btn-sm btn-secondary me-2" *ngIf="isSubmissionList() && isSalesforceUpdatable()"
+                  [disabled]="!isSelection()"
+                  (click)="closeSelectedOpportunities()"
+                  title="Close selected candidate cases. Not removed from list but hidden unless 'Show closed cases' checkbox is checked.">
+            <i class="fas fa-spinner fa-spin" *ngIf=closing></i>
+            <i class="fas fa-user-check"></i> Remove (Close)
+          </button>
+
+          <button class="btn btn-sm btn-secondary me-2" [disabled]="!isSelection()"
+                  (click)="clearSelection()"
+                  title="Clear selected candidates">
+            Clear <i class="fas fa-user-check"></i>
+          </button>
+
+          <button *ngIf="isSwapSelectionSupported()" class="btn btn-sm btn-secondary me-2"
+                  (click)="swapSelection()"
+                  title="Swap selected candidates. Selected becomes unselected and vice versa.">
+            <i class="fas fa-sync"></i><i class="fas fa-user-check"></i>
+          </button>
+
+        </div>
+      </div>
+
+      <!-- Second Group of Buttons (Shifted Right) -->
+      <div class="col d-flex justify-content-end">
+        <div class="d-flex flex-wrap buttons-spacing align-content-between">
+          <button  *ngIf="isImportable()" class="btn btn-sm btn-secondary me-2" (click)="importCandidates()"
+                   title="Import candidates">
+            <i class="fas fa-spinner fa-spin" *ngIf=importing></i>
+            Import <i class="fas fa-file-excel"></i>
+          </button>
+
+          <button *ngIf="!isSavedList() && isExportable()" class="btn btn-sm btn-secondary"
+                  (click)="exportCandidates()"
+                  title="Export candidates">
+            <i class="fas fa-spinner fa-spin" *ngIf=exporting></i>
+            Export <i class="fas fa-file-excel"></i>
+          </button>
+
+          <button *ngIf="isPublishable()" class="btn btn-sm btn-secondary me-2" (click)="modifyExportColumns()"
+                  title="Publish candidates to be shared externally - eg with employers">
+            <i class="fas fa-spinner fa-spin" *ngIf=publishing></i>
+            Publish <i class="fas fa-globe"></i>
+          </button>
+
+          <button  *ngIf= "hasPublishedDoc() && isContentModifiable()
+                      && salesforceService.joblink(candidateSource)"
+                   class="btn btn-sm btn-secondary me-2" (click)="importEmployerFeedback()"
+                   title="Import employer feedback from published list">
+            <i class="fas fa-spinner fa-spin" *ngIf=importingFeedback></i>
+            Feedback <i class="fas fa-globe"></i>
+          </button>
+
+        </div>
+      </div>
+
+      <!-- Third Group of Inputs (Right-aligned) -->
+      <div *ngIf="isSavedList()" class="col-auto d-flex justify-content-end">
+        <div *ngIf="isJobList()" class="form-check-reverse form-check-inline align-items-center me-2">
+          <input [title]="showClosedOppsTip" type="checkbox" formControlName="showClosedOpps" id="showClosedOpps" class="form-check-input">
+          <label class="form-check-label" [title]="showClosedOppsTip" for="showClosedOpps">Show closed cases</label>
+        </div>
+        <div *ngIf="isContentModifiable()" class="w-50 ms-3">
+          <input id="quickNumberOrNameSearch"
+                 type="text" class="form-control" #input
+                 [ngbTypeahead]="doNumberOrNameSearch"
+                 [resultTemplate]="rt"
+                 [inputFormatter]="renderCandidateRow"
+                 [editable]="false"
+                 (selectItem)="selectCandidateToAdd($event, input)"
+                 placeholder="Add (name or #)..."/>
+          <ng-template #rt let-r="result" let-t="term">
+            <ngb-highlight [result]="renderCandidateRow(r)" [term]="t"></ngb-highlight>
+          </ng-template>
+          <div *ngIf=adding class="small text-info text-center mt-1">Adding candidate to list <i class="fas fa-spinner fa-spin" ></i></div>
+        </div>
+        <div *ngIf="isSavedList()" class="w-50 ms-3">
+          <form [formGroup]="searchForm">
+            <div class="mb-3 mb-0 flex-fill">
+              <input type="text" class="form-control" placeholder="Search (name or #)..." aria-label="Search (name/number)..." formControlName="keyword"
+                     id="keyword" autofocus>
+            </div>
+          </form>
+        </div>
+      </div>
+
     </div>
 
 <!--    Table of list contents - plus candidate details of selected candidate-->

--- a/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.html
+++ b/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.html
@@ -21,13 +21,10 @@
 
   <ng-content></ng-content>
 
-  <nav aria-label="breadcrumb" [hidden]="!showBreadcrumb">
-    <ol class="breadcrumb">
-      <li class="breadcrumb-item"><a [routerLink]="['/']">Home</a></li>
-      <li class="breadcrumb-item active" aria-current="page">
+  <nav aria-label="breadcrumb" class="breadcrumb-container" [hidden]="!showBreadcrumb">
+    <h3 class="breadcrumb-heading">
         {{getBreadcrumb()}}
-      </li>
-    </ol>
+    </h3>
   </nav>
 
   <div class="alert alert-danger" *ngIf="error">

--- a/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.scss
+++ b/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.scss
@@ -158,3 +158,7 @@ $candidate-card-width: 40vw;
 ul#candidate-dropdown {
   cursor: pointer;
 }
+
+a i {
+  cursor: pointer;
+}

--- a/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.ts
+++ b/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.ts
@@ -738,7 +738,7 @@ export class ShowCandidatesComponent extends CandidateSourceBaseComponent implem
 
   getCandidateSourceBreadcrumb(candidateSource: CandidateSource): string {
     const sourceType = getCandidateSourceType(candidateSource);
-    let sourcePrefix = isSubmissionList(candidateSource) ? "Submission" : "Candidate";
+    let sourcePrefix = isSubmissionList(candidateSource) ? "Submission" : "";
     return candidateSource != null ?
       (sourcePrefix + ' ' + sourceType + ': ' + candidateSource.name) : sourceType;
   }

--- a/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.ts
+++ b/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.ts
@@ -764,6 +764,10 @@ export class ShowCandidatesComponent extends CandidateSourceBaseComponent implem
     return !isSavedSearch(this.candidateSource);
   }
 
+  isSavedSearch(): boolean {
+    return isSavedSearch(this.candidateSource);
+  }
+
   isSwapSelectionSupported(): boolean {
     //Not supported for saved searches because swapping an empty selection on a search could
     //potentially end up selecting huge numbers of candidates - up to the whole database.

--- a/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.ts
+++ b/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.ts
@@ -740,7 +740,7 @@ export class ShowCandidatesComponent extends CandidateSourceBaseComponent implem
     const sourceType = getCandidateSourceType(candidateSource);
     let sourcePrefix = isSubmissionList(candidateSource) ? "Submission" : "Candidate";
     return candidateSource != null ?
-      (sourcePrefix + ' ' + sourceType + ': ' + candidateSource.name + ' (' + candidateSource.id + ')') : sourceType;
+      (sourcePrefix + ' ' + sourceType + ': ' + candidateSource.name) : sourceType;
   }
 
   onReviewStatusFilterChange() {

--- a/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.ts
+++ b/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.ts
@@ -44,10 +44,9 @@ import {CandidateReviewStatusItem} from '../../../model/candidate-review-status-
 import {HttpClient} from '@angular/common/http';
 import {
   ClearSelectionRequest,
-  getCandidateSourceBreadcrumb,
   getCandidateSourceExternalHref,
   getCandidateSourceNavigation,
-  getCandidateSourceStatsNavigation,
+  getCandidateSourceStatsNavigation, getCandidateSourceType,
   getSavedSearchBreadcrumb,
   getSavedSourceNavigation,
   isSavedSearch,
@@ -76,7 +75,7 @@ import {
   ContentUpdateType,
   CopySourceContentsRequest,
   IHasSetOfCandidates,
-  isSavedList,
+  isSavedList, isSubmissionList,
   PublishedDocColumnConfig,
   PublishedDocImportReport,
   PublishListRequest,
@@ -731,9 +730,16 @@ export class ShowCandidatesComponent extends CandidateSourceBaseComponent implem
       const infos = this.savedSearchService.getSavedSearchTypeInfos();
       breadcrumb = getSavedSearchBreadcrumb(this.candidateSource, infos);
     } else {
-      breadcrumb = getCandidateSourceBreadcrumb(this.candidateSource);
+      breadcrumb = this.getCandidateSourceBreadcrumb(this.candidateSource);
     }
     return breadcrumb;
+  }
+
+  getCandidateSourceBreadcrumb(candidateSource: CandidateSource): string {
+    const sourceType = getCandidateSourceType(candidateSource);
+    let sourcePrefix = isSubmissionList(candidateSource) ? "Submission" : "Candidate";
+    return candidateSource != null ?
+      (sourcePrefix + ' ' + sourceType + ': ' + candidateSource.name + ' (' + candidateSource.id + ')') : sourceType;
   }
 
   onReviewStatusFilterChange() {

--- a/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.ts
+++ b/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.ts
@@ -154,6 +154,7 @@ export class ShowCandidatesComponent extends CandidateSourceBaseComponent implem
   updatingStatuses: boolean;
   updatingTasks: boolean;
   savingSelection: boolean;
+  showDescription: boolean = false;
   searchForm: FormGroup;
   monitoredTask: Task;
   tasksAssignedToList: Task[];

--- a/ui/admin-portal/src/app/components/candidates/view/view-candidate.component.html
+++ b/ui/admin-portal/src/app/components/candidates/view/view-candidate.component.html
@@ -74,7 +74,7 @@
           <a (click)="createTailoredCv()" class="link-info">
             <i class="fas fa-users-gear"  title="View tailored candidate's public CV"></i>
           </a>
-      </span>
+        </span>
       </h1>
 
 

--- a/ui/admin-portal/src/app/components/search/define-search/define-search.component.html
+++ b/ui/admin-portal/src/app/components/search/define-search/define-search.component.html
@@ -16,13 +16,10 @@
 
 <div [hidden]="loading" [class.split]="!!selectedCandidate">
 
-  <nav aria-label="breadcrumb">
-    <ol class="breadcrumb">
-      <li class="breadcrumb-item"><a [routerLink]="['/']">Home</a></li>
-      <li class="breadcrumb-item active" aria-current="page">
+  <nav aria-label="breadcrumb" class="breadcrumb-container">
+    <h3 class="breadcrumb-heading">
         {{getBreadcrumb()}}
-        </li>
-    </ol>
+    </h3>
   </nav>
 
   <div [hidden]="!showSearchRequest">
@@ -37,10 +34,10 @@
     <div>
       <div class="d-flex justify-content-between mb-4">
 
-        <h3 class="m-0">Candidate Search</h3>
-        <div class="d-flex">
+<!--        <h3 class="m-0">Candidate Search</h3>-->
+        <div class="d-flex mt-4">
           <div>
-            <button type="button" class="btn btn-warning me-2"
+            <button type="button" class="btn btn-warning"
                     [disabled]="loading"
                     (click)="clearForm()">Clear Search</button>
           </div>

--- a/ui/admin-portal/src/app/components/search/define-search/define-search.component.html
+++ b/ui/admin-portal/src/app/components/search/define-search/define-search.component.html
@@ -16,11 +16,11 @@
 
 <div [hidden]="loading" [class.split]="!!selectedCandidate">
 
-  <nav aria-label="breadcrumb" class="breadcrumb-container">
-    <h3 class="breadcrumb-heading">
-        {{getBreadcrumb()}}
-    </h3>
-  </nav>
+<!--  <nav aria-label="breadcrumb" class="breadcrumb-container">-->
+<!--    <h3 class="breadcrumb-heading">-->
+<!--        {{getBreadcrumb()}}-->
+<!--    </h3>-->
+<!--  </nav>-->
 
   <div [hidden]="!showSearchRequest">
     <div>

--- a/ui/admin-portal/src/app/components/util/candidate-source-description/candidate-source-description.component.html
+++ b/ui/admin-portal/src/app/components/util/candidate-source-description/candidate-source-description.component.html
@@ -11,7 +11,7 @@
 
     <textarea id="description" class="md-textarea-auto form-control" rows="2"
               [readOnly]="!isEditable()"
-              placeholder="Add notes ..."
+              placeholder="Describe the purpose of this {{ isSubmissionList() ? 'submission' : ''}} {{ isSavedList() ? 'list' : 'search'}}..."
               [formControlName]="'description'"></textarea>
   </div>
 

--- a/ui/admin-portal/src/app/components/util/candidate-source-description/candidate-source-description.component.ts
+++ b/ui/admin-portal/src/app/components/util/candidate-source-description/candidate-source-description.component.ts
@@ -6,6 +6,7 @@ import {CandidateSource, UpdateCandidateSourceDescriptionRequest} from "../../..
 import {CandidateService} from "../../../services/candidate.service";
 import {CandidateSourceService} from "../../../services/candidate-source.service";
 import {AuthorizationService} from "../../../services/authorization.service";
+import {isSavedList, isSubmissionList} from "../../../model/saved-list";
 
 @Component({
   selector: 'app-candidate-source-description',
@@ -56,4 +57,11 @@ export class CandidateSourceDescriptionComponent extends AutoSaveComponentBase
     this.candidateSource.description = this.description;
   }
 
+  isSavedList(): boolean {
+    return isSavedList(this.candidateSource);
+  }
+
+  isSubmissionList(): boolean {
+    return isSubmissionList(this.candidateSource);
+  }
 }

--- a/ui/admin-portal/src/app/model/saved-search.ts
+++ b/ui/admin-portal/src/app/model/saved-search.ts
@@ -111,13 +111,13 @@ export function isSavedSearch(source: CandidateSource): source is SavedSearch {
 export function getCandidateSourceBreadcrumb(candidateSource: CandidateSource): string {
   const sourceType = getCandidateSourceType(candidateSource);
   return candidateSource != null ?
-    (sourceType + ': ' + candidateSource.name + ' (' + candidateSource.id + ')') : sourceType;
+    ('Candidate ' + sourceType + ': ' + candidateSource.name + ' (' + candidateSource.id + ')') : sourceType;
 }
 
 export function getSavedSearchBreadcrumb(savedSearch: SavedSearch, infos: SavedSearchTypeInfo[]): string {
   let breadcrumb: string = "";
   if (savedSearch) {
-    breadcrumb += getCandidateSourceType(savedSearch) + ": ";
+    breadcrumb += 'Candidate ' + getCandidateSourceType(savedSearch) + ": ";
 
     if (savedSearch.defaultSearch) {
       breadcrumb += "Unsaved"

--- a/ui/admin-portal/src/app/model/saved-search.ts
+++ b/ui/admin-portal/src/app/model/saved-search.ts
@@ -111,7 +111,7 @@ export function isSavedSearch(source: CandidateSource): source is SavedSearch {
 export function getSavedSearchBreadcrumb(savedSearch: SavedSearch, infos: SavedSearchTypeInfo[]): string {
   let breadcrumb: string = "";
   if (savedSearch) {
-    breadcrumb += 'Candidate ' + getCandidateSourceType(savedSearch) + ": ";
+    breadcrumb += getCandidateSourceType(savedSearch) + ": ";
 
     if (savedSearch.defaultSearch) {
       breadcrumb += "Unsaved"

--- a/ui/admin-portal/src/app/model/saved-search.ts
+++ b/ui/admin-portal/src/app/model/saved-search.ts
@@ -129,7 +129,7 @@ export function getSavedSearchBreadcrumb(savedSearch: SavedSearch, infos: SavedS
         }
       }
 
-      breadcrumb += savedSearch.name + " (" + savedSearch.id + ")";
+      breadcrumb += savedSearch.name;
     }
   }
   return breadcrumb;

--- a/ui/admin-portal/src/app/model/saved-search.ts
+++ b/ui/admin-portal/src/app/model/saved-search.ts
@@ -108,12 +108,6 @@ export function isSavedSearch(source: CandidateSource): source is SavedSearch {
   return source ? 'savedSearchType' in source : false;
 }
 
-export function getCandidateSourceBreadcrumb(candidateSource: CandidateSource): string {
-  const sourceType = getCandidateSourceType(candidateSource);
-  return candidateSource != null ?
-    ('Candidate ' + sourceType + ': ' + candidateSource.name + ' (' + candidateSource.id + ')') : sourceType;
-}
-
 export function getSavedSearchBreadcrumb(savedSearch: SavedSearch, infos: SavedSearchTypeInfo[]): string {
   let breadcrumb: string = "";
   if (savedSearch) {


### PR DESCRIPTION
This PR:

- Removes breadcrumbs on search and list full views
- Use prominent titles instead with styling more consistent with candidates, cases and jobs
- Makes submission list titles distinct from regular lists
- Makes the source description collapsible
- Clusters the list / search action buttons
- Clusters list / search action icons with styling more consistent with candidates, cases and jobs
