### PR TITLE
Fix: sf populate next step fields

### DIFF
--- a/server/src/main/java/org/tctalent/server/service/db/impl/CandidateOpportunityServiceImpl.java
+++ b/server/src/main/java/org/tctalent/server/service/db/impl/CandidateOpportunityServiceImpl.java
@@ -205,9 +205,18 @@ public class CandidateOpportunityServiceImpl implements CandidateOpportunityServ
                 sfJobOpp = salesforceJobOppService.updateJob(sfJobOpp);
             }
 
+            CandidateOpportunityParams oppParams =
+                candidateOppParams != null ? candidateOppParams : new CandidateOpportunityParams();
+            if (candidateOppParams == null) {
+                oppParams.setStage(CandidateOpportunityStage.prospect);
+                oppParams.setNextStep("Contact candidate and do intake");
+                oppParams.setNextStepDueDate(LocalDate.now().plusWeeks(2));
+            }
+
             //Create/update opportunities on Salesforce first
             salesforceService.createOrUpdateCandidateOpportunities(
-                orderedCandidates, candidateOppParams, sfJobOpp);
+                orderedCandidates, oppParams, sfJobOpp);
+
             //Then update opps on local DB. SF opps already created, which will allow us to
             //add sfId to created opps on the local db.
             createOrUpdateCandidateOpportunities(


### PR DESCRIPTION
The `candidateOppParams` parameter is being passed as null from the `addCandidateToList` function. To address this, I added a check to initialize it if it’s null. This ensures that Salesforce creation happens before adding objects to the database.

There’s another default initialization that performs a similar check in the `createOrUpdateCandidateOpportunity` function. However, I’m unsure if this logic is ever triggered because of the following line:
```java
CandidateOpportunity opp = findOpp(candidate, jobOpp);
```
This line usually returns a value, so the if check for initialization is never reached. That said, it might still be triggered by other workflows.

I didn’t refactor the initialization logic into a separate function because:

1. `createOrUpdateCandidateOpportunity` requires a `CandidateOpportunity` object.

1. `createUpdateCandidateOpportunities` requires a `CandidateOpportunityParams` object.

The differing parameter types make it impractical to consolidate the initialization into a single function.