### PR TITLE
fix: match linkedin regex

### DIFF
--- a/server/src/main/java/org/tctalent/server/service/db/impl/CandidateServiceImpl.java
+++ b/server/src/main/java/org/tctalent/server/service/db/impl/CandidateServiceImpl.java
@@ -1335,7 +1335,7 @@ public class CandidateServiceImpl implements CandidateService {
                 .orElseThrow(() -> new InvalidSessionException("Not logged in"));
         candidate.setAdditionalInfo(request.getAdditionalInfo());
         if (request.getLinkedInLink() != null && !request.getLinkedInLink().isEmpty()) {
-            String linkedInRegex = "^http[s]?:/\\/www\\.linkedin\\.com\\/in\\/[A-z0-9_-]+\\/?$";
+            String linkedInRegex = "^http[s]?:/\\/(www\\.)?linkedin\\.com\\/in\\/[A-z0-9_-]+\\/?$";
             Pattern p = Pattern.compile(linkedInRegex);
             Matcher m = p.matcher(request.getLinkedInLink());
             if (m.find()) {

--- a/ui/admin-portal/src/app/components/candidates/view/special-links/edit/edit-candidate-special-links.component.ts
+++ b/ui/admin-portal/src/app/components/candidates/view/special-links/edit/edit-candidate-special-links.component.ts
@@ -16,7 +16,7 @@
 
 import {Component, OnInit} from '@angular/core';
 import {Candidate} from "../../../../../model/candidate";
-import {FormBuilder, FormGroup} from "@angular/forms";
+import {FormBuilder, FormGroup, Validators} from "@angular/forms";
 import {NgbActiveModal} from "@ng-bootstrap/ng-bootstrap";
 import {CandidateService} from "../../../../../services/candidate.service";
 import {EnvService} from "../../../../../services/env.service";
@@ -43,6 +43,7 @@ export class EditCandidateSpecialLinksComponent implements OnInit {
               private envService: EnvService) { }
 
   ngOnInit() {
+    const linkedInRegex = /^http(s)?:\/\/([\w]+\.)?linkedin\.com\/in\/[A-z0-9_-]+\/?/
     this.loading = true;
 
     this.candidateService.get(this.candidateId).subscribe(candidate => {
@@ -50,7 +51,7 @@ export class EditCandidateSpecialLinksComponent implements OnInit {
         sflink: [candidate.sflink],
         folderlink: [candidate.folderlink],
         videolink: [candidate.videolink],
-        linkedInLink: [candidate.linkedInLink],
+        linkedInLink: [candidate.linkedInLink, Validators.pattern(linkedInRegex)],
       });
       this.loading = false;
     });

--- a/ui/candidate-portal/src/app/components/register/additional-info/registration-additional-info.component.ts
+++ b/ui/candidate-portal/src/app/components/register/additional-info/registration-additional-info.component.ts
@@ -56,7 +56,7 @@ export class RegistrationAdditionalInfoComponent implements OnInit {
   }
 
   ngOnInit() {
-    const linkedInRegex = /http(s)?:\/\/([\w]+\.)?linkedin\.com\/in\/[A-z0-9_-]+\/?/
+    const linkedInRegex = /^http(s)?:\/\/([\w]+\.)?linkedin\.com\/in\/[A-z0-9_-]+\/?/
     this.saving = false;
     this.form = this.fb.group({
       additionalInfo: [''],


### PR DESCRIPTION
This PR updates the regular expression to correctly match LinkedIn URLs.

Server-side update: Previously, the server did not accept LinkedIn URLs without the "[www](http://www/)." prefix. Since URLs without "[www](http://www/)." still navigate correctly, I modified the server to make "[www](http://www/)." optional in the URL validation.

Client-side update: I enforced the use of "http" or "https" for LinkedIn URLs on the client side to ensure proper formatting and avoid potential security issues. Additionally, I added this validation check to the admin portal’s edit component to maintain consistency.

These changes ensure that LinkedIn URLs are handled correctly, whether they include "[www](http://www/)." or not, across both the client and server.