### PR TITLE
fixes gradle build

### DIFF
--- a/performance-tests/build.gradle.kts
+++ b/performance-tests/build.gradle.kts
@@ -20,7 +20,7 @@ val postgresVersion: String = "42.6.0"
 val gatlingVersion: String = "0.10.3"
 val highchartsVersion: String = "3.9.5"
 val javaTargetVersion = JavaVersion.VERSION_17
-val scalaCompileOpts: String = "-release:21"
+val scalaCompileOpts: String = "-release:17"
 val testName: String = "gatlingTest"
 
 plugins {


### PR DESCRIPTION
This PR:

- Fixes the Gradle build - java 21 compile options were not reverted to java 17 in scala compile options