### PR TITLE
2195 old completed candidate opps being mistakenly set to notfitforrole

### DIFF
--- a/server/src/main/java/org/tctalent/server/service/db/CandidateOpportunityService.java
+++ b/server/src/main/java/org/tctalent/server/service/db/CandidateOpportunityService.java
@@ -43,7 +43,11 @@ public interface CandidateOpportunityService {
      * Creates or updates Contact records on Salesforce for the given candidates and, if sfJobOpp
      * is not null, indicating that these candidates are associated with a job opportunity,
      * this will also create/update the associated candidate opportunities associated with that
-     * job on both Salesforce and on the local database.
+     * job on both Salesforce and on the TC.
+     * <p/>
+     * Note that it may be necessary to create contact records on Salesforce because Salesforce
+     * is designed to only store contact records for candidate who have opportunities - not ALL
+     * contacts registered on the TC.
      *
      * @param candidates Candidates to update
      * @param sfJobOpp If not null candidate opportunities are created/updated

--- a/server/src/main/java/org/tctalent/server/service/db/impl/JobServiceImpl.java
+++ b/server/src/main/java/org/tctalent/server/service/db/impl/JobServiceImpl.java
@@ -1067,9 +1067,9 @@ public class JobServiceImpl implements JobService {
                     if (originalStages.size() == 1) {
                         s = originalStages.iterator().next().toString();
                     } else {
-                        s = "one of the following " + originalStages.stream()
+                        s = "one of the following (" + originalStages.stream()
                             .map(CandidateOpportunityStage::toString)
-                            .collect(Collectors.joining(", "));
+                            .collect(Collectors.joining(", ")) + ")";
                     }
                     params.setClosingComments("Closed because the candidate's stage was " + s +
                         " when the job opportunity closed as " + jobCloseStage.toString());

--- a/server/src/test/java/org/tctalent/server/data/SalesforceJobOppTestData.java
+++ b/server/src/test/java/org/tctalent/server/data/SalesforceJobOppTestData.java
@@ -95,7 +95,6 @@ public class SalesforceJobOppTestData {
         job.setCreatedDate(OffsetDateTime.parse("2023-10-30T12:30:00+02:00"));
         job.setUpdatedBy(getAuditUser());
         job.setUpdatedDate(OffsetDateTime.parse("2023-10-30T12:30:00+02:00"));
-        job.setCandidateOpportunities(Set.of(getChildCandidateOpp(job)));
         return job;
     }
 
@@ -128,11 +127,12 @@ public class SalesforceJobOppTestData {
         return joi;
     }
 
-    private static CandidateOpportunity getChildCandidateOpp(SalesforceJobOpp job) {
+    public static CandidateOpportunity getChildCandidateOpp(
+        long id, SalesforceJobOpp job, CandidateOpportunityStage stage ) {
         CandidateOpportunity co = new CandidateOpportunity();
-        co.setId(99L);
+        co.setId(id);
         co.setJobOpp(job);
-        co.setStage(CandidateOpportunityStage.cvReview);
+        co.setStage(stage);
         co.setNextStep("Review CVs");
         co.setNextStepDueDate(LocalDate.parse("2020-01-01"));
         co.setCandidate(getCandidate());


### PR DESCRIPTION
This puts more informative information into the candidate notes of when cases are auto closed - including the original case stages before they were closed. 