### PR TITLE
do not copy job id from job associated with source

### DIFF
--- a/server/src/main/java/org/tctalent/server/service/db/impl/CandidateSavedListServiceImpl.java
+++ b/server/src/main/java/org/tctalent/server/service/db/impl/CandidateSavedListServiceImpl.java
@@ -157,12 +157,6 @@ public class CandidateSavedListServiceImpl implements CandidateSavedListService 
                 .orElseThrow(() -> new NoSuchObjectException(SavedList.class, targetId));
         }
 
-        //Set any specified Job Opportunity
-        final Long jobId = request.getJobId();
-        if (jobId != null) {
-            targetList.setSfJobOpp(salesforceJobOppService.getJobOpp(jobId));
-        }
-
         boolean replace = request.getUpdateType() == ContentUpdateType.replace;
         //New or replaced list inherits source's savedSearchSource, if any
         if (newList || replace) {


### PR DESCRIPTION
This PR:

- Fixes a bug where the job_id was unintentionally copied to a list when candidate selections were made from job-associated searches.
- Has already been deployed as a hotfix to production
