### PR TITLE
Hotfix 2.4.0 2196 publishing lists that exceed the google sheet api size limits silently fails

### DIFF
--- a/server/src/main/java/org/tctalent/server/service/db/impl/GoogleSheetPublisherServiceImpl.java
+++ b/server/src/main/java/org/tctalent/server/service/db/impl/GoogleSheetPublisherServiceImpl.java
@@ -291,12 +291,28 @@ public class GoogleSheetPublisherServiceImpl implements DocPublisherService {
             .message(res2.getReplies().size() + " batch update responses received")
             .logInfo();
 
+        //Validate the number of candidate rows to be written fits within the bounds of the named data range.
+        //Throws an IOException which the user will see in the admin portal if the range is too small.
+        validateDataRangeCapacity(dataRangeName, dataRange, nRowsData);
+
         //File is already public - ie viewable by anyone with the link - because of the folder where
         //it is located
         //Setting it public when it is already causes Google to throw a permissions error
 
         return file.getUrl();
 
+    }
+
+    static void validateDataRangeCapacity(String rangeName, GridRange range, int nRowsData)
+        throws IOException {
+
+        int availableDataRows = range.getEndRowIndex() - range.getStartRowIndex();
+
+        if (nRowsData > availableDataRows) {
+            throw new IOException("Attempting to publish too many candidates (" + (nRowsData - 1)
+                + ") to the sheet " + rangeName + " which can hold a maximum of "
+                + (availableDataRows - 1) + " rows.");
+        }
     }
 
     @Override

--- a/server/src/main/java/org/tctalent/server/service/db/impl/GoogleSheetPublisherServiceImpl.java
+++ b/server/src/main/java/org/tctalent/server/service/db/impl/GoogleSheetPublisherServiceImpl.java
@@ -107,6 +107,11 @@ public class GoogleSheetPublisherServiceImpl implements DocPublisherService {
         throws GeneralSecurityException, IOException {
 
         //Load candidates from database into persistence context
+        LogBuilder.builder(log)
+            .action("populatePublishedDoc")
+            .message("Loading " + candidateIds.size() +" candidates from database into persistence context")
+            .logInfo();
+
         List<Candidate> candidates = new ArrayList<>();
         for (Long candidateId : candidateIds) {
             final Candidate candidate = candidateService.getCandidate(candidateId);
@@ -117,8 +122,17 @@ public class GoogleSheetPublisherServiceImpl implements DocPublisherService {
         }
 
         //Create all candidate folders (and subfolders) as needed.
+        int count = 0;
         for (Candidate candidate : candidates) {
             candidateService.createCandidateFolder(candidate.getId());
+            count++;
+
+            if (count % 50 == 0 || count == candidates.size()) {
+                LogBuilder.builder(log)
+                    .action("populatePublishedDoc")
+                    .message("Created folders for " + count + " out of " + candidates.size() + " candidates")
+                    .logInfo();
+            }
         }
 
         //This is what will be used to create the published doc

--- a/server/src/test/java/org/tctalent/server/service/db/impl/GoogleSheetPublisherServiceImplTest.java
+++ b/server/src/test/java/org/tctalent/server/service/db/impl/GoogleSheetPublisherServiceImplTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2025 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.service.db.impl;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.tctalent.server.service.db.impl.GoogleSheetPublisherServiceImpl.validateDataRangeCapacity;
+
+import com.google.api.services.sheets.v4.model.GridRange;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+class GoogleSheetPublisherServiceImplTest {
+
+  @Test
+  public void throwsIfTooManyRows() {
+    GridRange grid = new GridRange()
+        .setStartRowIndex(5)
+        .setEndRowIndex(10); // 5 rows max
+
+    assertThrows(IOException.class, () -> {
+      validateDataRangeCapacity("Main!B6:W10", grid, 6); // trying to write 6 rows
+    });
+  }
+
+  @Test
+  public void doesNotThrowIfFitsExactly() {
+    GridRange grid = new GridRange()
+        .setStartRowIndex(5)
+        .setEndRowIndex(10); // 5 rows
+
+    assertDoesNotThrow(() -> {
+      validateDataRangeCapacity("Main!B6:W10", grid, 5);
+    });
+  }
+
+}


### PR DESCRIPTION
Hotfix PR that applies feature branch #2196 to master.

Applies 3 commits, affecting 2 files:

GoogleSheetPublisherServiceImpl and the corresponding unit test GoogleSheetPublisherServiceImplTest