### PR TITLE
Fix: remove roles from seeing candidate name info

### DIFF
--- a/ui/admin-portal/src/app/services/authorization.service.ts
+++ b/ui/admin-portal/src/app/services/authorization.service.ts
@@ -100,8 +100,6 @@ export class AuthorizationService {
     if (this.isSourcePartner() || this.isJobCreatorPartner()) {
       switch (this.getLoggedInRole()) {
         case Role.systemadmin:
-        case Role.admin:
-        case Role.partneradmin:
           result = true;
       }
     }


### PR DESCRIPTION
Since the admin and partner admin roles don't get candidate names from the API I also removed them from the front-end. 