### PR TITLE
Hotfix 2.3.0 2435 namenumber quick search

### DIFF
--- a/server/src/main/java/org/tctalent/server/repository/db/CandidateRepository.java
+++ b/server/src/main/java/org/tctalent/server/repository/db/CandidateRepository.java
@@ -201,11 +201,13 @@ public interface CandidateRepository extends CacheEvictingRepository<Candidate, 
 
                                          Pageable pageable);
 
-    @Query(" select distinct c from Candidate c left join c.user u "
-        + " where lower(u.firstName) like lower(:candidateName)"
-        + " or lower(u.lastName) like lower(:candidateName)"
-        + excludeDeleted
-        + sourceCountryRestriction)
+    @Query("""
+      select distinct c 
+      from Candidate c 
+      left join c.user u 
+      where lower(u.firstName) like lower(:candidateName)
+      or lower(u.lastName) like lower(:candidateName) 
+      """ + excludeDeleted + sourceCountryRestriction)
     Page<Candidate> searchCandidateName(@Param("candidateName") String candidateName,
         @Param("userSourceCountries") Set<Country> userSourceCountries,
         Pageable pageable);

--- a/server/src/main/java/org/tctalent/server/repository/db/CandidateRepository.java
+++ b/server/src/main/java/org/tctalent/server/repository/db/CandidateRepository.java
@@ -206,7 +206,8 @@ public interface CandidateRepository extends CacheEvictingRepository<Candidate, 
       from Candidate c 
       left join c.user u 
       where lower(u.firstName) like lower(:candidateName)
-      or lower(u.lastName) like lower(:candidateName) 
+         or lower(u.lastName) like lower(:candidateName) 
+         or lower(concat(u.firstName, ' ', u.lastName)) like lower(:candidateName)
       """ + excludeDeleted + sourceCountryRestriction)
     Page<Candidate> searchCandidateName(@Param("candidateName") String candidateName,
         @Param("userSourceCountries") Set<Country> userSourceCountries,

--- a/server/src/main/java/org/tctalent/server/repository/db/CandidateRepository.java
+++ b/server/src/main/java/org/tctalent/server/repository/db/CandidateRepository.java
@@ -208,6 +208,7 @@ public interface CandidateRepository extends CacheEvictingRepository<Candidate, 
       where lower(u.firstName) like lower(:candidateName)
          or lower(u.lastName) like lower(:candidateName) 
          or lower(concat(u.firstName, ' ', u.lastName)) like lower(:candidateName)
+         or lower(concat(u.lastName, ' ', u.firstName)) like lower(:candidateName)
       """ + excludeDeleted + sourceCountryRestriction)
     Page<Candidate> searchCandidateName(@Param("candidateName") String candidateName,
         @Param("userSourceCountries") Set<Country> userSourceCountries,


### PR DESCRIPTION
Hotfix PR to resolve an issue with fast name search.

It does not include the related Flyways migration - v365 - which applies the pg_trgm extension and creates two indices. This should be done manually. The branch issue documents the steps required.