### PR TITLE
2328 public api should support fetching creating and modification of lists

### DIFF
--- a/server/src/main/java/org/tctalent/server/api/admin/IManyToManyApi.java
+++ b/server/src/main/java/org/tctalent/server/api/admin/IManyToManyApi.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 
+import java.util.Set;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -162,6 +163,20 @@ public interface IManyToManyApi<SEARCH, CONTENT> extends ITalentCatalogWebApi {
             @PathVariable("id") long masterId, @Valid @RequestBody SEARCH request)
             throws NoSuchObjectException {
         throw new NotImplementedException(this.getClass(), "searchPaged");
+    }
+
+    /**
+     * Returns the public IDs of slave records associated with the given master public ID.
+     * <p/>
+     * @param masterPublicId public ID of the master record whose slave record public IDs we want
+     * @return Set of public IDs of slave records
+     * @throws NoSuchObjectException if masterPublicId is unknown
+     */
+    @GetMapping("public/{publicId}/public-ids")
+    default @NotNull Set<String> fetchPublicIds(
+            @PathVariable("publicId") String masterPublicId)
+            throws NoSuchObjectException {
+        throw new NotImplementedException(this.getClass(), "fetchPublicIds");
     }
 
 }

--- a/server/src/main/java/org/tctalent/server/api/admin/SavedListCandidateAdminApi.java
+++ b/server/src/main/java/org/tctalent/server/api/admin/SavedListCandidateAdminApi.java
@@ -196,6 +196,11 @@ public class SavedListCandidateAdminApi implements
         return builder.buildPage(candidates);
     }
 
+    @Override
+    public @NotNull Set<String> fetchPublicIds(String publicListId) throws NoSuchObjectException {
+        return savedListService.fetchCandidatePublicIds(publicListId);
+    }
+
     /**
      * Creates a new SavedList and initializes it's contents.
      * <p>

--- a/server/src/main/java/org/tctalent/server/repository/db/SavedListRepository.java
+++ b/server/src/main/java/org/tctalent/server/repository/db/SavedListRepository.java
@@ -78,4 +78,14 @@ public interface SavedListRepository extends CacheEvictingRepository<SavedList, 
     @Query(value = "select csl.candidate_id from candidate_saved_list csl "
         + "where csl.saved_list_id in (:listIds)", nativeQuery = true)
     Set<Long> findUnionOfCandidates(@Param("listIds") List<Long> listIds);
+
+    @Query(value = """
+        select c.public_id
+        from candidate_saved_list csl
+        join saved_list sl on csl.saved_list_id = sl.id
+        join candidate c on csl.candidate_id = c.id
+        where sl.public_id in (:publicListIds)
+        """, nativeQuery = true)
+    Set<String> findCandidatePublicIdsBySavedListPublicIds(@Param("publicListIds") List<String> publicListIds);
+
 }

--- a/server/src/main/java/org/tctalent/server/service/db/SavedListService.java
+++ b/server/src/main/java/org/tctalent/server/service/db/SavedListService.java
@@ -251,6 +251,15 @@ public interface SavedListService {
     @Nullable
     Set<Long> fetchIntersectionCandidateIds(@Nullable List<Long> listIds);
 
+    /**
+     * Fetches the public ids of the intersection of all candidates in all the given lists, note
+     * that the list ids provided must be the public ids of the lists, not the internal ids.
+     *
+     * @param publicListIds public ids of saved lists
+     * @return public ids of candidates common to all the lists, or null if input is null
+     */
+    @Nullable
+    Set<String> fetchIntersectionCandidatePublicIds(@Nullable List<String> publicListIds);
 
     /**
      * Get the SavedList with the given id.

--- a/server/src/main/java/org/tctalent/server/service/db/SavedListService.java
+++ b/server/src/main/java/org/tctalent/server/service/db/SavedListService.java
@@ -216,12 +216,32 @@ public interface SavedListService {
     Set<Long> fetchCandidateIds(long listId);
 
     /**
+     * Fetches the public ids of candidates in the given list, note that the list id provided
+     * must be the public id of the list, not the internal id.
+     *
+     * @param publicListId public Id of list
+     * @return public Ids of candidates contained in the list
+     */
+    @NonNull
+    Set<String> fetchCandidatePublicIds(String publicListId);
+
+    /**
      * Fetches the ids of the union of all candidates in all the given lists
      * @param listIds Ids of lists
      * @return Ids of candidates contained in the lists or null if ids is null
      */
     @Nullable
     Set<Long> fetchUnionCandidateIds(@Nullable List<Long> listIds);
+
+    /**
+     * Fetches the public ids of the union of all candidates in all the given lists, note that the
+     * list ids provided must be the public ids of the lists, not the internal ids.
+     *
+     * @param publicListIds public ids of saved lists
+     * @return public ids of candidates contained in the lists, or null if input is null
+     */
+    @Nullable
+    Set<String> fetchUnionCandidatePublicIds(@Nullable List<String> publicListIds);
 
     /**
      * Fetches the ids of candidates which appear in all the given lists

--- a/server/src/main/java/org/tctalent/server/service/db/impl/SavedListServiceImpl.java
+++ b/server/src/main/java/org/tctalent/server/service/db/impl/SavedListServiceImpl.java
@@ -1071,6 +1071,15 @@ public class SavedListServiceImpl implements SavedListService {
         return savedListRepository.findUnionOfCandidates(Collections.singletonList(listId));
     }
 
+    @NonNull
+    @Override
+    public Set<String> fetchCandidatePublicIds(String publicListId) {
+        return savedListRepository
+            .findCandidatePublicIdsBySavedListPublicIds(
+                Collections.singletonList(publicListId)
+            );
+    }
+
     @Nullable
     @Override
     public Set<Long> fetchUnionCandidateIds(@Nullable List<Long> listIds) {
@@ -1079,6 +1088,21 @@ public class SavedListServiceImpl implements SavedListService {
             candidateIds = null;
         } else {
             candidateIds = savedListRepository.findUnionOfCandidates(listIds);
+        }
+        return candidateIds;
+    }
+
+    @Nullable
+    @Override
+    public Set<String> fetchUnionCandidatePublicIds(@Nullable List<String> publicListIds) {
+        Set<String> candidateIds;
+        if (publicListIds == null) {
+            candidateIds = null;
+        } else {
+            candidateIds = savedListRepository
+                .findCandidatePublicIdsBySavedListPublicIds(
+                    publicListIds
+                );
         }
         return candidateIds;
     }

--- a/server/src/main/java/org/tctalent/server/service/db/impl/SavedListServiceImpl.java
+++ b/server/src/main/java/org/tctalent/server/service/db/impl/SavedListServiceImpl.java
@@ -1130,6 +1130,28 @@ public class SavedListServiceImpl implements SavedListService {
     }
 
     @Nullable
+    @Override
+    public Set<String> fetchIntersectionCandidatePublicIds(@Nullable List<String> publicListIds) {
+        Set<String> candidatePublicIds;
+        if (publicListIds == null) {
+            candidatePublicIds = null;
+        } else {
+            final Iterator<String> iterator = publicListIds.iterator();
+            if (iterator.hasNext()) {
+                candidatePublicIds = fetchCandidatePublicIds(iterator.next());
+                while (iterator.hasNext() && !candidatePublicIds.isEmpty()) {
+                    String nextPublicListId = iterator.next();
+                    candidatePublicIds.retainAll(fetchCandidatePublicIds(nextPublicListId));
+                }
+            } else {
+                // No lists provided. Return empty set of candidate public ids.
+                candidatePublicIds = new HashSet<>();
+            }
+        }
+        return candidatePublicIds;
+    }
+
+    @Nullable
     public SavedList fetchSourceList(UpdateSavedListContentsRequest request)
             throws NoSuchObjectException {
         SavedList sourceList = null;

--- a/server/src/main/java/org/tctalent/server/service/db/impl/SavedListServiceImpl.java
+++ b/server/src/main/java/org/tctalent/server/service/db/impl/SavedListServiceImpl.java
@@ -987,13 +987,11 @@ public class SavedListServiceImpl implements SavedListService {
             //For job lists where publishClosedOpps is false, filter out closed opps (unless they
             //are "won" - we always publish won opps, which are a special kind of closed).
             candidates = savedList.getCandidates().stream().filter(
-                candidate -> {
-                    return candidate.getCandidateOpportunities().stream()
-                        .anyMatch(opp -> {
-                            return opp.getJobOpp().getId().equals(sfJob.getId())
-                                && (opp.isWon() || !opp.isClosed());
-                        });
-                }
+                candidate ->
+                    candidate.getCandidateOpportunities()
+                    .stream()
+                    .anyMatch(opp -> opp.getJobOpp().getId().equals(sfJob.getId())
+                            && (opp.isWon() || !opp.isClosed()))
             ).toList();
         } else {
             //Publish all for non job lists, or job lists where we have been asked to publish all

--- a/server/src/main/python/FetchCandidateDataFromMongo.py
+++ b/server/src/main/python/FetchCandidateDataFromMongo.py
@@ -22,7 +22,7 @@ Prerequisites
 
    $ python3 -m venv venv
    $ source venv/bin/activate
-   $ pip install pymongo
+   $ pip install pymongo requests
 
 2. Configure the connection settings in `main()`
 

--- a/server/src/main/python/FetchCandidateDataFromMongo.py
+++ b/server/src/main/python/FetchCandidateDataFromMongo.py
@@ -26,9 +26,12 @@ Prerequisites
 
 2. Configure the connection settings in `main()`
 
-3. Run the script:
+3. Run the script, redirecting output to a file and errors to a log:
 
    $ python3 FetchCandidateDataFromMongo.py > candidates.json 2> missing_ids.log
+
+   - candidates.json: will contain a JSON array of all found candidate documents.
+   - missing_ids.log: will list any `publicId` values that weren’t found in MongoDB.
 """
 
 

--- a/server/src/main/python/FetchCandidateDataFromMongo.py
+++ b/server/src/main/python/FetchCandidateDataFromMongo.py
@@ -113,7 +113,7 @@ def main():
   tc_base_url    = "http://localhost:8080/api/admin"
   tc_username    = "appAnonDatabaseService"
   tc_password    = "12345678"
-  public_list_id = "7201"
+  public_list_id = "a2JqM7-7SQ-uy7pZnX0S8w"
 
   # ┌───────────────────────────────────────────────────────────────────────────┐
   # │           FETCH & SAVE THE PUBLIC IDs CSV FOR MONGO LOOKUP                │

--- a/server/src/main/python/FetchCandidateDataFromMongo.py
+++ b/server/src/main/python/FetchCandidateDataFromMongo.py
@@ -26,7 +26,8 @@ Prerequisites
 
 2. Configure the connection settings in `main()`
 
-3. Run the script, redirecting output to a file and errors to a log:
+3. Run the script with the public list ID as an argument, redirecting output to
+   a file and errors to a log:
 
    $ python3 FetchCandidateDataFromMongo.py > candidates.json 2> missing_ids.log
 
@@ -35,6 +36,7 @@ Prerequisites
 """
 
 
+import argparse
 import csv
 import sys
 import requests
@@ -110,13 +112,22 @@ def stream_documents_to_stdout(file_path, collection):
 
 
 def main():
+  parser = argparse.ArgumentParser(
+      description="Fetch candidate docs given a TC public list ID"
+  )
+  parser.add_argument(
+      'public_list_id',
+      help='The public list ID to fetch candidate public IDs'
+  )
+  args = parser.parse_args()
+
   # ┌───────────────────────────────────────────────────────────────────────────┐
   # │              CONFIGURE TC SERVICE & LIST ID TO PULL                       │
   # └───────────────────────────────────────────────────────────────────────────┘
   tc_base_url    = "http://localhost:8080/api/admin"
   tc_username    = "appAnonDatabaseService"
   tc_password    = "12345678"
-  public_list_id = "a2JqM7-7SQ-uy7pZnX0S8w"
+  public_list_id = args.public_list_id
 
   # ┌───────────────────────────────────────────────────────────────────────────┐
   # │           FETCH & SAVE THE PUBLIC IDs CSV FOR MONGO LOOKUP                │

--- a/server/src/main/python/FetchCandidateDataFromMongo.py
+++ b/server/src/main/python/FetchCandidateDataFromMongo.py
@@ -66,7 +66,7 @@ def generate_public_ids_file(
   GET /public/{publicListId}/public-ids using the JWT bearer token,
   then write the returned IDs (one per line) into output_csv with a header.
   """
-  url = f"{base_url}/public/{public_list_id}/public-ids"
+  url = f"{base_url}/saved-list-candidate/public/{public_list_id}/public-ids"
   headers = {"Authorization": auth_header}
   resp = requests.get(url, headers=headers)
   resp.raise_for_status()

--- a/server/src/test/java/org/tctalent/server/api/admin/SavedListCandidateAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/SavedListCandidateAdminApiTest.java
@@ -40,7 +40,9 @@ import java.io.InputStream;
 import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -410,4 +412,29 @@ class SavedListCandidateAdminApiTest extends ApiTestBase {
         verify(savedListService).mergeSavedList(anyLong(),
             any(UpdateExplicitSavedListContentsRequest.class));
     }
+
+    @Test
+    void fetchPublicIds() throws Exception {
+        String publicListId = "abc123";
+        Set<String> candidatePublicIds = new LinkedHashSet<>(List.of("cand-001", "cand-002", "cand-003"));
+
+        given(savedListService.fetchCandidatePublicIds(publicListId))
+            .willReturn(candidatePublicIds);
+
+        mockMvc.perform(
+                get(BASE_PATH + "/public/" + publicListId + "/public-ids")
+                    .with(csrf())
+                    .header("Authorization", "Bearer jwt-token")
+                    .accept(MediaType.APPLICATION_JSON)
+            )
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$", hasSize(3)))
+            .andExpect(jsonPath("$[0]", is("cand-001")))
+            .andExpect(jsonPath("$[1]", is("cand-002")))
+            .andExpect(jsonPath("$[2]", is("cand-003")));
+
+        verify(savedListService).fetchCandidatePublicIds(publicListId);
+    }
+
 }


### PR DESCRIPTION
This PR - 

- adds the ability to fetch candidate public ids for a given saved list by its public id
- updates the relevant controller and service methods
- adds a fetchPublicIds method to the IManyToMany interface
- adds fetchUnionCandidatePublicIds and fetchIntersectionCandidatePublicIds methods to saved list service
- includes controller unit test
- Resolves a couple of minor IntelliJ warnings

Also updates the FetchCandidateData Python script to - 

- support fetching candidate public IDs by list ID before streaming Mongo docs 
- includes login, public-IDs CSV generation, and parameterised public list ID