### PR TITLE
change maven artefact group to org.tctalent

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -167,7 +167,7 @@ dependencies {
     implementation 'io.github.mweirauch:micrometer-jvm-extras:0.2.2'
 
     // tc api
-    implementation "io.github.sadatmalik:tc-api-spec:1.0.11"
+    implementation "org.tctalent:tc-api-spec:1.0.0"
 
     // Mapstruct
     implementation "org.mapstruct:mapstruct:${mapstructVersion}"


### PR DESCRIPTION
Small PR that updates the tc-api-spec dependency namespace to org.tctalent