### PR TITLE
Fixed erroneous help text and added a bit of space to right of labels

### DIFF
--- a/ui/admin-portal/src/app/components/job/view/tab/job-intake-tab/job-intake-tab.component.html
+++ b/ui/admin-portal/src/app/components/job/view/tab/job-intake-tab/job-intake-tab.component.html
@@ -79,7 +79,7 @@
               <div class="form-text">You update this in the Job Summary - see top of page</div>
             </span>
             <ng-template #noJd>
-              <span>Please upload or provide link under Job Description tab</span>
+              <span>Please upload or provide link under Job Uploads tab</span>
             </ng-template>
           </div>
         </div>

--- a/ui/admin-portal/src/app/components/job/view/tab/job-intake-tab/job-intake-tab.component.scss
+++ b/ui/admin-portal/src/app/components/job/view/tab/job-intake-tab/job-intake-tab.component.scss
@@ -7,3 +7,7 @@
 p, span {
   font-weight: 300;
 }
+
+label {
+  margin-right: 3px;
+}


### PR DESCRIPTION
<img width="563" alt="Screenshot 2024-11-05 at 10 31 42 AM" src="https://github.com/user-attachments/assets/d426bf08-96ce-4531-acfc-783925b9e484">


👇


<img width="534" alt="Screenshot 2024-11-05 at 10 30 45 AM" src="https://github.com/user-attachments/assets/4534c2fc-b23a-4223-b924-33a400520af8">
