### PR TITLE
Candidate Education Tab - DetExam Year and Notes Fields Showing N/A in Exams Section

### DIFF
--- a/server/src/main/java/org/tctalent/server/api/admin/CandidateBuilderSelector.java
+++ b/server/src/main/java/org/tctalent/server/api/admin/CandidateBuilderSelector.java
@@ -390,6 +390,8 @@ public class CandidateBuilderSelector {
                 .add("id")
                 .add("exam")
                 .add("score")
+                .add("year")
+                .add("notes")
                 ;
     }
 


### PR DESCRIPTION
It looks like the issue was due to missing fields (year and notes) in the CandidateBuilderSelector examsDto() method for DtoType.EXTENDED. After adding these fields, the problem was resolved.