### PR TITLE
Removed 'Opportunity' from hardcoded text

### DIFF
--- a/ui/admin-portal/src/app/components/opportunity/edit-opp/edit-opp.component.html
+++ b/ui/admin-portal/src/app/components/opportunity/edit-opp/edit-opp.component.html
@@ -1,6 +1,6 @@
 <div class="modal-header">
 
-  <h4 class="modal-title">Update {{oppType}} Opportunity Progress</h4>
+  <h4 class="modal-title">Update {{oppType}} Progress</h4>
 
   <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close" (click)="cancel()"></button>
 


### PR DESCRIPTION
See issue for screens

Now instead of 'Job Opportunity Progress' and 'Candidate Opportunity Opportunity Progress'

we get 'Job Progress' and 'Candidate Opportunity Progress'