### PR TITLE
Amended `isViewingAsSource()` check to allow for non-job creator user belonging to employer

### DIFF
--- a/ui/admin-portal/src/app/components/job/view/source-contacts/view-job-source-contacts/view-job-source-contacts.component.html
+++ b/ui/admin-portal/src/app/components/job/view/source-contacts/view-job-source-contacts/view-job-source-contacts.component.html
@@ -32,7 +32,9 @@
 
     <tbody>
     <tr *ngFor="let partner of sourcePartners" (click)="selectCurrent(partner)"
-        [ngClass]="{'current': currentSourcePartner?.id == partner.id && selectable}">
+        [ngClass]=
+          "{'current': currentSourcePartner?.id == partner.id && selectable, 'clickable': selectable}"
+    >
       <td>
         <div class="btn-group" *ngIf="isEditable(partner)">
           <button type="button" class="btn btn-default" (click)="editPartnerContact(partner)"><i

--- a/ui/admin-portal/src/app/services/authorization.service.ts
+++ b/ui/admin-portal/src/app/services/authorization.service.ts
@@ -362,12 +362,18 @@ export class AuthorizationService {
   /**
    * Return true if currently logged-in user is viewing the TC as a source person.
    * <p/>
+   * <p>
    * This is more complicated that just asking whether the user works for a source partner because
    * of TBB special status where it is both a source partner and a destination partner.
+   * </p>
+   * <p>
+   * With the third condition check we also allow for a user who is not themselves designated a job
+   * creator, but who works for an employer partner. Otherwise, they would be designated source by
+   * this check.
    */
   isViewingAsSource(): boolean {
-    //View as source partner as long as user is not a job creator.
-    return this.isSourcePartner() && !this.isJobCreatorUser();
+    //View as source partner as long as user is not a job creator or belonging to an employer org.
+    return this.isSourcePartner() && !this.isJobCreatorUser() && !this.isEmployerPartner();
   }
 
   /**

--- a/ui/admin-portal/src/styles.scss
+++ b/ui/admin-portal/src/styles.scss
@@ -234,3 +234,7 @@ ngx-wig {
 .sortable-column-header:hover {
   cursor: pointer;
 }
+
+tr.clickable:hover {
+  cursor: pointer;
+}


### PR DESCRIPTION
...also added hover-over behaviour for clickable rows.

See issue notes for detailed rationale