### PR TITLE
2146 enhance test coverage for orgtctalentserversecurity package

### DIFF
--- a/server/src/test/java/org/tctalent/server/security/AuthServiceTest.java
+++ b/server/src/test/java/org/tctalent/server/security/AuthServiceTest.java
@@ -1,0 +1,299 @@
+/*
+ * Copyright (c) 2025 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.security;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.tctalent.server.model.db.Candidate;
+import org.tctalent.server.model.db.Country;
+import org.tctalent.server.model.db.Role;
+import org.tctalent.server.model.db.User;
+
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class AuthServiceTest {
+
+  @InjectMocks
+  private AuthService authService;
+
+  @Mock
+  private SecurityContext securityContext;
+
+  @Mock
+  private Authentication authentication;
+
+  @Mock
+  private TcUserDetails tcUserDetails;
+
+  @Mock
+  private User user;
+
+  @Mock
+  private Candidate candidate;
+
+  @Mock
+  private Country country;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+    SecurityContextHolder.setContext(securityContext);
+    when(securityContext.getAuthentication()).thenReturn(authentication);
+  }
+
+  @Test
+  void getLoggedInUser_returnsUser_whenAuthenticated() {
+    when(authentication.getPrincipal()).thenReturn(tcUserDetails);
+    when(tcUserDetails.getUser()).thenReturn(user);
+
+    Optional<User> result = authService.getLoggedInUser();
+
+    assertTrue(result.isPresent());
+    assertEquals(user, result.get());
+  }
+
+  @Test
+  void getLoggedInUser_returnsEmpty_whenNotAuthenticated() {
+    when(authentication.getPrincipal()).thenReturn(null);
+
+    Optional<User> result = authService.getLoggedInUser();
+
+    assertFalse(result.isPresent());
+  }
+
+  @Test
+  void getLoggedInUser_returnsEmpty_whenAuthenticationIsNull() {
+    when(securityContext.getAuthentication()).thenReturn(null);
+
+    Optional<User> result = authService.getLoggedInUser();
+
+    assertFalse(result.isPresent());
+  }
+
+  @Test
+  void getLoggedInCandidateId_returnsId_whenUserHasCandidate() {
+    Long candidateId = 123L;
+    when(authentication.getPrincipal()).thenReturn(tcUserDetails);
+    when(tcUserDetails.getUser()).thenReturn(user);
+    when(user.getCandidate()).thenReturn(candidate);
+    when(candidate.getId()).thenReturn(candidateId);
+
+    Long result = authService.getLoggedInCandidateId();
+
+    assertEquals(candidateId, result);
+  }
+
+  @Test
+  void getLoggedInCandidateId_returnsNull_whenNoUser() {
+    when(authentication.getPrincipal()).thenReturn(null);
+
+    Long result = authService.getLoggedInCandidateId();
+
+    assertNull(result);
+  }
+
+  @Test
+  void getLoggedInCandidateId_returnsNull_whenUserHasNoCandidate() {
+    when(authentication.getPrincipal()).thenReturn(tcUserDetails);
+    when(tcUserDetails.getUser()).thenReturn(user);
+    when(user.getCandidate()).thenReturn(null);
+
+    Long result = authService.getLoggedInCandidateId();
+
+    assertNull(result);
+  }
+
+  @Test
+  void getLoggedInCandidate_returnsCandidate_whenUserHasCandidate() {
+    when(authentication.getPrincipal()).thenReturn(tcUserDetails);
+    when(tcUserDetails.getUser()).thenReturn(user);
+    when(user.getCandidate()).thenReturn(candidate);
+
+    Candidate result = authService.getLoggedInCandidate();
+
+    assertEquals(candidate, result);
+  }
+
+  @Test
+  void getLoggedInCandidate_returnsNull_whenNoUser() {
+    when(authentication.getPrincipal()).thenReturn(null);
+
+    Candidate result = authService.getLoggedInCandidate();
+
+    assertNull(result);
+  }
+
+  @Test
+  void getLoggedInCandidate_returnsNull_whenUserHasNoCandidate() {
+    when(authentication.getPrincipal()).thenReturn(tcUserDetails);
+    when(tcUserDetails.getUser()).thenReturn(user);
+    when(user.getCandidate()).thenReturn(null);
+
+    Candidate result = authService.getLoggedInCandidate();
+
+    assertNull(result);
+  }
+
+  @Test
+  void getUserLanguage_returnsLanguage_whenUserLoggedIn() {
+    String language = "en";
+    when(authentication.getPrincipal()).thenReturn(tcUserDetails);
+    when(tcUserDetails.getUser()).thenReturn(user);
+    when(user.getSelectedLanguage()).thenReturn(language);
+
+    String result = authService.getUserLanguage();
+
+    assertEquals(language, result);
+  }
+
+  @Test
+  void getUserLanguage_returnsNull_whenNoUser() {
+    when(authentication.getPrincipal()).thenReturn(null);
+
+    String result = authService.getUserLanguage();
+
+    assertNull(result);
+  }
+
+  @Test
+  void authoriseLoggedInUser_returnsFalse_whenNoUser() {
+    when(authentication.getPrincipal()).thenReturn(null);
+
+    boolean result = authService.authoriseLoggedInUser(candidate);
+
+    assertFalse(result);
+  }
+
+  @Test
+  void authoriseLoggedInUser_returnsFalse_whenUserIsReadOnly() {
+    when(authentication.getPrincipal()).thenReturn(tcUserDetails);
+    when(tcUserDetails.getUser()).thenReturn(user);
+    when(user.getReadOnly()).thenReturn(true);
+
+    boolean result = authService.authoriseLoggedInUser(candidate);
+
+    assertFalse(result);
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = Role.class, names = {"admin", "systemadmin"})
+  void authoriseLoggedInUser_returnsTrue_forAdminRoles(Role role) {
+    when(authentication.getPrincipal()).thenReturn(tcUserDetails);
+    when(tcUserDetails.getUser()).thenReturn(user);
+    when(user.getReadOnly()).thenReturn(false);
+    when(user.getRole()).thenReturn(role);
+
+    boolean result = authService.authoriseLoggedInUser(candidate);
+
+    assertTrue(result);
+  }
+
+  @Test
+  void authoriseLoggedInUser_returnsTrue_forPartnerAdminNoCountryRestrictions() {
+    when(authentication.getPrincipal()).thenReturn(tcUserDetails);
+    when(tcUserDetails.getUser()).thenReturn(user);
+    when(user.getReadOnly()).thenReturn(false);
+    when(user.getRole()).thenReturn(Role.partneradmin);
+    when(user.getSourceCountries()).thenReturn(Collections.emptySet());
+
+    boolean result = authService.authoriseLoggedInUser(candidate);
+
+    assertTrue(result);
+  }
+
+  @Test
+  void authoriseLoggedInUser_returnsTrue_forPartnerAdminWithMatchingCountry() {
+    when(authentication.getPrincipal()).thenReturn(tcUserDetails);
+    when(tcUserDetails.getUser()).thenReturn(user);
+    when(user.getReadOnly()).thenReturn(false);
+    when(user.getRole()).thenReturn(Role.partneradmin);
+    when(user.getSourceCountries()).thenReturn(Set.of(country));
+    when(candidate.getCountry()).thenReturn(country);
+
+    boolean result = authService.authoriseLoggedInUser(candidate);
+
+    assertTrue(result);
+  }
+
+  @Test
+  void authoriseLoggedInUser_returnsFalse_forPartnerAdminWithNonMatchingCountry() {
+    Country otherCountry = mock(Country.class);
+    when(authentication.getPrincipal()).thenReturn(tcUserDetails);
+    when(tcUserDetails.getUser()).thenReturn(user);
+    when(user.getReadOnly()).thenReturn(false);
+    when(user.getRole()).thenReturn(Role.partneradmin);
+    when(user.getSourceCountries()).thenReturn(Set.of(country));
+    when(candidate.getCountry()).thenReturn(otherCountry);
+
+    boolean result = authService.authoriseLoggedInUser(candidate);
+
+    assertFalse(result);
+  }
+
+  @Test
+  void authoriseLoggedInUser_returnsTrue_forUserOwningCandidate() {
+    Long candidateId = 123L;
+    when(authentication.getPrincipal()).thenReturn(tcUserDetails);
+    when(tcUserDetails.getUser()).thenReturn(user);
+    when(user.getReadOnly()).thenReturn(false);
+    when(user.getRole()).thenReturn(Role.user);
+    when(user.getCandidate()).thenReturn(candidate);
+    when(candidate.getId()).thenReturn(candidateId);
+    when(candidate.getId()).thenReturn(candidateId);
+
+    boolean result = authService.authoriseLoggedInUser(candidate);
+
+    assertTrue(result);
+  }
+
+  @Test
+  void authoriseLoggedInUser_returnsFalse_forUserNotOwningCandidate() {
+    Candidate otherCandidate = mock(Candidate.class);
+    when(authentication.getPrincipal()).thenReturn(tcUserDetails);
+    when(tcUserDetails.getUser()).thenReturn(user);
+    when(user.getReadOnly()).thenReturn(false);
+    when(user.getRole()).thenReturn(Role.user);
+    when(user.getCandidate()).thenReturn(otherCandidate);
+    when(otherCandidate.getId()).thenReturn(456L);
+    when(candidate.getId()).thenReturn(123L);
+
+    boolean result = authService.authoriseLoggedInUser(candidate);
+
+    assertFalse(result);
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = Role.class, names = {"partneradmin", "admin", "systemadmin"})
+  void hasAdminPrivileges_returnsTrue_forAdminRoles(Role role) {
+    boolean result = authService.hasAdminPrivileges(role);
+
+    assertTrue(result);
+  }
+}

--- a/server/src/test/java/org/tctalent/server/security/JwtAuthenticationFilterTest.java
+++ b/server/src/test/java/org/tctalent/server/security/JwtAuthenticationFilterTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2025 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.security;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class JwtAuthenticationFilterTest {
+
+  @Mock
+  private JwtTokenProvider tokenProvider;
+
+  @Mock
+  private TcUserDetailsService userDetailsService;
+
+  @Mock
+  private HttpServletRequest request;
+
+  @Mock
+  private HttpServletResponse response;
+
+  @Mock
+  private FilterChain filterChain;
+
+  @InjectMocks
+  private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+  private AutoCloseable mocks;
+  private ListAppender<ILoggingEvent> logAppender;
+  private Logger logger;
+  private Level originalLevel;
+
+  @BeforeEach
+  void setUp() {
+    mocks = MockitoAnnotations.openMocks(this);
+
+    logger = (Logger) LoggerFactory.getLogger(JwtAuthenticationFilter.class);
+    originalLevel = logger.getLevel();
+    logger.setLevel(Level.ERROR);
+    logAppender = new ListAppender<>();
+    logAppender.start();
+    logger.addAppender(logAppender);
+    SecurityContextHolder.clearContext();
+  }
+
+  @AfterEach
+  void tearDown() throws Exception {
+    logger.detachAppender(logAppender);
+    logAppender.stop();
+    logger.setLevel(originalLevel);
+
+    SecurityContextHolder.clearContext();
+
+    mocks.close();
+  }
+
+  @Test
+  void doFilterInternal_skipsAuthenticationForInvalidJwt() throws ServletException, IOException {
+    String jwt = "invalid.jwt.token";
+    when(request.getHeader("Authorization")).thenReturn("Bearer " + jwt);
+    when(tokenProvider.validateToken(jwt)).thenReturn(false);
+
+    jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+    verify(tokenProvider).validateToken(jwt);
+    verifyNoMoreInteractions(tokenProvider, userDetailsService);
+    verify(filterChain).doFilter(request, response);
+    assertNull(SecurityContextHolder.getContext().getAuthentication(), "Authentication should not be set");
+
+    assertTrue(logAppender.list.isEmpty(), "No error logs expected for invalid JWT");
+  }
+
+  @Test
+  void doFilterInternal_skipsAuthenticationForMissingJwt() throws ServletException, IOException {
+    when(request.getHeader("Authorization")).thenReturn(null);
+
+    jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+    verifyNoInteractions(tokenProvider, userDetailsService);
+    verify(filterChain).doFilter(request, response);
+    assertNull(SecurityContextHolder.getContext().getAuthentication(), "Authentication should not be set");
+
+    assertTrue(logAppender.list.isEmpty(), "No error logs expected for missing JWT");
+  }
+
+  @Test
+  void getJwtFromRequest_extractsTokenFromValidBearerHeader() {
+    String jwt = "valid.jwt.token";
+    when(request.getHeader("Authorization")).thenReturn("Bearer " + jwt);
+
+    String result = invokePrivateMethod("getJwtFromRequest", request);
+    assertEquals(jwt, result, "Extracted JWT should match the token");
+    verify(request).getHeader("Authorization");
+  }
+
+  @Test
+  void getJwtFromRequest_returnsNullForInvalidBearerHeader() {
+    when(request.getHeader("Authorization")).thenReturn("InvalidToken");
+    String result = invokePrivateMethod("getJwtFromRequest", request);
+
+    assertNull(result, "Should return null for invalid Authorization header");
+    verify(request).getHeader("Authorization");
+  }
+
+  @Test
+  void getJwtFromRequest_returnsNullForMissingBearerHeader() {
+    when(request.getHeader("Authorization")).thenReturn(null);
+    String result = invokePrivateMethod("getJwtFromRequest", request);
+    assertNull(result, "Should return null for missing Authorization header");
+    verify(request).getHeader("Authorization");
+  }
+
+  @SuppressWarnings("unchecked")
+  private <T> T invokePrivateMethod(String methodName, Object... args) {
+    try {
+      Method method = JwtAuthenticationFilter.class.getDeclaredMethod(methodName, HttpServletRequest.class);
+      method.setAccessible(true);
+      return (T) method.invoke(jwtAuthenticationFilter, args);
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to invoke private method: " + methodName, e);
+    }
+  }
+}

--- a/server/src/test/java/org/tctalent/server/security/JwtTokenProviderTest.java
+++ b/server/src/test/java/org/tctalent/server/security/JwtTokenProviderTest.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) 2025 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import java.security.Key;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.security.core.Authentication;
+import org.tctalent.server.logging.LogBuilder;
+import org.tctalent.server.model.db.Role;
+import org.tctalent.server.model.db.User;
+
+import java.util.Base64;
+import java.util.Date;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class JwtTokenProviderTest {
+
+  @InjectMocks
+  private JwtTokenProvider jwtTokenProvider;
+
+  @Mock
+  private LogBuilder logBuilder;
+
+  @Mock
+  private Authentication authentication;
+
+  @Mock
+  private TcUserDetails tcUserDetails;
+
+  @Mock
+  private User user;
+
+  private Key jwtSecret;
+  private final int jwtExpirationInMs = 3_600_000;
+  private AutoCloseable mocks;
+
+  @BeforeEach
+  void setUp() {
+    mocks = MockitoAnnotations.openMocks(this);
+
+    byte[] keyBytes = new byte[64];
+    new java.security.SecureRandom().nextBytes(keyBytes);
+    String jwtSecretBase64 = Base64.getEncoder().encodeToString(keyBytes);
+    jwtSecret = io.jsonwebtoken.security.Keys.hmacShaKeyFor(Base64.getDecoder().decode(
+        jwtSecretBase64));
+
+    setField(jwtTokenProvider, "jwtSecretBase64", jwtSecretBase64);
+    setField(jwtTokenProvider, "jwtExpirationInMs", jwtExpirationInMs);
+
+    jwtTokenProvider.afterPropertiesSet();
+  }
+
+  @AfterEach
+  void tearDown() throws Exception {
+    mocks.close();
+  }
+
+  @Test
+  void afterPropertiesSet_initializesJwtSecret() {
+    jwtTokenProvider.afterPropertiesSet();
+    java.security.Key initializedKey = getField(jwtTokenProvider, "jwtSecret");
+    assertNotNull(initializedKey, "JWT secret key should be initialized");
+  }
+
+  @Test
+  void generateToken_withUserDetails_generatesValidToken() {
+    String username = "testuser";
+    when(authentication.getPrincipal()).thenReturn(tcUserDetails);
+    when(tcUserDetails.getUsername()).thenReturn(username);
+    when(tcUserDetails.getUser()).thenReturn(user);
+    when(user.getRole()).thenReturn(Role.admin);
+
+    String token = jwtTokenProvider.generateToken(authentication);
+
+    assertNotNull(token, "Generated token should not be null");
+    Claims claims = Jwts.parserBuilder()
+        .setSigningKey(jwtSecret)
+        .build()
+        .parseClaimsJws(token)
+        .getBody();
+
+    assertEquals(username, claims.getSubject(), "Token subject should match username");
+    assertNotNull(claims.getIssuedAt(), "Token should have issued-at date");
+    assertNotNull(claims.getExpiration(), "Token should have expiration date");
+  }
+
+  @Test
+  void generateToken_withCandidateRole_setsNoExpiration() {
+    String username = "candidate";
+    when(authentication.getPrincipal()).thenReturn(tcUserDetails);
+    when(tcUserDetails.getUsername()).thenReturn(username);
+    when(tcUserDetails.getUser()).thenReturn(user);
+    when(user.getRole()).thenReturn(Role.user);
+
+    String token = jwtTokenProvider.generateToken(authentication);
+
+    assertNotNull(token, "Generated token should not be null");
+    Claims claims = Jwts.parserBuilder()
+        .setSigningKey(jwtSecret)
+        .build()
+        .parseClaimsJws(token)
+        .getBody();
+
+    assertEquals(username, claims.getSubject(), "Token subject should match username");
+    assertNull(claims.getExpiration(), "Candidate token should have no expiration");
+  }
+
+  @Test
+  void generateToken_withNonUserDetailsPrincipal_generatesTokenWithNullSubject() {
+    when(authentication.getPrincipal()).thenReturn(new Object());
+
+    String token = jwtTokenProvider.generateToken(authentication);
+
+    assertNotNull(token, "Generated token should not be null");
+    Claims claims = Jwts.parserBuilder()
+        .setSigningKey(jwtSecret)
+        .build()
+        .parseClaimsJws(token)
+        .getBody();
+
+    assertNull(claims.getSubject(), "Token subject should be null for non-TcUserDetails principal");
+    assertNotNull(claims.getExpiration(), "Token should have expiration date");
+  }
+
+  @Test
+  void getUsernameFromJwt_extractsUsername() {
+    String username = "testuser";
+    String token = Jwts.builder()
+        .setSubject(username)
+        .setIssuedAt(new Date())
+        .setExpiration(new Date(System.currentTimeMillis() + jwtExpirationInMs))
+        .signWith(jwtSecret)
+        .compact();
+
+    String extractedUsername = jwtTokenProvider.getUsernameFromJwt(token);
+
+    assertEquals(username, extractedUsername, "Extracted username should match token subject");
+  }
+
+  @Test
+  void validateToken_withValidToken_returnsTrue() {
+    String token = Jwts.builder()
+        .setSubject("testuser")
+        .setIssuedAt(new Date())
+        .setExpiration(new Date(System.currentTimeMillis() + jwtExpirationInMs))
+        .signWith(jwtSecret)
+        .compact();
+
+    boolean isValid = jwtTokenProvider.validateToken(token);
+
+    assertTrue(isValid, "Valid token should return true");
+    verifyNoInteractions(logBuilder);
+  }
+
+  // Helper methods for reflection-based field access
+  private void setField(Object target, String fieldName, Object value) {
+    try {
+      java.lang.reflect.Field field = target.getClass().getDeclaredField(fieldName);
+      field.setAccessible(true);
+      field.set(target, value);
+    } catch (NoSuchFieldException | IllegalAccessException e) {
+      throw new RuntimeException("Failed to set field: " + fieldName, e);
+    }
+  }
+
+  private <T> T getField(Object target, String fieldName) {
+    try {
+      java.lang.reflect.Field field = target.getClass().getDeclaredField(fieldName);
+      field.setAccessible(true);
+      return (T) field.get(target);
+    } catch (NoSuchFieldException | IllegalAccessException e) {
+      throw new RuntimeException("Failed to get field: " + fieldName, e);
+    }
+  }
+}

--- a/server/src/test/java/org/tctalent/server/security/LanguageFilterTest.java
+++ b/server/src/test/java/org/tctalent/server/security/LanguageFilterTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2025 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.tctalent.server.logging.LogBuilder;
+import org.tctalent.server.model.db.User;
+
+import java.io.IOException;
+
+import static org.mockito.Mockito.*;
+
+class LanguageFilterTest {
+
+  @InjectMocks
+  private LanguageFilter languageFilter;
+
+  @Mock
+  private HttpServletRequest request;
+
+  @Mock
+  private HttpServletResponse response;
+
+  @Mock
+  private FilterChain filterChain;
+
+  @Mock
+  private SecurityContext securityContext;
+
+  @Mock
+  private Authentication authentication;
+
+  @Mock
+  private TcUserDetails tcUserDetails;
+
+  @Mock
+  private User user;
+
+
+  @Mock
+  private LogBuilder logBuilder;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+    SecurityContextHolder.setContext(securityContext);
+  }
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHolder.clearContext();
+  }
+
+  @Test
+  void doFilter_withValidLanguageHeader_setsUserLanguage() throws IOException, ServletException {
+    String language = "fr";
+    when(request.getHeader("X-Language")).thenReturn(language);
+    when(securityContext.getAuthentication()).thenReturn(authentication);
+    when(authentication.getPrincipal()).thenReturn(tcUserDetails);
+    when(tcUserDetails.getUser()).thenReturn(user);
+
+    languageFilter.doFilterInternal(request, response, filterChain);
+
+    verify(user).setSelectedLanguage(language);
+    verify(filterChain).doFilter(request, response);
+    verifyNoInteractions(logBuilder);
+  }
+
+  @Test
+  void doFilter_withBlankLanguageHeader_setsDefaultLanguage() throws IOException, ServletException {
+    when(request.getHeader("X-Language")).thenReturn("");
+    when(securityContext.getAuthentication()).thenReturn(authentication);
+    when(authentication.getPrincipal()).thenReturn(tcUserDetails);
+    when(tcUserDetails.getUser()).thenReturn(user);
+
+    languageFilter.doFilterInternal(request, response, filterChain);
+
+    verify(user).setSelectedLanguage("en");
+    verify(filterChain).doFilter(request, response);
+    verifyNoInteractions(logBuilder);
+  }
+
+  @Test
+  void doFilter_withNullLanguageHeader_setsDefaultLanguage() throws IOException, ServletException {
+    when(request.getHeader("X-Language")).thenReturn(null);
+    when(securityContext.getAuthentication()).thenReturn(authentication);
+    when(authentication.getPrincipal()).thenReturn(tcUserDetails);
+    when(tcUserDetails.getUser()).thenReturn(user);
+
+    languageFilter.doFilterInternal(request, response, filterChain);
+
+    verify(user).setSelectedLanguage("en");
+    verify(filterChain).doFilter(request, response);
+    verifyNoInteractions(logBuilder);
+  }
+
+  @Test
+  void doFilter_withNoAuthentication_proceedsWithoutSettingLanguage() throws IOException, ServletException {
+    when(securityContext.getAuthentication()).thenReturn(null);
+
+    languageFilter.doFilterInternal(request, response, filterChain);
+
+    verifyNoInteractions(tcUserDetails, user);
+    verify(filterChain).doFilter(request, response);
+    verifyNoInteractions(logBuilder);
+  }
+
+  @Test
+  void doFilter_withNonTcUserDetailsPrincipal_proceedsWithoutSettingLanguage() throws IOException, ServletException {
+    when(securityContext.getAuthentication()).thenReturn(authentication);
+    when(authentication.getPrincipal()).thenReturn(new Object());
+
+    languageFilter.doFilterInternal(request, response, filterChain);
+
+    verifyNoInteractions(tcUserDetails, user);
+    verify(filterChain).doFilter(request, response);
+    verifyNoInteractions(logBuilder);
+  }
+}

--- a/server/src/test/java/org/tctalent/server/security/PasswordHelperTest.java
+++ b/server/src/test/java/org/tctalent/server/security/PasswordHelperTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2025 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.security;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.tctalent.server.exception.InvalidPasswordFormatException;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+class PasswordHelperTest {
+
+  @InjectMocks
+  private PasswordHelper passwordHelper;
+
+  @Mock
+  private PasswordEncoder passwordEncoder;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+  }
+
+  @Test
+  void validateAndEncodePassword_validPassword_returnsEncodedPassword() {
+    String password = "password123";
+    String encodedPassword = "encodedPass123";
+
+    when(passwordEncoder.encode(password)).thenReturn(encodedPassword);
+
+    String result = passwordHelper.validateAndEncodePassword(password);
+
+    assertEquals(encodedPassword, result);
+  }
+
+  @Test
+  void validateAndEncodePassword_blankPassword_throwsInvalidPasswordFormatException() {
+    String password = "";
+
+    InvalidPasswordFormatException ex = assertThrows(InvalidPasswordFormatException.class,
+        () -> {
+          passwordHelper.validateAndEncodePassword(password);
+        });
+
+    assertEquals("Password must not be blank", ex.getMessage());
+  }
+
+  @Test
+  void validateAndEncodePassword_shortPassword_throwsInvalidPasswordFormatException() {
+    String password = "pass";
+
+    InvalidPasswordFormatException ex = assertThrows(InvalidPasswordFormatException.class,
+        () -> {
+          passwordHelper.validateAndEncodePassword(password);
+        });
+
+    assertEquals("Password must be at least 8 characters long", ex.getMessage());
+  }
+
+  @Test
+  void encodePassword_encodesPassword() {
+    String password = "password123";
+    String encodedPassword = "encodedPass123";
+
+    when(passwordEncoder.encode(password)).thenReturn(encodedPassword);
+
+    String result = passwordHelper.encodePassword(password);
+
+    assertEquals(encodedPassword, result);
+  }
+
+  @Test
+  void validatePasswordRules_validPassword_passes() {
+    String password = "password123";
+
+    assertDoesNotThrow(() -> passwordHelper.validatePasswordRules(password));
+  }
+
+  @Test
+  void validatePasswordRules_nullPassword_throwsInvalidPasswordFormatException() {
+    String password = null;
+
+    InvalidPasswordFormatException ex = assertThrows(InvalidPasswordFormatException.class,
+        () -> {
+          passwordHelper.validatePasswordRules(password);
+        });
+
+    assertEquals("Password must not be blank", ex.getMessage());
+  }
+
+  @Test
+  void validatePasswordRules_blankPassword_throwsInvalidPasswordFormatException() {
+    String password = " ";
+
+    InvalidPasswordFormatException ex = assertThrows(InvalidPasswordFormatException.class,
+        () -> {
+          passwordHelper.validatePasswordRules(password);
+        });
+
+    assertEquals("Password must not be blank", ex.getMessage());
+  }
+
+  @Test
+  void validatePasswordRules_shortPassword_throwsInvalidPasswordFormatException() {
+    String password = "pass123";
+
+    InvalidPasswordFormatException ex = assertThrows(InvalidPasswordFormatException.class,
+        () -> {
+          passwordHelper.validatePasswordRules(password);
+        });
+
+    assertEquals("Password must be at least 8 characters long", ex.getMessage());
+  }
+
+  @Test
+  void isValidPassword_matchingPassword_returnsTrue() {
+    String password = "password123";
+    String encodedPassword = "encodedPass123";
+
+    when(passwordEncoder.matches(password, encodedPassword)).thenReturn(true);
+
+    boolean result = passwordHelper.isValidPassword(password, encodedPassword);
+
+    assertTrue(result);
+  }
+
+  @Test
+  void isValidPassword_nonMatchingPassword_returnsFalse() {
+    String password = "password123";
+    String encodedPassword = "encodedPass123";
+
+    when(passwordEncoder.matches(password, encodedPassword)).thenReturn(false);
+
+    boolean result = passwordHelper.isValidPassword(password, encodedPassword);
+
+    assertFalse(result);
+  }
+}

--- a/server/src/test/java/org/tctalent/server/security/PublicApiKeyGeneratorTest.java
+++ b/server/src/test/java/org/tctalent/server/security/PublicApiKeyGeneratorTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2025 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+/*
+ * Copyright (c) 2025 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.security;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Base64;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PublicApiKeyGeneratorTest {
+
+  @Test
+  void generateApiKey_producesKeyOfCorrectLength() {
+    String apiKey = PublicApiKeyGenerator.generateApiKey();
+
+    assertEquals(43, apiKey.length(), "API key should be 44 characters long (Base64 URL-safe encoding of 32 bytes)");
+  }
+
+  @Test
+  void generateApiKey_producesValidBase64UrlSafeKey() {
+    String apiKey = PublicApiKeyGenerator.generateApiKey();
+
+    assertDoesNotThrow(() -> Base64.getUrlDecoder().decode(apiKey), "API key should be valid Base64 URL-safe encoded");
+    assertTrue(apiKey.matches("^[A-Za-z0-9-_]+$"), "API key should only contain Base64 URL-safe characters (A-Z, a-z, 0-9, -, _)");
+    assertFalse(apiKey.contains("="), "API key should not contain padding characters");
+  }
+
+  @Test
+  void generateApiKey_produces32ByteKey() {
+    String apiKey = PublicApiKeyGenerator.generateApiKey();
+
+    byte[] decodedBytes = Base64.getUrlDecoder().decode(apiKey);
+    assertEquals(32, decodedBytes.length, "Decoded API key should be 32 bytes (256 bits)");
+  }
+
+  @Test
+  void generateApiKey_producesUniqueKeys() {
+    Set<String> apiKeys = new HashSet<>();
+    int iterations = 1000;
+
+    for (int i = 0; i < iterations; i++) {
+      String apiKey = PublicApiKeyGenerator.generateApiKey();
+      assertTrue(apiKeys.add(apiKey), "API key should be unique");
+    }
+
+    assertEquals(iterations, apiKeys.size(), "All generated API keys should be unique");
+  }
+
+  @Test
+  void generateApiKey_isNotNullOrEmpty() {
+    String apiKey = PublicApiKeyGenerator.generateApiKey();
+
+    assertNotNull(apiKey, "API key should not be null");
+    assertFalse(apiKey.isEmpty(), "API key should not be empty");
+  }
+}

--- a/server/src/test/java/org/tctalent/server/security/TcAuthenticationProviderTest.java
+++ b/server/src/test/java/org/tctalent/server/security/TcAuthenticationProviderTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2025 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.security;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UserDetailsService;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class TcAuthenticationProviderTest {
+
+  @Mock
+  private UserDetailsService userDetailsService;
+
+  @InjectMocks
+  private TcAuthenticationProvider tcAuthenticationProvider;
+
+  private TcAuthorizationToken tcAuthorizationToken;
+
+  private AutoCloseable mocks;
+
+  @BeforeEach
+  void setUp() {
+    mocks = MockitoAnnotations.openMocks(this);
+    tcAuthorizationToken = new TcAuthorizationToken("testuser", "password");
+  }
+
+  @AfterEach
+  void tearDown() throws Exception {
+    mocks.close();
+  }
+
+  @Test
+  void authenticate_throwsAuthenticationException_onFailure() {
+    when(userDetailsService.loadUserByUsername("testuser")).thenThrow(new BadCredentialsException("Invalid credentials"));
+    assertThrows(AuthenticationException.class, () -> tcAuthenticationProvider.authenticate(tcAuthorizationToken),
+        "authenticate should throw AuthenticationException on failure");
+    verify(userDetailsService).loadUserByUsername("testuser");
+  }
+
+  @Test
+  void supports_returnsTrue_forTcAuthorizationToken() {
+    boolean supports = tcAuthenticationProvider.supports(TcAuthorizationToken.class);
+    assertTrue(supports, "supports should return true for TcAuthorizationToken");
+  }
+}

--- a/server/src/test/java/org/tctalent/server/security/TcAuthorizationTokenTest.java
+++ b/server/src/test/java/org/tctalent/server/security/TcAuthorizationTokenTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2025 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.security;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+class TcAuthorizationTokenTest {
+
+  @Mock
+  private UserDetails principal;
+
+  @Mock
+  private Object credentials;
+
+  private TcAuthorizationToken token;
+
+  private AutoCloseable mocks;
+
+  @BeforeEach
+  void setUp() {
+    mocks = MockitoAnnotations.openMocks(this);
+  }
+
+  @AfterEach
+  void tearDown() throws Exception {
+    mocks.close();
+  }
+
+  @Test
+  void constructor_setsPrincipalAndCredentials() {
+    token = new TcAuthorizationToken(principal, credentials);
+
+    assertSame(principal, token.getPrincipal(), "Principal should match the constructor argument");
+    assertSame(credentials, token.getCredentials(), "Credentials should match the constructor argument");
+  }
+
+  @Test
+  void constructor_withNullPrincipalAndCredentials_setsCorrectly() {
+    token = new TcAuthorizationToken(null, null);
+
+    assertNull(token.getPrincipal(), "Principal should be null");
+    assertNull(token.getCredentials(), "Credentials should be null");
+  }
+
+  @Test
+  void constructor_setsEmptyAuthoritiesByDefault() {
+    token = new TcAuthorizationToken(principal, credentials);
+
+    Collection<? extends GrantedAuthority> authorities = token.getAuthorities();
+    assertNotNull(authorities, "Authorities should not be null");
+    assertTrue(authorities.isEmpty(), "Authorities should be empty by default");
+  }
+
+  @Test
+  void constructor_setsNotAuthenticatedByDefault() {
+    token = new TcAuthorizationToken(principal, credentials);
+
+    assertFalse(token.isAuthenticated(), "Token should not be authenticated by default");
+  }
+
+  @Test
+  void getName_returnsPrincipalName_whenPrincipalIsUserDetails() {
+    String username = "testuser";
+    when(principal.getUsername()).thenReturn(username);
+
+    token = new TcAuthorizationToken(principal, credentials);
+
+    assertEquals(username, token.getName(), "getName should return the principal's username");
+  }
+
+  @Test
+  void getName_returnsToString_whenPrincipalIsNotUserDetails() {
+    Object nonUserDetailsPrincipal = new Object();
+    token = new TcAuthorizationToken(nonUserDetailsPrincipal, credentials);
+
+    assertEquals(nonUserDetailsPrincipal.toString(), token.getName(),
+        "getName should return the principal's toString for non-UserDetails principal");
+  }
+
+  @Test
+  void getName_returnsEmptyString_whenPrincipalIsNull() {
+    token = new TcAuthorizationToken(null, credentials);
+
+    assertEquals("", token.getName(), "getName should return empty string when principal is null");
+  }
+}

--- a/server/src/test/java/org/tctalent/server/security/TcPasswordEncoderTest.java
+++ b/server/src/test/java/org/tctalent/server/security/TcPasswordEncoderTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2025 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.security;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class TcPasswordEncoderTest {
+
+  @Spy
+  private TcPasswordEncoder tcPasswordEncoder;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+    doCallRealMethod().when(tcPasswordEncoder).matches(any(), any());
+  }
+
+  @Test
+  void matches_withValidEncodedPassword_delegatesToSuper() {
+    String rawPassword = "password123";
+    String encodedPassword = new BCryptPasswordEncoder().encode(rawPassword);
+
+    doReturn(true).when((BCryptPasswordEncoder) tcPasswordEncoder).matches(rawPassword, encodedPassword);
+
+    boolean result = tcPasswordEncoder.matches(rawPassword, encodedPassword);
+
+    assertTrue(result);
+    verify((BCryptPasswordEncoder) tcPasswordEncoder).matches(rawPassword, encodedPassword);
+  }
+
+  @Test
+  void matches_withInvalidEncodedPassword_delegatesToSuper() {
+    String rawPassword = "password123";
+    String encodedPassword = new BCryptPasswordEncoder().encode("differentPassword");
+
+    doReturn(false).when((BCryptPasswordEncoder) tcPasswordEncoder).matches(rawPassword, encodedPassword);
+
+    boolean result = tcPasswordEncoder.matches(rawPassword, encodedPassword);
+
+    assertFalse(result);
+    verify((BCryptPasswordEncoder) tcPasswordEncoder).matches(rawPassword, encodedPassword);
+  }
+
+  @Test
+  void matches_withNullRawPassword_throwsIllegalArgumentException() {
+    CharSequence rawPassword = null;
+    String encodedPassword = new BCryptPasswordEncoder().encode("password123");
+
+    IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> {
+      tcPasswordEncoder.matches(rawPassword, encodedPassword);
+    });
+
+    assertEquals("rawPassword cannot be null", ex.getMessage());
+    verify((BCryptPasswordEncoder) tcPasswordEncoder).matches(rawPassword, encodedPassword);
+  }
+}

--- a/server/src/test/java/org/tctalent/server/security/TcUserDetailsServiceTest.java
+++ b/server/src/test/java/org/tctalent/server/security/TcUserDetailsServiceTest.java
@@ -1,0 +1,139 @@
+
+/*
+ * Copyright (c) 2025 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.security;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.tctalent.server.model.db.Role;
+import org.tctalent.server.model.db.User;
+import org.tctalent.server.repository.db.UserRepository;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class TcUserDetailsServiceTest {
+
+  @Mock
+  private UserRepository userRepository;
+
+  @InjectMocks
+  private TcUserDetailsService tcUserDetailsService;
+
+  private AutoCloseable mocks;
+  private ListAppender<ILoggingEvent> logAppender;
+  private Logger logger;
+  private Level originalLevel;
+
+  @BeforeEach
+  void setUp() {
+    mocks = MockitoAnnotations.openMocks(this);
+
+    logger = (Logger) LoggerFactory.getLogger(TcUserDetailsService.class);
+    originalLevel = logger.getLevel();
+    logger.setLevel(Level.DEBUG);
+    logAppender = new ListAppender<>();
+    logAppender.start();
+    logger.addAppender(logAppender);
+  }
+
+  @AfterEach
+  void tearDown() throws Exception {
+    logger.detachAppender(logAppender);
+    logAppender.stop();
+    logger.setLevel(originalLevel);
+
+    mocks.close();
+  }
+
+  @Test
+  void constructor_setsUserRepository() {
+    verifyNoInteractions(userRepository);
+  }
+
+  @Test
+  void loadUserByUsername_returnsTcUserDetails_forValidUsername() {
+    String username = "testuser";
+    User user = new User();
+    user.setId(1L);
+    user.setUsername(username);
+    user.setRole(Role.user);
+    when(userRepository.findByUsernameIgnoreCase(username)).thenReturn(user);
+
+    TcUserDetails result = tcUserDetailsService.loadUserByUsername(username);
+
+    assertNotNull(result, "Returned UserDetails should not be null");
+    assertEquals(user, result.getUser(), "User in TcUserDetails should match the found user");
+    verify(userRepository).findByUsernameIgnoreCase(username);
+
+    // Verify logging
+    List<ILoggingEvent> logs = logAppender.list;
+    assertEquals(1, logs.size(), "Expected one log message");
+    assertEquals(Level.DEBUG, logs.get(0).getLevel());
+    assertTrue(logs.get(0).getFormattedMessage().contains("Found user with ID 1 for username 'testuser'"));
+  }
+
+  @Test
+  void loadUserByUsername_throwsUsernameNotFoundException_forInvalidUsername() {
+    String username = "nonexistentuser";
+    when(userRepository.findByUsernameIgnoreCase(username)).thenReturn(null);
+
+    UsernameNotFoundException exception = assertThrows(UsernameNotFoundException.class,
+        () -> tcUserDetailsService.loadUserByUsername(username),
+        "Expected UsernameNotFoundException for invalid username");
+
+    assertEquals("No user found for: " + username, exception.getMessage());
+    verify(userRepository).findByUsernameIgnoreCase(username);
+
+    List<ILoggingEvent> logs = logAppender.list;
+    assertTrue(logs.isEmpty(), "No log messages expected when user is not found");
+  }
+
+  @Test
+  void loadUserByUsername_handlesCaseInsensitiveUsername() {
+    String username = "TestUser";
+    String usernameLower = "testuser";
+    User user = new User();
+    user.setId(2L);
+    user.setUsername(usernameLower);
+    user.setRole(Role.user);
+    when(userRepository.findByUsernameIgnoreCase(username)).thenReturn(user);
+
+    TcUserDetails result = tcUserDetailsService.loadUserByUsername(username);
+
+    assertNotNull(result, "Returned UserDetails should not be null");
+    assertEquals(user, result.getUser(), "User in TcUserDetails should match the found user");
+    verify(userRepository).findByUsernameIgnoreCase(username);
+
+    List<ILoggingEvent> logs = logAppender.list;
+    assertEquals(1, logs.size(), "Expected one log message");
+    assertEquals(Level.DEBUG, logs.get(0).getLevel());
+    assertTrue(logs.get(0).getFormattedMessage().contains("Found user with ID 2 for username 'TestUser'"));
+  }
+}

--- a/server/src/test/java/org/tctalent/server/security/TcUserDetailsTest.java
+++ b/server/src/test/java/org/tctalent/server/security/TcUserDetailsTest.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright (c) 2025 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.security;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.security.core.GrantedAuthority;
+import org.tctalent.server.model.db.Role;
+import org.tctalent.server.model.db.User;
+
+import java.util.Collection;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class TcUserDetailsTest {
+
+  @Mock
+  private User user;
+
+  private TcUserDetails tcUserDetails;
+
+  private AutoCloseable mocks;
+
+  @BeforeEach
+  void setUp() {
+    mocks = MockitoAnnotations.openMocks(this);
+    // Default stubbing for tests where role is irrelevant
+    when(user.getReadOnly()).thenReturn(false);
+    when(user.getRole()).thenReturn(Role.user);
+  }
+
+  @AfterEach
+  void tearDown() throws Exception {
+    mocks.close();
+  }
+
+  @Test
+  void constructor_withReadOnly_setsReadOnlyAuthority() {
+    when(user.getReadOnly()).thenReturn(true);
+    when(user.getRole()).thenReturn(Role.admin); // Role should be ignored if read-only
+
+    tcUserDetails = new TcUserDetails(user);
+
+    Collection<? extends GrantedAuthority> authorities = tcUserDetails.getAuthorities();
+    assertEquals(1, authorities.size(), "Should have exactly one authority");
+    assertTrue(authorities.stream().anyMatch(a -> a.getAuthority().equals("ROLE_READONLY")), "Authority should be ROLE_READONLY");
+  }
+
+  @Test
+  void constructor_withSystemAdminRole_setsSystemAdminAuthority() {
+    when(user.getReadOnly()).thenReturn(false);
+    when(user.getRole()).thenReturn(Role.systemadmin);
+
+    tcUserDetails = new TcUserDetails(user);
+
+    Collection<? extends GrantedAuthority> authorities = tcUserDetails.getAuthorities();
+    assertEquals(1, authorities.size(), "Should have exactly one authority");
+    assertTrue(authorities.stream().anyMatch(a -> a.getAuthority().equals("ROLE_SYSTEMADMIN")), "Authority should be ROLE_SYSTEMADMIN");
+  }
+
+  @Test
+  void constructor_withAdminRole_setsAdminAuthority() {
+    when(user.getReadOnly()).thenReturn(false);
+    when(user.getRole()).thenReturn(Role.admin);
+
+    tcUserDetails = new TcUserDetails(user);
+
+    Collection<? extends GrantedAuthority> authorities = tcUserDetails.getAuthorities();
+    assertEquals(1, authorities.size(), "Should have exactly one authority");
+    assertTrue(authorities.stream().anyMatch(a -> a.getAuthority().equals("ROLE_ADMIN")), "Authority should be ROLE_ADMIN");
+  }
+
+  @Test
+  void constructor_withPartnerAdminRole_setsPartnerAdminAuthority() {
+    when(user.getReadOnly()).thenReturn(false);
+    when(user.getRole()).thenReturn(Role.partneradmin);
+
+    tcUserDetails = new TcUserDetails(user);
+
+    Collection<? extends GrantedAuthority> authorities = tcUserDetails.getAuthorities();
+    assertEquals(1, authorities.size(), "Should have exactly one authority");
+    assertTrue(authorities.stream().anyMatch(a -> a.getAuthority().equals("ROLE_PARTNERADMIN")), "Authority should be ROLE_PARTNERADMIN");
+  }
+
+  @Test
+  void constructor_withSemiLimitedRole_setsSemiLimitedAuthority() {
+    when(user.getReadOnly()).thenReturn(false);
+    when(user.getRole()).thenReturn(Role.semilimited);
+
+    tcUserDetails = new TcUserDetails(user);
+
+    Collection<? extends GrantedAuthority> authorities = tcUserDetails.getAuthorities();
+    assertEquals(1, authorities.size(), "Should have exactly one authority");
+    assertTrue(authorities.stream().anyMatch(a -> a.getAuthority().equals("ROLE_SEMILIMITED")), "Authority should be ROLE_SEMILIMITED");
+  }
+
+  @Test
+  void constructor_withLimitedRole_setsLimitedAuthority() {
+    when(user.getReadOnly()).thenReturn(false);
+    when(user.getRole()).thenReturn(Role.limited);
+
+    tcUserDetails = new TcUserDetails(user);
+
+    Collection<? extends GrantedAuthority> authorities = tcUserDetails.getAuthorities();
+    assertEquals(1, authorities.size(), "Should have exactly one authority");
+    assertTrue(authorities.stream().anyMatch(a -> a.getAuthority().equals("ROLE_LIMITED")), "Authority should be ROLE_LIMITED");
+  }
+
+  @Test
+  void constructor_withUserRole_setsUserAuthority() {
+    when(user.getReadOnly()).thenReturn(false);
+    when(user.getRole()).thenReturn(Role.user);
+
+    tcUserDetails = new TcUserDetails(user);
+
+    Collection<? extends GrantedAuthority> authorities = tcUserDetails.getAuthorities();
+    assertEquals(1, authorities.size(), "Should have exactly one authority");
+    assertTrue(authorities.stream().anyMatch(a -> a.getAuthority().equals("ROLE_USER")), "Authority should be ROLE_USER");
+  }
+
+  @Test
+  void getUser_returnsUser() {
+    tcUserDetails = new TcUserDetails(user);
+
+    assertSame(user, tcUserDetails.getUser(), "getUser should return the same User instance");
+  }
+
+  @Test
+  void setUser_updatesUser() {
+    tcUserDetails = new TcUserDetails(user);
+    User newUser = mock(User.class);
+    when(newUser.getReadOnly()).thenReturn(false);
+    when(newUser.getRole()).thenReturn(Role.user);
+
+    tcUserDetails.setUser(newUser);
+
+    assertSame(newUser, tcUserDetails.getUser(), "setUser should update the User instance");
+  }
+
+  @Test
+  void getPassword_returnsUserPassword() {
+    String password = "encryptedPassword";
+    when(user.getPasswordEnc()).thenReturn(password);
+
+    tcUserDetails = new TcUserDetails(user);
+
+    assertEquals(password, tcUserDetails.getPassword(), "getPassword should return the user's encrypted password");
+  }
+
+  @Test
+  void getUsername_returnsUserUsername() {
+    String username = "testuser";
+    when(user.getUsername()).thenReturn(username);
+
+    tcUserDetails = new TcUserDetails(user);
+
+    assertEquals(username, tcUserDetails.getUsername(), "getUsername should return the user's username");
+  }
+
+  @Test
+  void isAccountNonExpired_returnsTrue() {
+    tcUserDetails = new TcUserDetails(user);
+
+    assertTrue(tcUserDetails.isAccountNonExpired(), "isAccountNonExpired should always return true");
+  }
+
+  @Test
+  void isAccountNonLocked_returnsTrue() {
+    tcUserDetails = new TcUserDetails(user);
+
+    assertTrue(tcUserDetails.isAccountNonLocked(), "isAccountNonLocked should always return true");
+  }
+
+  @Test
+  void isCredentialsNonExpired_returnsTrue() {
+    tcUserDetails = new TcUserDetails(user);
+
+    assertTrue(tcUserDetails.isCredentialsNonExpired(), "isCredentialsNonExpired should always return true");
+  }
+
+  @Test
+  void isEnabled_returnsTrue() {
+    tcUserDetails = new TcUserDetails(user);
+
+    assertTrue(tcUserDetails.isEnabled(), "isEnabled should always return true");
+  }
+
+  @Test
+  void constructor_withNullUser_throwsNullPointerException() {
+    assertThrows(NullPointerException.class, () -> new TcUserDetails(null),
+        "Constructor should throw NullPointerException for null User due to @NotNull");
+  }
+}


### PR DESCRIPTION
Greatly improved test coverage for the **org.tctalent.server.security** package, increasing from 9% to **82%**. Added comprehensive unit tests for critical components, including TcUserDetailsService, JwtAuthenticationFilter, and related classes, covering authentication, JWT validation, exception handling, and logging scenarios. Leveraging JaCoCo was really helpful, as its reports clearly highlighted classes needing tests, enabling targeted improvements. 