### PR TITLE
remove transactional annotations on sf sync

### DIFF
--- a/server/src/main/java/org/tctalent/server/service/db/impl/CandidateServiceImpl.java
+++ b/server/src/main/java/org/tctalent/server/service/db/impl/CandidateServiceImpl.java
@@ -2933,7 +2933,6 @@ public class CandidateServiceImpl implements CandidateService {
         }
     }
 
-    @Transactional
     @Scheduled(cron = "0 0 18 * * SUN", zone = "GMT")
     @SchedulerLock(name = "CandidateService_syncLiveCandidatesToSf", lockAtLeastFor = "PT23H",
         lockAtMostFor = "PT23H")
@@ -2945,7 +2944,6 @@ public class CandidateServiceImpl implements CandidateService {
         }
     }
 
-    @Transactional
     @Scheduled(cron = "0 0 18 * * SAT", zone = "GMT")
     @SchedulerLock(name = "CandidateService_syncLiveCandidatesToSf", lockAtLeastFor = "PT23H",
         lockAtMostFor = "PT23H")


### PR DESCRIPTION
This PR:

- removes the transactional annotation on SF sync methods

It should be removed as it may override the attempt to clear() the persistence context and, therefore, blow the heap despite the attempted clear().