### PR TITLE
305 keep url on jwt token expired

### DIFF
--- a/ui/admin-portal/src/app/app.module.ts
+++ b/ui/admin-portal/src/app/app.module.ts
@@ -578,6 +578,7 @@ import {
 import {SharedModule} from "./shared/shared.module";
 import {ChatMuteToggleButtonComponent} from './components/chat/chat-mute-toggle-button/chat-mute-toggle-button.component';
 import {ViewPrivacyPolicyInfoComponent} from './components/candidates/view/privacy-policy-info/view-privacy-policy-info.component';
+import {AuthExpiryInterceptor} from "./services/auth-expiry.interceptor";
 
 @NgModule({
   declarations: [
@@ -944,6 +945,7 @@ import {ViewPrivacyPolicyInfoComponent} from './components/candidates/view/priva
   providers: [
     {provide: HTTP_INTERCEPTORS, useClass: JwtInterceptor, multi: true},
     {provide: HTTP_INTERCEPTORS, useClass: ErrorInterceptor, multi: true},
+    {provide: HTTP_INTERCEPTORS, useClass: AuthExpiryInterceptor, multi: true},
     {provide: NgbDateAdapter, useClass: CustomDateAdapter},
     {provide: NgbDateParserFormatter, useClass: CustomDateParserFormatter},
     {

--- a/ui/admin-portal/src/app/services/auth-expiry.interceptor.spec.ts
+++ b/ui/admin-portal/src/app/services/auth-expiry.interceptor.spec.ts
@@ -1,8 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import {
   HTTP_INTERCEPTORS,
-  HttpClient,
-  HttpErrorResponse
+  HttpClient
 } from '@angular/common/http';
 import {
   HttpClientTestingModule,
@@ -82,18 +81,16 @@ describe('AuthExpiryInterceptor', () => {
     expect(routerMock.navigate).not.toHaveBeenCalled();
   });
 
-  it('does nothing on non-401 errors', (done) => {
+  it('does nothing on non-401 errors', () => {
     http.get('/api/test').subscribe({
       next: () => fail('expected error'),
-      error: (err: HttpErrorResponse) => {
-        expect(err.status).toBe(403);
-        expect(authMock.logout).not.toHaveBeenCalled();
-        expect(routerMock.navigate).not.toHaveBeenCalled();
-        done();
-      }
+      error: () => { /* ignore error shape */ }
     });
 
     const req = httpMock.expectOne('/api/test');
-    req.flush('Forbidden', { status: 403, statusText: 'Forbidden' });
+    req.flush({}, { status: 403, statusText: 'Forbidden' });
+
+    expect(authMock.logout).not.toHaveBeenCalled();
+    expect(routerMock.navigate).not.toHaveBeenCalled();
   });
 });

--- a/ui/admin-portal/src/app/services/auth-expiry.interceptor.spec.ts
+++ b/ui/admin-portal/src/app/services/auth-expiry.interceptor.spec.ts
@@ -66,21 +66,19 @@ describe('AuthExpiryInterceptor', () => {
     req.flush('Unauthorized', { status: 401, statusText: 'Unauthorized' });
   });
 
-  it('does not redirect if already on login page (still logs out)', (done) => {
+  it('does not redirect if already on login page (still logs out)', () => {
     routerMock.url = '/login/reset-password';
 
     http.get('/api/test').subscribe({
-      next: () => fail('expected error'),
-      error: (err: HttpErrorResponse) => {
-        expect(err.status).toBe(401);
-        expect(authMock.logout).toHaveBeenCalled();
-        expect(routerMock.navigate).not.toHaveBeenCalled();
-        done();
-      }
+      next: () => fail('expected 401'),
+      error: () => { /* ignore */ }
     });
 
     const req = httpMock.expectOne('/api/test');
-    req.flush('Unauthorized', { status: 401, statusText: 'Unauthorized' });
+    req.flush(null, { status: 401, statusText: 'Unauthorized' });
+
+    expect(authMock.logout).toHaveBeenCalledTimes(1);
+    expect(routerMock.navigate).not.toHaveBeenCalled();
   });
 
   it('does nothing on non-401 errors', (done) => {

--- a/ui/admin-portal/src/app/services/auth-expiry.interceptor.spec.ts
+++ b/ui/admin-portal/src/app/services/auth-expiry.interceptor.spec.ts
@@ -1,0 +1,100 @@
+import { TestBed } from '@angular/core/testing';
+import {
+  HTTP_INTERCEPTORS,
+  HttpClient,
+  HttpErrorResponse
+} from '@angular/common/http';
+import {
+  HttpClientTestingModule,
+  HttpTestingController
+} from '@angular/common/http/testing';
+import { Router } from '@angular/router';
+import { AuthExpiryInterceptor } from './auth-expiry.interceptor';
+import { AuthenticationService } from './authentication.service';
+
+describe('AuthExpiryInterceptor', () => {
+  let http: HttpClient;
+  let httpMock: HttpTestingController;
+
+  // simple spies
+  let routerMock: any;
+  let authMock: any;
+
+  beforeEach(() => {
+    routerMock = {
+      url: '/admin-portal/list/6233',
+      navigate: jasmine.createSpy('navigate')
+    };
+    authMock = {
+      logout: jasmine.createSpy('logout')
+    };
+
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [
+        { provide: Router, useValue: routerMock },
+        { provide: AuthenticationService, useValue: authMock },
+        { provide: HTTP_INTERCEPTORS, useClass: AuthExpiryInterceptor, multi: true },
+      ],
+    });
+
+    http = TestBed.inject(HttpClient);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+    routerMock.navigate.calls.reset();
+    authMock.logout.calls.reset();
+  });
+
+  it('redirects to /login with returnUrl and logs out on 401', (done) => {
+    http.get('/api/test').subscribe({
+      next: () => fail('expected error'),
+      error: (err: HttpErrorResponse) => {
+        expect(err.status).toBe(401);
+        expect(authMock.logout).toHaveBeenCalled();
+        expect(routerMock.navigate).toHaveBeenCalledOnceWith(
+          ['/login'],
+          { queryParams: { returnUrl: '/admin-portal/list/6233' } }
+        );
+        done();
+      }
+    });
+
+    const req = httpMock.expectOne('/api/test');
+    req.flush('Unauthorized', { status: 401, statusText: 'Unauthorized' });
+  });
+
+  it('does not redirect if already on login page (still logs out)', (done) => {
+    routerMock.url = '/login/reset-password';
+
+    http.get('/api/test').subscribe({
+      next: () => fail('expected error'),
+      error: (err: HttpErrorResponse) => {
+        expect(err.status).toBe(401);
+        expect(authMock.logout).toHaveBeenCalled();
+        expect(routerMock.navigate).not.toHaveBeenCalled();
+        done();
+      }
+    });
+
+    const req = httpMock.expectOne('/api/test');
+    req.flush('Unauthorized', { status: 401, statusText: 'Unauthorized' });
+  });
+
+  it('does nothing on non-401 errors', (done) => {
+    http.get('/api/test').subscribe({
+      next: () => fail('expected error'),
+      error: (err: HttpErrorResponse) => {
+        expect(err.status).toBe(403);
+        expect(authMock.logout).not.toHaveBeenCalled();
+        expect(routerMock.navigate).not.toHaveBeenCalled();
+        done();
+      }
+    });
+
+    const req = httpMock.expectOne('/api/test');
+    req.flush('Forbidden', { status: 403, statusText: 'Forbidden' });
+  });
+});

--- a/ui/admin-portal/src/app/services/auth-expiry.interceptor.spec.ts
+++ b/ui/admin-portal/src/app/services/auth-expiry.interceptor.spec.ts
@@ -48,22 +48,23 @@ describe('AuthExpiryInterceptor', () => {
     authMock.logout.calls.reset();
   });
 
-  it('redirects to /login with returnUrl and logs out on 401', (done) => {
+  it('redirects to /login with returnUrl and logs out on 401', () => {
+    routerMock.url = '/admin-portal/list/6233';
+
     http.get('/api/test').subscribe({
-      next: () => fail('expected error'),
-      error: (err: HttpErrorResponse) => {
-        expect(err.status).toBe(401);
-        expect(authMock.logout).toHaveBeenCalled();
-        expect(routerMock.navigate).toHaveBeenCalledOnceWith(
-          ['/login'],
-          { queryParams: { returnUrl: '/admin-portal/list/6233' } }
-        );
-        done();
-      }
+      next: () => fail('expected 401'),
+      error: () => { /* ignore */ }
     });
 
     const req = httpMock.expectOne('/api/test');
-    req.flush('Unauthorized', { status: 401, statusText: 'Unauthorized' });
+    req.flush(null, { status: 401, statusText: 'Unauthorized' });
+
+    expect(authMock.logout).toHaveBeenCalledTimes(1);
+    expect(routerMock.navigate).toHaveBeenCalledTimes(1);
+    expect(routerMock.navigate).toHaveBeenCalledWith(
+      ['/login'],
+      { queryParams: { returnUrl: '/admin-portal/list/6233' } }
+    );
   });
 
   it('does not redirect if already on login page (still logs out)', () => {

--- a/ui/admin-portal/src/app/services/auth-expiry.interceptor.ts
+++ b/ui/admin-portal/src/app/services/auth-expiry.interceptor.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@angular/core';
+import {
+  HttpRequest,
+  HttpHandler,
+  HttpEvent,
+  HttpInterceptor, HttpErrorResponse
+} from '@angular/common/http';
+import {Observable, throwError} from 'rxjs';
+import {Router} from "@angular/router";
+import {AuthenticationService} from "./authentication.service";
+import {catchError} from "rxjs/operators";
+
+@Injectable()
+export class AuthExpiryInterceptor implements HttpInterceptor {
+
+  constructor(private router: Router, private auth: AuthenticationService) {}
+
+  intercept(request: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
+    return next.handle(request).pipe(
+      catchError((err: unknown) => {
+        if (err instanceof HttpErrorResponse && err.status === 401) {
+          const currentUrl = this.router.url || '/';
+          this.auth.logout();
+          // Avoid infinite loop by checking if we're already on the login page
+          if (!currentUrl.startsWith('/login')) {
+            console.log('Navigating to login page with returnUrl:', currentUrl);
+            this.router.navigate(['/login'], { queryParams: { returnUrl: currentUrl } });
+          }
+        }
+        return throwError(() => err);
+      })
+    );
+
+  }
+}

--- a/ui/admin-portal/src/app/services/auth-expiry.interceptor.ts
+++ b/ui/admin-portal/src/app/services/auth-expiry.interceptor.ts
@@ -23,7 +23,6 @@ export class AuthExpiryInterceptor implements HttpInterceptor {
           this.auth.logout();
           // Avoid infinite loop by checking if we're already on the login page
           if (!currentUrl.startsWith('/login')) {
-            console.log('Navigating to login page with returnUrl:', currentUrl);
             this.router.navigate(['/login'], { queryParams: { returnUrl: currentUrl } });
           }
         }

--- a/ui/admin-portal/src/app/services/auth-expiry.interceptor.ts
+++ b/ui/admin-portal/src/app/services/auth-expiry.interceptor.ts
@@ -30,6 +30,5 @@ export class AuthExpiryInterceptor implements HttpInterceptor {
         return throwError(() => err);
       })
     );
-
   }
 }


### PR DESCRIPTION
This PR -

- Adds an http interceptor for auth expiry
- Redirects to /login with the target url passed in returnUrl
- The user is thus returned to the target url after re-authenticating
- Includes unit tests

