### PR TITLE
Global background color (removed), font family and h tags

### DIFF
--- a/ui/admin-portal/src/app/shared/components/dropdown/dropdown-divider/tc-dropdown-divider.component.scss
+++ b/ui/admin-portal/src/app/shared/components/dropdown/dropdown-divider/tc-dropdown-divider.component.scss
@@ -1,0 +1,4 @@
+.dropdown-divider {
+  margin-right:  1rem;
+  margin-left:  1rem;
+}

--- a/ui/admin-portal/src/app/shared/components/dropdown/tc-dropdown.component.scss
+++ b/ui/admin-portal/src/app/shared/components/dropdown/tc-dropdown.component.scss
@@ -17,9 +17,11 @@
   ::ng-deep a.dropdown-item,   ::ng-deep button.dropdown-item{
     border-radius: 0.5rem;
     cursor:pointer;
+    padding-top:0.3rem;
+    padding-bottom:0.3rem;
 
     &:hover {
-      @include background-color-blue;
+      background: color(primary, 100);
       @include text-color-body;
     }
 

--- a/ui/admin-portal/src/app/shared/components/table/tc-table.component.scss
+++ b/ui/admin-portal/src/app/shared/components/table/tc-table.component.scss
@@ -40,19 +40,29 @@
       &.table-hover > tbody > tr:hover {
         @include background-color-soft;
         cursor: pointer;
+        background-color: color(primary, 50) !important;
       }
 
       tr.current {
-        background-color: color(gray, 400);
+        background-color: color(primary, 100) !important;
       }
 
       tr.selected {
-        @include background-color-soft;
+        background-color: color(primary, 100) !important;
       }
 
       tr.clickable:hover {
         cursor: pointer;
       }
     }
+  }
+
+  .table-hover tbody tr:hover {
+    --bs-table-hover-bg:  color(primary, 50) !important;
+  }
+
+  .alert-warning {
+    background-color: color(yellow, 50) !important;
+    --bs-alert-bg:  color(yellow, 50);
   }
 }

--- a/ui/admin-portal/src/scss/components/_ng-select.scss
+++ b/ui/admin-portal/src/scss/components/_ng-select.scss
@@ -5,8 +5,8 @@
 @import '../typography-classes';
 
 .tc-select.ng-select.ng-select-focused:not(.ng-select-opened) > .ng-select-container {
-  @include border-color-info;
-  box-shadow: 0 0 0 1px color(blue, 500);
+ border-color: color(primary, 500);
+  box-shadow: 0 0 0 1px color(primary, 500);
   border-color: white;
 }
 
@@ -37,7 +37,7 @@
     &.ng-select-focused, &.ng-dirty {
       outline: none;
       @include border-color-info;
-      box-shadow: 0 0 0 1px color(blue, 500);
+      box-shadow: 0 0 0 1px color(primary, 500);
     }
 
     &.ng-invalid {
@@ -46,7 +46,7 @@
 
     &.ng-invalid.ng-select-focused {
       @include border-color-info;
-      box-shadow: 0 0 0 1px color(blue, 500);
+      box-shadow: 0 0 0 1px color(primary, 500);
     }
   }
 
@@ -74,7 +74,7 @@
     }
 
     &.ng-option-selected {
-      background-color: color(blue, 50) !important;
+      background-color: color(primary, 50) !important;
       font-weight: 400;
       position: relative;
     }
@@ -87,28 +87,23 @@
       transform: translateY(-50%);
       width: 1.5rem;
       height: 1.5rem;
-      background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='%231D4ED8' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='20,6 9,17 4,12'%3E%3C/polyline%3E%3C/svg%3E");
+      background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='%230084d1' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='20,6 9,17 4,12'%3E%3C/polyline%3E%3C/svg%3E");
       background-size: contain;
       background-repeat: no-repeat;
     }
 
     &:hover {
-      background: color(blue, 700) !important;
-      color: white !important;
-    }
-
-    &:hover::after {
-      background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='%23ffffff' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='20,6 9,17 4,12'%3E%3C/polyline%3E%3C/svg%3E");
+      background: color(primary, 100) !important;
     }
   }
 
   .ng-value {
-    background: color(blue, 100) !important;
+    background: color(primary, 100) !important;
     border-radius: 0.3rem !important;
   }
 
   .ng-value-icon:hover {
-    background: color(blue, 200) !important;
+    background: color(primary, 200) !important;
     border-radius: 0.3rem 0 0 0.3rem !important;
   }
 }

--- a/ui/admin-portal/src/styles.scss
+++ b/ui/admin-portal/src/styles.scss
@@ -44,8 +44,24 @@ $fa-font-path: "~@fortawesome/fontawesome-free/webfonts";
 @import './scss/components/ng-select';
 
 body {
-  padding-top: 6rem;
-  background-color: $light;
+  padding-top: 5rem;
+  font-family: 'Lato', sans-serif;
+}
+
+h1 {
+  @include heading-lg;
+}
+
+h2 {
+  @include heading-md;
+}
+
+h3 {
+  @include heading-sm;
+}
+
+h4 {
+  @include heading-xs;
 }
 
 .nav-link {

--- a/ui/admin-portal/src/styles.scss
+++ b/ui/admin-portal/src/styles.scss
@@ -45,7 +45,9 @@ $fa-font-path: "~@fortawesome/fontawesome-free/webfonts";
 
 body {
   padding-top: 5rem;
+  margin:0 0.8rem 0 0.8rem;
   font-family: 'Lato', sans-serif;
+  @include text-color-body;
 }
 
 h1 {
@@ -62,6 +64,12 @@ h3 {
 
 h4 {
   @include heading-xs;
+}
+
+a {
+  @include label-md;
+  color: inherit;
+  text-decoration: underline;
 }
 
 .nav-link {
@@ -119,17 +127,17 @@ h1 {
 
 //Table row highlighting
 highlighting.table-hover> tbody> tr:hover{
-  background-color: $accent3
+  //background-color: $accent3
 }
 
 //Current item - the one whose detailed data is displayed
 tr.current {
-  background-color: fade-out($accent1, 0.7)
+  //background-color: fade-out($accent1, 0.7)
 }
 
 //Selected item(s)- item is one of the selected ones (those with checked selection checkbox)
 tr.selected {
-  background-color: fade-out($accent1, 0.7)
+  //background-color: fade-out($accent1, 0.7)
 }
 //end - Table row highlighting
 


### PR DESCRIPTION
I'm not sure if there's anything else globally to add that'll avoid us all having to do this in our own rollover branches. Thoughts?

I did reduce the top padding slightly as it was more inline with the figma design too