### PR TITLE
843 add GA4 tag to Admin portal

### DIFF
--- a/ui/admin-portal/src/app/components/app.component.ts
+++ b/ui/admin-portal/src/app/components/app.component.ts
@@ -48,6 +48,8 @@ export class AppComponent implements OnInit {
   }
 
   ngOnInit(): void {
+    this.trackPageViews();
+
     this.authenticationService.loggedInUser$.subscribe(
       (user) => {
         this.onChangedLogin(user);
@@ -120,4 +122,35 @@ export class AppComponent implements OnInit {
       }
     );
   }
+
+
+  /**
+   * Tracks page views in a Single Page Application (SPA) context using Google Analytics.
+   *
+   * In traditional websites, navigation between pages naturally triggers a page load,
+   * which Google Analytics uses to track page views. However, in SPAs like those built with Angular,
+   * navigation changes the content dynamically without reloading the entire page. This function
+   * subscribes to Angular Router events to detect when navigation ends and a new "page" is viewed,
+   * manually sending page view information to Google Analytics.
+   *
+   * The `NavigationEnd` event indicates a successful route change, at which point we use the
+   * `gtag` function with the 'config' command to send the current page path to Google Analytics.
+   *
+   * Additionally, console logs are included for testing purposes.
+   *
+   * See, for example, https://blog.mestwin.net/add-google-analytics-to-angular-application-in-3-easy-steps
+   */
+  private trackPageViews() {
+    this.router.events.subscribe(event => {
+      if (event instanceof NavigationEnd) {
+        gtag('config', environment.googleAnalyticsId, {
+          'page_path': event.urlAfterRedirects
+        });
+        // console.log('Sending Google Analytics tracking for: ', event.urlAfterRedirects);
+        // console.log('Google Analytics property ID: ', environment.googleAnalyticsId);
+      }
+    });
+  }
 }
+}
+declare let gtag: Function;

--- a/ui/admin-portal/src/app/components/app.component.ts
+++ b/ui/admin-portal/src/app/components/app.component.ts
@@ -23,6 +23,7 @@ import {User} from "../model/user";
 import {Subscription} from "rxjs";
 import {ChatService} from "../services/chat.service";
 import { UserService} from "../services/user.service";
+import {environment} from "../../environments/environment";
 
 @Component({
   selector: 'app-root',
@@ -152,5 +153,5 @@ export class AppComponent implements OnInit {
     });
   }
 }
-}
+
 declare let gtag: Function;

--- a/ui/admin-portal/src/environments/environment.prod.ts
+++ b/ui/admin-portal/src/environments/environment.prod.ts
@@ -30,5 +30,6 @@ export const environment = {
   s3BucketUrl: 'https://s3.us-east-1.amazonaws.com/files.tbbtalent.org',
   assetBaseUrl: '/admin-portal',
   environmentName: 'prod',
-  presetWorkspaceId: '987e2e02'
+  presetWorkspaceId: '987e2e02',
+  googleAnalyticsId: 'G-BPDYWB77Y3'
 };

--- a/ui/admin-portal/src/environments/environment.ts
+++ b/ui/admin-portal/src/environments/environment.ts
@@ -28,7 +28,8 @@ export const environment = {
   s3BucketUrl: 'https://s3.us-east-1.amazonaws.com/dev.files.tbbtalent.org',
   assetBaseUrl: '',
   environmentName: 'local',
-  presetWorkspaceId: '987e2e02'
+  presetWorkspaceId: '987e2e02',
+  googleAnalyticsId: 'G-K9ML1Y40B4' // for testing
 };
 
 /*

--- a/ui/admin-portal/src/index.html
+++ b/ui/admin-portal/src/index.html
@@ -17,7 +17,7 @@
 <!doctype html>
 <html lang="en">
 <head>
-  <!-- Global site tag (gtag.js) - Google Analytics -->
+  <!-- Global site tag (gtag.js) - Google Universal Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=UA-163314566-2"></script>
   <script>
     window.dataLayer = window.dataLayer || [];
@@ -25,6 +25,14 @@
     gtag('js', new Date());
 
     gtag('config', 'UA-163314566-2');
+  </script>
+
+  <!-- Google tag (gtag.js) - GA4 -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-BPDYWB77Y3"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
   </script>
 
   <meta charset="utf-8">

--- a/ui/candidate-portal/src/app/components/app.component.ts
+++ b/ui/candidate-portal/src/app/components/app.component.ts
@@ -106,6 +106,7 @@ export class AppComponent implements OnInit {
    *
    * See, for example, https://blog.mestwin.net/add-google-analytics-to-angular-application-in-3-easy-steps
    */
+  
   trackPageViews() {
     this.router.events.subscribe(event => {
       if (event instanceof NavigationEnd) {


### PR DESCRIPTION
This PR adds the new GA4 tag for Google Analytics to Admin Portal. It is related to this issue #843, and I tried to follow the same steps as #767. 
