### PR TITLE
2016 candidate portal support for changing password

### DIFF
--- a/server/src/main/java/org/tctalent/server/api/portal/CandidatePortalApi.java
+++ b/server/src/main/java/org/tctalent/server/api/portal/CandidatePortalApi.java
@@ -217,6 +217,7 @@ public class CandidatePortalApi {
         return new DtoBuilder()
                 .add("candidateNumber")
                 .add("publicId")
+                .add("changePassword")
                 ;
     }
 

--- a/server/src/main/java/org/tctalent/server/model/db/Candidate.java
+++ b/server/src/main/java/org/tctalent/server/model/db/Candidate.java
@@ -109,6 +109,16 @@ public class Candidate extends AbstractAuditableDomainObject<Long> implements Ha
     private boolean muted;
 
     /**
+     * Indicates whether the user's password requires update.
+     * If true, the candidate will be required to change their password upon their next login.
+     * This is particularly useful for candidates who are automatically registered by a third party
+     * and assigned a temporary password. When the candidate logs in for the first time, they will
+     * be prompted to change their password.
+     */
+    @Column(name = "change_password" , nullable = false)
+    private boolean changePassword;
+
+    /**
      * Candidate's internal id reference with the source partner handling their case.
      * This is the reference used to identify the candidate on the source partner's internal systems.
      * <p/>
@@ -1192,6 +1202,14 @@ public class Candidate extends AbstractAuditableDomainObject<Long> implements Ha
 
     public void setMuted(boolean muted) {
         this.muted = muted;
+    }
+
+    public boolean isChangePassword() {
+        return changePassword;
+    }
+
+    public void setChangePassword(boolean changePassword) {
+        this.changePassword = changePassword;
     }
 
     public SurveyType getSurveyType() { return surveyType; }

--- a/server/src/main/java/org/tctalent/server/service/db/impl/UserServiceImpl.java
+++ b/server/src/main/java/org/tctalent/server/service/db/impl/UserServiceImpl.java
@@ -617,11 +617,12 @@ public class UserServiceImpl implements UserService {
         userRepository.save(user);
 
         /* Update changePassword */
-        if (user.getCandidate().isChangePassword()) {
+        if (user.getCandidate() != null && user.getCandidate().isChangePassword()) {
             Candidate candidate = candidateRepository.findById(user.getCandidate().getId())
                 .orElseThrow(
                     () -> new NoSuchObjectException(Candidate.class, user.getCandidate().getId()));
             candidate.setChangePassword(false);
+            candidateRepository.save(candidate);
         }
     }
 

--- a/server/src/main/java/org/tctalent/server/service/db/impl/UserServiceImpl.java
+++ b/server/src/main/java/org/tctalent/server/service/db/impl/UserServiceImpl.java
@@ -63,6 +63,7 @@ import org.tctalent.server.exception.ServiceException;
 import org.tctalent.server.exception.UserDeactivatedException;
 import org.tctalent.server.exception.UsernameTakenException;
 import org.tctalent.server.logging.LogBuilder;
+import org.tctalent.server.model.db.Candidate;
 import org.tctalent.server.model.db.Country;
 import org.tctalent.server.model.db.PartnerImpl;
 import org.tctalent.server.model.db.Role;
@@ -71,6 +72,7 @@ import org.tctalent.server.model.db.User;
 import org.tctalent.server.model.db.partner.Partner;
 import org.tctalent.server.repository.db.CountryRepository;
 import org.tctalent.server.repository.db.UserRepository;
+import org.tctalent.server.repository.db.CandidateRepository;
 import org.tctalent.server.repository.db.UserSpecification;
 import org.tctalent.server.request.LoginRequest;
 import org.tctalent.server.request.user.CheckPasswordResetTokenRequest;
@@ -96,6 +98,7 @@ import org.tctalent.server.exception.ExpiredEmailTokenException;
 @Slf4j
 public class UserServiceImpl implements UserService {
     private final UserRepository userRepository;
+    private final CandidateRepository candidateRepository;
     private final CountryRepository countryRepository;
     private final PasswordHelper passwordHelper;
     private final AuthenticationManager authenticationManager;
@@ -123,6 +126,7 @@ public class UserServiceImpl implements UserService {
 
     @Autowired
     public UserServiceImpl(UserRepository userRepository,
+        CandidateRepository candidateRepository,
         CountryRepository countryRepository,
         PasswordHelper passwordHelper,
         AuthenticationManager authenticationManager,
@@ -130,6 +134,7 @@ public class UserServiceImpl implements UserService {
         AuthService authService,
         EmailHelper emailHelper, PartnerService partnerService) {
         this.userRepository = userRepository;
+        this.candidateRepository = candidateRepository;
         this.countryRepository = countryRepository;
         this.passwordHelper = passwordHelper;
         this.authenticationManager = authenticationManager;
@@ -610,6 +615,14 @@ public class UserServiceImpl implements UserService {
         String passwordEnc = passwordHelper.validateAndEncodePassword(request.getPassword());
         user.setPasswordEnc(passwordEnc);
         userRepository.save(user);
+
+        /* Update changePassword */
+        if (user.getCandidate().isChangePassword()) {
+            Candidate candidate = candidateRepository.findById(user.getCandidate().getId())
+                .orElseThrow(
+                    () -> new NoSuchObjectException(Candidate.class, user.getCandidate().getId()));
+            candidate.setChangePassword(false);
+        }
     }
 
     /**

--- a/server/src/main/resources/db/migration/V1_352__add_change_password_field_to_candidate.sql
+++ b/server/src/main/resources/db/migration/V1_352__add_change_password_field_to_candidate.sql
@@ -1,17 +1,1 @@
-/*
- * Copyright (c) 2025 Talent Catalog.
- *
- * This program is free software: you can redistribute it and/or modify it under
- * the terms of the GNU Affero General Public License as published by the Free
- * Software Foundation, either version 3 of the License, or any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
- * for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program. If not, see https://www.gnu.org/licenses/.
- */
-
 alter table candidate add change_password boolean default false;

--- a/server/src/main/resources/db/migration/V1_352__add_change_password_field_to_candidate.sql
+++ b/server/src/main/resources/db/migration/V1_352__add_change_password_field_to_candidate.sql
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2025 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+alter table candidate add change_password boolean default false;

--- a/ui/candidate-portal/src/app/components/account/change-password/change-password.component.html
+++ b/ui/candidate-portal/src/app/components/account/change-password/change-password.component.html
@@ -14,7 +14,7 @@
   ~ along with this program. If not, see https://www.gnu.org/licenses/.
   -->
 
-<div class="container">
+<div class="container p-5">
 
   <h1>{{ 'CHANGEPASSWORD.TITLE' | translate }}</h1>
 

--- a/ui/candidate-portal/src/app/components/account/login/login.component.ts
+++ b/ui/candidate-portal/src/app/components/account/login/login.component.ts
@@ -21,6 +21,8 @@ import {ActivatedRoute, Router} from "@angular/router";
 import {CandidateService} from "../../../services/candidate.service";
 import {AuthenticationService} from "../../../services/authentication.service";
 import {LoginRequest} from "../../../model/base";
+import {ChangePasswordComponent} from '../change-password/change-password.component';
+import {NgbModal} from '@ng-bootstrap/ng-bootstrap';
 
 @Component({
   selector: 'app-login',
@@ -39,7 +41,8 @@ export class LoginComponent implements OnInit {
               private authenticationService: AuthenticationService,
               private candidateService: CandidateService,
               private route: ActivatedRoute,
-              private router: Router) {
+              private router: Router,
+              private modalService: NgbModal) {
   }
 
   ngOnInit() {
@@ -84,6 +87,11 @@ export class LoginComponent implements OnInit {
         // Get candidate number to save in storage to display in the header
         this.candidateService.getCandidateNumber().subscribe(
           (candidate) => {
+            if (candidate.changePassword  === true) {
+              const  changePasswordModal = this.modalService.open(ChangePasswordComponent, {
+                centered: true
+              });
+            }
             this.candidateService.setCandNumberStorage(candidate.candidateNumber);
           }
         )

--- a/ui/candidate-portal/src/app/components/profile/view/tab/profile/candidate-profile.component.html
+++ b/ui/candidate-portal/src/app/components/profile/view/tab/profile/candidate-profile.component.html
@@ -64,6 +64,9 @@
         </div>
         <div class="row">
           <div class="col-md-6">
+            <button class="btn  btn-outline-primary" (click)="openChangePasswordModal()">Edit Password</button>
+          </div>
+          <div class="col-md-6">
               <h6>{{ 'PROFILE.CONTACT.WHATSAPP' | translate }}</h6>
               <p>
                 {{candidate?.whatsapp || ''}}

--- a/ui/candidate-portal/src/app/components/profile/view/tab/profile/candidate-profile.component.ts
+++ b/ui/candidate-portal/src/app/components/profile/view/tab/profile/candidate-profile.component.ts
@@ -32,6 +32,8 @@ import {LanguageLevelService} from "../../../../../services/language-level.servi
 import {LanguageLevel} from "../../../../../model/language-level";
 import {SurveyTypeService} from "../../../../../services/survey-type.service";
 import {isOppStageGreaterThanOrEqualTo} from "../../../../../model/candidate-opportunity";
+import {NgbModal} from '@ng-bootstrap/ng-bootstrap';
+import {ChangePasswordComponent} from '../../../../account/change-password/change-password.component';
 
 @Component({
   selector: 'app-candidate-profile',
@@ -70,7 +72,8 @@ export class CandidateProfileComponent implements OnInit {
               private languageService: LanguageService,
               private languageLevelService: LanguageLevelService,
               private surveyTypeService: SurveyTypeService,
-              private route: ActivatedRoute) { }
+              private route: ActivatedRoute,
+              private modalService: NgbModal) { }
 
   ngOnInit() {
     const lang = this.route.snapshot.queryParams['lang'];
@@ -197,4 +200,9 @@ export class CandidateProfileComponent implements OnInit {
     return showRelocated;
   }
 
+  openChangePasswordModal() {
+    const  changePasswordModal = this.modalService.open(ChangePasswordComponent, {
+      centered: true
+    });
+  }
 }

--- a/ui/candidate-portal/src/app/model/candidate.ts
+++ b/ui/candidate-portal/src/app/model/candidate.ts
@@ -90,6 +90,7 @@ export interface Candidate extends HasId {
   listShareableCv: CandidateAttachment;
   listShareableDoc: CandidateAttachment;
   muted: boolean;
+  changePassword: boolean;
   shareableNotes: string;
   surveyType: SurveyType;
   surveyComment: string;


### PR DESCRIPTION
This PR adds support for the changePassword flag on the Candidate model and implements related updates on both the server and frontend sides.

Server-side:
- Adds a changePassword boolean flag to the Candidate entity.
- Updates the password reset flow to set changePassword to false after the candidate successfully resets their password.

Frontend:
- When a candidate logs in and the changePassword flag is true, a modal prompts them to change their password.
- Adds an "Edit Password" button on the profile edit page, allowing users to update their password manually.

I used the same component we already have for ChangePasswordComponent. 