### PR TITLE
Stats display of different candidate statuses should show draft statuses - which are normally ignored except in registration stats 

### DIFF
--- a/ui/admin-portal/src/app/components/infographics/infographic.component.html
+++ b/ui/admin-portal/src/app/components/infographics/infographic.component.html
@@ -73,12 +73,12 @@
     <div class="row my-4">
       <div class="col">
         <button class="btn btn-success float-end" (click)="submitStatsRequest(true)">
-          <i class="fas fa-calendar-alt"></i> Run stats
+          <i class="fas fa-calendar-alt"></i> Old Run stats
         </button>
       </div>
       <div class="col">
         <button class="btn btn-success float-end" (click)="submitStatsRequest(false)">
-          <i class="fas fa-calendar-alt"></i> New Run stats
+          <i class="fas fa-calendar-alt"></i> Run stats
         </button>
       </div>
     </div>

--- a/ui/admin-portal/src/app/components/infographics/infographic.component.spec.ts
+++ b/ui/admin-portal/src/app/components/infographics/infographic.component.spec.ts
@@ -31,6 +31,7 @@ import {MockSavedList} from "../../MockData/MockSavedList";
 import {MockSavedSearch} from "../../MockData/MockSavedSearch";
 import {StatReport} from "../../model/stat-report";
 import {ChartType} from "chart.js"
+
 describe('InfographicComponent', () => {
   let component: InfographicComponent;
   let fixture: ComponentFixture<InfographicComponent>;
@@ -141,7 +142,7 @@ describe('InfographicComponent', () => {
     mockCandidateStatService.getAllStats.and.returnValue(of(mockStatReports));
 
     // Call the method
-    component.submitStatsRequest(true);
+    component.submitStatsRequest(false);
 
     // Simulate asynchronous observables
     tick();
@@ -164,7 +165,7 @@ describe('InfographicComponent', () => {
     mockCandidateStatService.getAllStats.and.returnValue(throwError(mockError));
 
     // Call the method
-    component.submitStatsRequest(true);
+    component.submitStatsRequest(false);
 
     // Simulate asynchronous observables
     tick();

--- a/ui/admin-portal/src/app/components/infographics/infographic.component.ts
+++ b/ui/admin-portal/src/app/components/infographics/infographic.component.ts
@@ -120,7 +120,7 @@ export class InfographicComponent implements OnInit {
           this.savedSearchService.get(id).subscribe(
             (savedSearch) => {
               this.statsFilter.controls['savedSearch'].patchValue(savedSearch);
-              this.submitStatsRequest(true);
+              this.submitStatsRequest(false);
             }, error => {
               this.error = error;
             });
@@ -129,7 +129,7 @@ export class InfographicComponent implements OnInit {
           this.savedListService.get(id).subscribe(
             (savedList) => {
               this.statsFilter.controls['savedList'].patchValue(savedList);
-              this.submitStatsRequest(true);
+              this.submitStatsRequest(false);
             }, error => {
               this.error = error;
           });


### PR DESCRIPTION
Also change to run new stats by default.