### PR TITLE
Update job refactor and test

### DIFF
--- a/server/src/main/java/org/tctalent/server/service/db/NextStepProcessingService.java
+++ b/server/src/main/java/org/tctalent/server/service/db/NextStepProcessingService.java
@@ -29,7 +29,8 @@ import org.tctalent.server.model.db.AbstractOpportunity;
 public interface NextStepProcessingService {
 
     /**
-     * If requested Next Step differs from current, provides an audit stamped version.
+     * If requested Next Step differs from current, returns an audit stamped version. Otherwise,
+     * will return unchanged current Next Step.
      * @param opp the Opp whose Next Step may be updated
      * @param requestedNextStep the user-entered value, prior to audit stamp
      * @return processed Next Step String

--- a/server/src/main/java/org/tctalent/server/service/db/impl/JobServiceImpl.java
+++ b/server/src/main/java/org/tctalent/server/service/db/impl/JobServiceImpl.java
@@ -288,7 +288,7 @@ public class JobServiceImpl implements JobService {
                     "No such Salesforce opportunity: " + sfJoblink);
             }
 
-            updateJobFromRequest(job, request);
+            updateTcJobFromRequest(job, request);
 
             job.setAuditFields(loggedInUser);
 
@@ -401,7 +401,7 @@ public class JobServiceImpl implements JobService {
         job.setAuditFields(loggedInUser);
 
         //Update from request
-        updateJobFromRequest(job, request);
+        updateTcJobFromRequest(job, request);
 
         //Save job to TC so that it has an id.
         job = salesforceJobOppRepository.save(job);
@@ -795,7 +795,7 @@ public class JobServiceImpl implements JobService {
         }
     }
 
-    private void updateJobFromRequest(SalesforceJobOpp job, UpdateJobRequest request) {
+    private void updateTcJobFromRequest(SalesforceJobOpp job, UpdateJobRequest request) {
 
         //Perform any notifications before actually applying the change so that we have the
         //old and current state
@@ -964,20 +964,30 @@ public class JobServiceImpl implements JobService {
         User loggedInUser = getLoggedInUser("update job");
         SalesforceJobOpp job = getJob(id);
 
+        updateSfJobFromRequest(job, request);
+        updateTcJobFromRequest(job, request);
+        job.setAuditFields(loggedInUser);
+
+        return salesforceJobOppRepository.save(job);
+    }
+
+    private void updateSfJobFromRequest(SalesforceJobOpp job, UpdateJobRequest request) {
         final JobOpportunityStage stage = request.getStage();
         final LocalDate nextStepDueDate = request.getNextStepDueDate();
-        final String processedNextStep =
-            nextStepProcessingService.processNextStep(job, request.getNextStep());
-        salesforceService.updateEmployerOpportunityStage(job, stage, processedNextStep, nextStepDueDate);
+
+        String nextStep = request.getNextStep();
+        if (nextStep != null) {
+            nextStep = nextStepProcessingService.processNextStep(job, request.getNextStep());
+        }
+
+        if (stage != null | nextStep != null | nextStepDueDate != null) {
+            salesforceService.updateEmployerOpportunityStage(job, stage, nextStep, nextStepDueDate);
+        }
 
         final String jobName = request.getJobName();
         if (jobName != null) {
             salesforceService.updateEmployerOpportunityName(job.getSfId(), jobName);
         }
-
-        updateJobFromRequest(job, request);
-        job.setAuditFields(loggedInUser);
-        return salesforceJobOppRepository.save(job);
     }
 
     private void closeUnclosedCandidateOppsForJob(SalesforceJobOpp job, JobOpportunityStage jobCloseStage) {
@@ -1184,7 +1194,7 @@ public class JobServiceImpl implements JobService {
                     UpdateJobRequest updateRequest =
                         extractUpdateJobRequestFromSalesforceOpp(sfOpp, tcOpp);
                     if (updateRequest != null) {
-                        updateJobFromRequest(tcOpp, updateRequest);
+                        updateTcJobFromRequest(tcOpp, updateRequest);
                         salesforceJobOppRepository.save(tcOpp);
                         updates++;
                     }

--- a/server/src/main/java/org/tctalent/server/service/db/impl/NextStepProcessingServiceImpl.java
+++ b/server/src/main/java/org/tctalent/server/service/db/impl/NextStepProcessingServiceImpl.java
@@ -16,7 +16,7 @@
 
 package org.tctalent.server.service.db.impl;
 
-import static org.tctalent.server.util.NextStepHelper.auditStampNextStep;
+import static org.tctalent.server.util.NextStepHelper.auditStampNextStepIfChanged;
 
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
@@ -42,7 +42,7 @@ public class NextStepProcessingServiceImpl implements NextStepProcessingService 
         String currentNextStep =
             opp == null ? null : opp.getNextStep();
 
-        final String processedNextStep = auditStampNextStep(
+        final String processedNextStep = auditStampNextStepIfChanged(
             userForAttribution.getUsername(),
             LocalDate.now(),
             currentNextStep,

--- a/server/src/main/java/org/tctalent/server/util/NextStepHelper.java
+++ b/server/src/main/java/org/tctalent/server/util/NextStepHelper.java
@@ -44,11 +44,11 @@ public class NextStepHelper {
 
     /**
      * This method strips the current and existing Next Step of their audit stamps (if any) and
-     * checks if they're different. If they're the same, it simply returns the current Next Step;
-     * if changed, it audit stamps the new Next Step and returns it for subsequent Job create/update
-     * steps.
+     * checks if they're different. If they're the same, it simply returns the current Next Step,
+     * which will be stamped already; if changed, it audit stamps the new Next Step and returns it
+     * for subsequent Job create/update steps.
      *
-     * <p>Audit stamping does the following:
+     * <p>Audit stamping:
      * <ul>
      *     <li> appends the updating user's username.</li>
      *     <li> prepends the current date. </li>

--- a/server/src/main/java/org/tctalent/server/util/NextStepHelper.java
+++ b/server/src/main/java/org/tctalent/server/util/NextStepHelper.java
@@ -43,25 +43,28 @@ public class NextStepHelper {
     public static String nextStepAuditDateDelimiter = "| ";
 
     /**
-     * If the requested next step is different from the current next step, the next step
-     * will be updated. In that case we add special text:
+     * This method strips the current and existing Next Step of their audit stamps (if any) and
+     * checks if they're different. If they're the same, it simply returns the current Next Step;
+     * if changed, it audit stamps the new Next Step and returns it for subsequent Job create/update
+     * steps.
+     *
+     * <p>Audit stamping does the following:
      * <ul>
-     *     <li> the audit name to the end of the stripped nextStep.</li>
-     *     <li> the audit date to the start of the stripped nextStep. </li>
+     *     <li> appends the updating user's username.</li>
+     *     <li> prepends the current date. </li>
      * </ul>
-     * This indicates who has made this change to the next step, and when.
-     * This is useful for auditing purposes.
-     * <p/>
-     * This method performs this logic, returning the processed next step which is what should be
-     * used as the new next step.
      * @param name Name of person initiating the next step update
      * @param date Date of the update
      * @param currentNextStep The current next step
      * @param requestedNextStep The requested new next step
      * @return The processed text which should be used for the next step update
      */
-    public static String auditStampNextStep(String name, LocalDate date,
-        @Nullable String currentNextStep, @Nullable String requestedNextStep) {
+    public static String auditStampNextStepIfChanged(
+        String name,
+        LocalDate date,
+        @Nullable String currentNextStep,
+        @Nullable String requestedNextStep
+    ) {
         //Initialize the processedNextStep tp the current next step
         String processedNextStep = currentNextStep;
 

--- a/server/src/test/java/org/tctalent/server/service/db/impl/JobServiceImplTest.java
+++ b/server/src/test/java/org/tctalent/server/service/db/impl/JobServiceImplTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2025 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT 
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License 
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.service.db.impl;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tctalent.server.model.db.Employer;
+import org.tctalent.server.model.db.SalesforceJobOpp;
+import org.tctalent.server.model.db.User;
+import org.tctalent.server.repository.db.SalesforceJobOppRepository;
+import org.tctalent.server.request.job.UpdateJobRequest;
+import org.tctalent.server.service.db.SalesforceService;
+import org.tctalent.server.service.db.SavedListService;
+import org.tctalent.server.service.db.SavedSearchService;
+import org.tctalent.server.service.db.UserService;
+
+@ExtendWith(MockitoExtension.class)
+class JobServiceImplTest {
+
+    SalesforceJobOpp job;
+    UpdateJobRequest updateJobRequest;
+
+    private static final String JOB_SF_ID = "LKJH66446GGFDFSA";
+    private static final String JOB_NAME = "test job";
+    private static final String JOB_NEXT_STEP = "do something";
+
+    @Mock User user;
+    @Mock UserService userService;
+    @Mock SalesforceJobOppRepository salesforceJobOppRepository;
+    @Mock Employer employerEntity;
+    @Mock SalesforceService sfService;
+    @Mock SavedSearchService savedSearchService;
+    @Mock SavedListService savedListService;
+
+    @InjectMocks
+    JobServiceImpl jobService;
+
+    @BeforeEach
+    void setUp() {
+        job = new SalesforceJobOpp();
+        job.setId(1L);
+        job.setName(JOB_NAME);
+        job.setSfId(JOB_SF_ID);
+        job.setNextStep(JOB_NEXT_STEP);
+        job.setEmployerEntity(employerEntity);
+        updateJobRequest = new UpdateJobRequest();
+    }
+
+    @Test
+    @DisplayName("updateJob sets new name on SF and TC when changed")
+    void updateJobSetsNewNameWhenChanged() {
+        final String newName = "new name";
+        updateJobRequest.setJobName(newName);
+
+        given(userService.getLoggedInUser()).willReturn(user);
+        given(salesforceJobOppRepository.findById(anyLong())).willReturn(Optional.of(job));
+
+        jobService.updateJob(99L, updateJobRequest);
+
+        then(sfService).should().updateEmployerOpportunityName(eq(JOB_SF_ID), eq(newName));
+        Assertions.assertEquals(job.getName(), newName);
+        then(savedSearchService).should().updateSuggestedSearchesNames(eq(job), eq(JOB_NAME));
+        then(savedListService).should().updateAssociatedListsNames(eq(job));
+    }
+}

--- a/server/src/test/java/org/tctalent/server/service/db/impl/JobServiceImplTest.java
+++ b/server/src/test/java/org/tctalent/server/service/db/impl/JobServiceImplTest.java
@@ -46,8 +46,8 @@ import org.tctalent.server.service.db.UserService;
 @ExtendWith(MockitoExtension.class)
 class JobServiceImplTest {
 
-    SalesforceJobOpp job;
-    UpdateJobRequest updateJobRequest;
+    private SalesforceJobOpp job;
+    private UpdateJobRequest updateJobRequest;
 
     private static final String JOB_SF_ID = "LKJH66446GGFDFSA";
     private static final String JOB_NAME = "test job";
@@ -56,18 +56,18 @@ class JobServiceImplTest {
         LocalDate.of(1901, 1, 1);
     private static final JobOpportunityStage JOB_STAGE = JobOpportunityStage.candidateSearch;
 
-    @Mock User user;
-    @Mock UserService userService;
-    @Mock SalesforceJobOppRepository salesforceJobOppRepository;
-    @Mock Employer employerEntity;
-    @Mock SalesforceService sfService;
-    @Mock SavedSearchService savedSearchService;
-    @Mock SavedListService savedListService;
-    @Mock OppNotificationService oppNotificationService;
-    @Mock NextStepProcessingService nextStepProcessingService;
+    @Mock private User user;
+    @Mock private UserService userService;
+    @Mock private SalesforceJobOppRepository salesforceJobOppRepository;
+    @Mock private Employer employerEntity;
+    @Mock private SalesforceService sfService;
+    @Mock private SavedSearchService savedSearchService;
+    @Mock private SavedListService savedListService;
+    @Mock private OppNotificationService oppNotificationService;
+    @Mock private NextStepProcessingService nextStepProcessingService;
 
     @InjectMocks
-    JobServiceImpl jobService;
+    private JobServiceImpl jobService;
 
     @BeforeEach
     void setUp() {

--- a/server/src/test/java/org/tctalent/server/service/db/impl/NextStepProcessingServiceImplTest.java
+++ b/server/src/test/java/org/tctalent/server/service/db/impl/NextStepProcessingServiceImplTest.java
@@ -72,7 +72,7 @@ class NextStepProcessingServiceImplTest {
         try (var mockedHelper = mockStatic(NextStepHelper.class)) {
             nextStepProcessingService.processNextStep(jobOpp, REQUESTED_NEXT_STEP);
 
-            mockedHelper.verify(() -> NextStepHelper.auditStampNextStep(
+            mockedHelper.verify(() -> NextStepHelper.auditStampNextStepIfChanged(
                 eq("SystemAdmin"),
                 eq(LocalDate.now()),
                 eq(CURRENT_NEXT_STEP),
@@ -89,7 +89,7 @@ class NextStepProcessingServiceImplTest {
         try (var mockedHelper = mockStatic(NextStepHelper.class)) {
             nextStepProcessingService.processNextStep(jobOpp, REQUESTED_NEXT_STEP);
 
-            mockedHelper.verify(() -> NextStepHelper.auditStampNextStep(
+            mockedHelper.verify(() -> NextStepHelper.auditStampNextStepIfChanged(
                 eq("LoggedInUser"),
                 eq(LocalDate.now()),
                 eq(CURRENT_NEXT_STEP),
@@ -106,7 +106,7 @@ class NextStepProcessingServiceImplTest {
         try (var mockedHelper = mockStatic(NextStepHelper.class)) {
             nextStepProcessingService.processNextStep(candidateOpp, REQUESTED_NEXT_STEP);
 
-            mockedHelper.verify(() -> NextStepHelper.auditStampNextStep(
+            mockedHelper.verify(() -> NextStepHelper.auditStampNextStepIfChanged(
                 eq("LoggedInUser"),
                 eq(LocalDate.now()),
                 eq(CURRENT_NEXT_STEP),
@@ -125,7 +125,7 @@ class NextStepProcessingServiceImplTest {
         try (var mockedHelper = mockStatic(NextStepHelper.class)) {
             nextStepProcessingService.processNextStep(candidateOpp, REQUESTED_NEXT_STEP);
 
-            mockedHelper.verify(() -> NextStepHelper.auditStampNextStep(
+            mockedHelper.verify(() -> NextStepHelper.auditStampNextStepIfChanged(
                 eq("LoggedInUser"),
                 eq(LocalDate.now()),
                 eq(null),

--- a/server/src/test/java/org/tctalent/server/util/NextStepHelperTest.java
+++ b/server/src/test/java/org/tctalent/server/util/NextStepHelperTest.java
@@ -20,7 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.tctalent.server.util.NextStepHelper.auditStampNextStep;
+import static org.tctalent.server.util.NextStepHelper.auditStampNextStepIfChanged;
 import static org.tctalent.server.util.NextStepHelper.constructNextStepAuditStamp;
 import static org.tctalent.server.util.NextStepHelper.isNextStepDifferent;
 
@@ -56,7 +56,7 @@ class NextStepHelperTest {
     @Test
     void doNothingIfRequestNextStepIsNull() {
        String currentNextStep = "anything";
-       String processed = auditStampNextStep(name, date, currentNextStep, null);
+       String processed = auditStampNextStepIfChanged(name, date, currentNextStep, null);
        assertEquals(processed, currentNextStep);
     }
 
@@ -64,7 +64,7 @@ class NextStepHelperTest {
     void doNothingIfNextStepUnchanged() {
         String currentNextStep = "anything";
         String requestedNextStep = currentNextStep;
-        String processed = auditStampNextStep(name, date, currentNextStep, requestedNextStep);
+        String processed = auditStampNextStepIfChanged(name, date, currentNextStep, requestedNextStep);
         assertEquals(processed, currentNextStep);
     }
 
@@ -72,7 +72,7 @@ class NextStepHelperTest {
     void doNothingIfBothNextStepsAreNull() {
         String currentNextStep = null;
         String requestedNextStep = null;
-        String processed = auditStampNextStep(name, date, currentNextStep, requestedNextStep);
+        String processed = auditStampNextStepIfChanged(name, date, currentNextStep, requestedNextStep);
         assertNull(processed);
     }
 
@@ -80,7 +80,7 @@ class NextStepHelperTest {
     void auditStampChangedNextStepWhenCurrentIsNotStamped() {
         String currentNextStep = "Complete intake";
         String requestedNextStep = "Prepare CV";
-        String processed = auditStampNextStep(name, date, currentNextStep, requestedNextStep);
+        String processed = auditStampNextStepIfChanged(name, date, currentNextStep, requestedNextStep);
         assertEquals(constructNextStepAuditStamp(name, date, requestedNextStep), processed);
     }
 
@@ -89,7 +89,7 @@ class NextStepHelperTest {
         String currentNextStep = "Complete intake";
         String requestedNextStepUnstamped = "Prepare CV";
         String requestedNextStep = "01Mar24| " + requestedNextStepUnstamped + " --john";
-        String processed = auditStampNextStep(name, date, currentNextStep, requestedNextStep);
+        String processed = auditStampNextStepIfChanged(name, date, currentNextStep, requestedNextStep);
         assertEquals(constructNextStepAuditStamp(name, date, requestedNextStepUnstamped), processed);
     }
 
@@ -97,7 +97,7 @@ class NextStepHelperTest {
     void auditStampChangedNextStepWhenCurrentIsAlreadyStamped() {
         String currentNextStep = "Complete intake --240301 john";
         String requestedNextStep = "Prepare CV";
-        String processed = auditStampNextStep(name, date, currentNextStep, requestedNextStep);
+        String processed = auditStampNextStepIfChanged(name, date, currentNextStep, requestedNextStep);
         assertEquals(constructNextStepAuditStamp(name, date, requestedNextStep), processed);
     }
 
@@ -107,20 +107,20 @@ class NextStepHelperTest {
     }
 
     @Test
-    void auditStampNextStep_noChange_returnsFalse() {
+    void auditStampNextStepIfChanged_noChange_returnsFalse() {
         String nextStep = "Complete intake";
         assertFalse(isNextStepDifferent(nextStep, nextStep));
     }
 
     @Test
-    void auditStampNextStep_sameValueDiffAuditStamp_returnsFalse() {
+    void auditStampNextStepIfChanged_sameValueDiffAuditStamp_returnsFalseIfChanged() {
         String currentNextStep = "01Mar24| Complete intake --john";
         String requestedNextStep = "03Mar24| Complete intake --sam";
         assertFalse(isNextStepDifferent(currentNextStep, requestedNextStep));
     }
 
     @Test
-    void auditStampNextStep_diffValueSameAuditStamp_returnsTrue() {
+    void auditStampNextStepIfChanged_diffValueSameAuditStamp_returnsTrueIfChanged() {
         String currentNextStep = "01Mar24| Complete intake --john";
         String requestedNextStep = "01Mar24| Do nothing --john";
         assertTrue(isNextStepDifferent(currentNextStep, requestedNextStep));

--- a/ui/admin-portal/src/app/MockData/MockJob.ts
+++ b/ui/admin-portal/src/app/MockData/MockJob.ts
@@ -160,7 +160,8 @@ export const MockJob: Job = {
   stage: JobOpportunityStage.prospect,
   starringUsers: [{ id: 4, username: 'alicejohnson', firstName: 'Alice', lastName: 'Johnson', email: 'alicejohnson@example.com', role: 'limited', jobCreator: false, approver: null, purpose: 'Some purpose', readOnly: false, sourceCountries: [], status: 'Active', createdDate: Date.now(), createdBy: null, updatedDate: Date.now(), lastLogin: Date.now(), usingMfa: true, mfaConfigured: false, partner: null, name: 'Alice Johnson',emailVerified: false,}],
   submissionDueDate: new Date(),
-   jobOppIntake: { employerCostCommitment: 'High', recruitmentProcess: 'Some process', minSalary: 50000, occupationCode: '123', salaryRange: '50k - 100k', locationDetails: 'Some location details', location: 'Some location', visaPathways: 'Some pathways', benefits: 'Some benefits', educationRequirements: 'Some education requirements', languageRequirements: 'Some language requirements', employmentExperience: 'Some employment experience', skillRequirements: 'Some skill requirements' }
+   jobOppIntake: { employerCostCommitment: 'High', recruitmentProcess: 'Some process', minSalary: 50000, occupationCode: '123', salaryRange: '50k - 100k', locationDetails: 'Some location details', location: 'Some location', visaPathways: 'Some pathways', benefits: 'Some benefits', educationRequirements: 'Some education requirements', languageRequirements: 'Some language requirements', employmentExperience: 'Some employment experience', skillRequirements: 'Some skill requirements' },
+  createdBy: new MockUser()
 };
 
 

--- a/ui/admin-portal/src/app/services/authorization.service.spec.ts
+++ b/ui/admin-portal/src/app/services/authorization.service.spec.ts
@@ -21,10 +21,13 @@ import {Role, User} from '../model/user';
 import {Candidate} from '../model/candidate';
 import {Partner} from "../model/partner";
 import {CandidateSource} from "../model/base";
+import {MockJob} from "../MockData/MockJob";
+import {Job} from "../model/job";
 
 describe('AuthorizationService', () => {
   let service: AuthorizationService;
   let authenticationServiceSpy: jasmine.SpyObj<AuthenticationService>;
+  let job: Job;
 
   beforeEach(() => {
     const spy = jasmine.createSpyObj('AuthenticationService', ['getLoggedInUser']);
@@ -38,6 +41,7 @@ describe('AuthorizationService', () => {
 
     service = TestBed.inject(AuthorizationService);
     authenticationServiceSpy = TestBed.inject(AuthenticationService) as jasmine.SpyObj<AuthenticationService>;
+    job = MockJob;
   });
 
   it('should be created', () => {
@@ -290,6 +294,27 @@ describe('AuthorizationService', () => {
 
     authenticationServiceSpy.getLoggedInUser.and.returnValue({ ...user, id: 2 });
     expect(service.isStarredByMe(users)).toBeFalse();
+  });
+
+  it('should return true for System Admin', () => {
+    const user: User = { id: 2, role: 'systemadmin' } as User; // Not the creator
+    authenticationServiceSpy.getLoggedInUser.and.returnValue(user);
+
+    expect(service.canChangeJobName(job)).toBeTrue();
+  })
+
+  it('should return true for job creator', () => {
+    const user: User = { id: 1, role: 'systemadmin' } as User;
+    authenticationServiceSpy.getLoggedInUser.and.returnValue(user);
+
+    expect(service.canChangeJobName(job)).toBeTrue();
+  })
+
+  it('should return false for a user who is not the creator and not a system admin', () => {
+    const user: User = { id: 2, role: 'admin' } as User; // Not the creator or a System Admin
+    authenticationServiceSpy.getLoggedInUser.and.returnValue(user);
+
+    expect(service.canChangeJobName(job)).toBeFalse();
   });
 
 });


### PR DESCRIPTION
As noted in the issue comments, the refactoring is minor and purely for readibility. Ditto the renaming.

The rationale is that we've had a few bugs in this area recently and anything we can do to make the paths more obvious may help.