### PR TITLE
flush entity manager before clearing persistence context

### DIFF
--- a/server/src/main/java/org/tctalent/server/service/db/impl/CandidateServiceImpl.java
+++ b/server/src/main/java/org/tctalent/server/service/db/impl/CandidateServiceImpl.java
@@ -3125,6 +3125,7 @@ public class CandidateServiceImpl implements CandidateService {
             candidatePage = getSavedListCandidates(savedList, request);
             List<Candidate> candidates = candidatePage.getContent();
             processCandidateReassignment(candidates, newPartner);
+            entityManager.flush(); // Flush changes to DB before clearing in-memory persistence context
             entityManager.clear(); // Keeps candidates from piling up in persistence context
             pagesProcessed++;
         }


### PR DESCRIPTION
This PR:

- flushes the persistence context to sync changes with the DB before the persistence context is cleared

This update is isolated to the sys admin API for reassigning partners on lists (resolving a reported bug). However, it should be considered wherever the persistence context is cleared with entityManager.clear().

The changes in this PR should be cherry-picked into production.