### PR TITLE
2288 accordion   figma to code

### DIFF
--- a/ui/admin-portal/src/app/shared/components/accordion/accordion-item/tc-accordion-item.component.html
+++ b/ui/admin-portal/src/app/shared/components/accordion/accordion-item/tc-accordion-item.component.html
@@ -1,6 +1,10 @@
 <div class="tc-accordion-item">
   <a class="tc-accordion-header" (click)="toggle()">
-    {{ title }}
+    <!-- If exists custom header projected using attribute selector -->
+    <ng-content select="[custom-header]"></ng-content>
+
+    <span>{{ header }}</span>
+
     <tc-icon size="sm" color="gray">
       <i *ngIf="!isOpen" class="fa-solid fa-chevron-down"></i>
       <i *ngIf="isOpen" class="fa-solid fa-chevron-up"></i>

--- a/ui/admin-portal/src/app/shared/components/accordion/accordion-item/tc-accordion-item.component.html
+++ b/ui/admin-portal/src/app/shared/components/accordion/accordion-item/tc-accordion-item.component.html
@@ -1,0 +1,13 @@
+<div class="tc-accordion-item">
+  <a class="tc-accordion-header" (click)="toggle()">
+    {{ title }}
+    <tc-icon size="sm" color="gray">
+      <i *ngIf="!isOpen" class="fa-solid fa-chevron-down"></i>
+      <i *ngIf="isOpen" class="fa-solid fa-chevron-up"></i>
+    </tc-icon>
+  </a>
+
+  <div class="tc-accordion-body" *ngIf="isOpen">
+    <ng-content></ng-content>
+  </div>
+</div>

--- a/ui/admin-portal/src/app/shared/components/accordion/accordion-item/tc-accordion-item.component.scss
+++ b/ui/admin-portal/src/app/shared/components/accordion/accordion-item/tc-accordion-item.component.scss
@@ -28,7 +28,7 @@
   }
 }
 
-/* 🔥 Remove border on the last accordion item */
+/* Remove border on the last accordion item */
 :host:last-of-type {
   .tc-accordion-item {
     border-bottom: none;

--- a/ui/admin-portal/src/app/shared/components/accordion/accordion-item/tc-accordion-item.component.scss
+++ b/ui/admin-portal/src/app/shared/components/accordion/accordion-item/tc-accordion-item.component.scss
@@ -1,0 +1,36 @@
+@import 'src/scss/typography-mixins';
+@import 'src/scss/color-mixins';
+
+.tc-accordion-item {
+  border: none;
+  border-bottom: 1px solid;
+  @include border-color-base;
+
+  .tc-accordion-header {
+    @include label-lg;
+    @include text-color-body;
+    width: 100%;
+    padding: 20px 0;
+    text-align: left;
+    cursor: pointer;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+
+    &:hover {
+      @include text-color-primary;
+    }
+  }
+
+  .tc-accordion-body {
+    @include paragraph-md;
+    padding-bottom: 16px;
+  }
+}
+
+/* 🔥 Remove border on the last accordion item */
+:host:last-of-type {
+  .tc-accordion-item {
+    border-bottom: none;
+  }
+}

--- a/ui/admin-portal/src/app/shared/components/accordion/accordion-item/tc-accordion-item.component.spec.ts
+++ b/ui/admin-portal/src/app/shared/components/accordion/accordion-item/tc-accordion-item.component.spec.ts
@@ -1,0 +1,21 @@
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+
+import {TcAccordionItemComponent} from './tc-accordion-item.component';
+
+describe('TcAccordionItemComponent', () => {
+  let component: TcAccordionItemComponent;
+  let fixture: ComponentFixture<TcAccordionItemComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [TcAccordionItemComponent]
+    });
+    fixture = TestBed.createComponent(TcAccordionItemComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/ui/admin-portal/src/app/shared/components/accordion/accordion-item/tc-accordion-item.component.spec.ts
+++ b/ui/admin-portal/src/app/shared/components/accordion/accordion-item/tc-accordion-item.component.spec.ts
@@ -1,6 +1,7 @@
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 
 import {TcAccordionItemComponent} from './tc-accordion-item.component';
+import {TcAccordionComponent} from "../tc-accordion.component";
 
 describe('TcAccordionItemComponent', () => {
   let component: TcAccordionItemComponent;
@@ -8,7 +9,16 @@ describe('TcAccordionItemComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [TcAccordionItemComponent]
+      declarations: [TcAccordionItemComponent],
+      providers: [
+        {
+          provide: TcAccordionComponent,
+          useValue: {
+            toggle: () => {},
+            isOpen: (index: number) => false
+          }
+        }
+      ]
     });
     fixture = TestBed.createComponent(TcAccordionItemComponent);
     component = fixture.componentInstance;

--- a/ui/admin-portal/src/app/shared/components/accordion/accordion-item/tc-accordion-item.component.ts
+++ b/ui/admin-portal/src/app/shared/components/accordion/accordion-item/tc-accordion-item.component.ts
@@ -1,4 +1,4 @@
-import {Component, Input} from '@angular/core';
+import {Component, ContentChild, ElementRef, Input} from '@angular/core';
 import {TcAccordionComponent} from "../tc-accordion.component";
 
 /**
@@ -9,20 +9,53 @@ import {TcAccordionComponent} from "../tc-accordion.component";
  * Represents a single collapsible item inside an Accordion.
  * Contains a header and a body. Can be expanded or collapsed by the parent AccordionComponent.
  *
+ * **How it works**
+ * - Text only accordion header: use the [header] input to pass the string for the accordion header.
+ * - Custom accordion header: if need more flexibility in the accordion header
+ * (e.g. display another component, buttons) then add the 'custom-header' element ref to a div in the
+ * TcAccordionItemComponent. Within that `<div custom-header>` you can customize what will appear in the header (see example below)
+ *
+ * **Inputs**
+ * - Header: The text displayed in the accordion header
+ *
  * @example
- * <tc-accordion-item title="Panel Title">
+ * <!-- Simple text header -->
+ * <tc-accordion-item header="Panel Header">
  *   <p>Panel content goes here.</p>
  * </tc-accordion-item>
- */
+ *
+ * @example
+ * <!-- Custom header -->
+ *  <tc-accordion-item>
+ *     <div custom-header>
+ *       <div class="row">
+ *         <div class="col">
+ *           <p>My Custom Header</p>
+ *           <small>This is an example of a customized accordion header</small>
+ *         </div>
+ *         <div class="col-1">
+ *           <tc-button>
+ *             <i class="fas fa-plus"></i>
+ *           </tc-button>
+ *         </div>
+ *       </div>
+ *     </div>
+ *     <p>You can sign up to the TC following these simple steps 1,2</p>
+ *   </tc-accordion-item>
+ *
+ **/
 @Component({
-  selector: 'app-tc-accordion-item',
+  selector: 'tc-accordion-item',
   templateUrl: './tc-accordion-item.component.html',
   styleUrls: ['./tc-accordion-item.component.scss']
 })
 export class TcAccordionItemComponent {
   /** The text displayed in the accordion header */
-  @Input() title = '';
+  @Input() header = '';
   index: number;
+
+  /** Reference to projected custom header */
+  @ContentChild('[custom-header]', { read: ElementRef }) customHeader?: ElementRef;
 
   constructor(public accordion: TcAccordionComponent) {}
 

--- a/ui/admin-portal/src/app/shared/components/accordion/accordion-item/tc-accordion-item.component.ts
+++ b/ui/admin-portal/src/app/shared/components/accordion/accordion-item/tc-accordion-item.component.ts
@@ -1,0 +1,38 @@
+import {Component, Input} from '@angular/core';
+import {TcAccordionComponent} from "../tc-accordion.component";
+
+/**
+ * @component TcAccordionItemComponent
+ * @selector tc-accordion-item
+ *
+ * @description
+ * Represents a single collapsible item inside an Accordion.
+ * Contains a header and a body. Can be expanded or collapsed by the parent AccordionComponent.
+ *
+ * @example
+ * <tc-accordion-item title="Panel Title">
+ *   <p>Panel content goes here.</p>
+ * </tc-accordion-item>
+ */
+@Component({
+  selector: 'app-tc-accordion-item',
+  templateUrl: './tc-accordion-item.component.html',
+  styleUrls: ['./tc-accordion-item.component.scss']
+})
+export class TcAccordionItemComponent {
+  /** The text displayed in the accordion header */
+  @Input() title = '';
+  index: number;
+
+  constructor(public accordion: TcAccordionComponent) {}
+
+  toggle() {
+    if (this.accordion) {
+      this.accordion.toggle(this.index);
+    }
+  }
+
+  get isOpen(): boolean {
+    return this.accordion ? this.accordion.isOpen(this.index) : false;
+  }
+}

--- a/ui/admin-portal/src/app/shared/components/accordion/tc-accordion.component.html
+++ b/ui/admin-portal/src/app/shared/components/accordion/tc-accordion.component.html
@@ -1,0 +1,3 @@
+<div class="tc-accordion">
+  <ng-content></ng-content>
+</div>

--- a/ui/admin-portal/src/app/shared/components/accordion/tc-accordion.component.scss
+++ b/ui/admin-portal/src/app/shared/components/accordion/tc-accordion.component.scss
@@ -1,0 +1,6 @@
+.tc-accordion {
+  padding: 16px;
+  border-radius: 6px;
+  overflow: hidden;
+  background-color: #ffffff;
+}

--- a/ui/admin-portal/src/app/shared/components/accordion/tc-accordion.component.spec.ts
+++ b/ui/admin-portal/src/app/shared/components/accordion/tc-accordion.component.spec.ts
@@ -1,0 +1,21 @@
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+
+import {TcAccordionComponent} from './tc-accordion.component';
+
+describe('TcAccordionComponent', () => {
+  let component: TcAccordionComponent;
+  let fixture: ComponentFixture<TcAccordionComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [TcAccordionComponent]
+    });
+    fixture = TestBed.createComponent(TcAccordionComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/ui/admin-portal/src/app/shared/components/accordion/tc-accordion.component.ts
+++ b/ui/admin-portal/src/app/shared/components/accordion/tc-accordion.component.ts
@@ -1,0 +1,90 @@
+import {AfterContentInit, Component, ContentChildren, Input, QueryList} from '@angular/core';
+import {TcAccordionItemComponent} from "./accordion-item/tc-accordion-item.component";
+
+/**
+ * @component TcAccordionComponent
+ * @selector tc-accordion
+ * @description
+ * A reusable Accordion component that contains multiple collapsible panels (TcAccordionItemComponents).
+ * Panels can start all open, first open or default to all closed.
+ *
+ * **How it works**
+ * - Wraps the TcAccordionItem components
+ * - Sets the default open/close state of the panels
+ * - Keeps track of which panels are opened and closed on click
+ *
+ * **Inputs**
+ * - allOpen: if true initializes accordion with all panels opened, defaults to false.
+ * - firstOpen: if true initializes accordion with first panel opened, defaults to false.
+ *
+ *
+ * @example
+ * <!-- All panels closed (default) -->
+ * <tc-accordion>
+ *   <tc-accordion-item title="First">
+ *     <p>First content</p>
+ *   </tc-accordion-item>
+ *   <tc-accordion-item title="Second">
+ *     <p>Second content</p>
+ *   </tc-accordion-item>
+ * </tc-accordion>
+ *
+ * @example
+ * <!-- Only first panel open initially -->
+ * <tc-accordion [firstOpen]="true">
+ *   <tc-accordion-item title="First">
+ *     <p>First content</p>
+ *   </tc-accordion-item>
+ *   <tc-accordion-item title="Second">
+ *     <p>Second content</p>
+ *   </tc-accordion-item>
+ * </tc-accordion>
+ *
+ * @example
+ * <!-- All panels open initially -->
+ * <tc-accordion [allOpen]="true">
+ *   <tc-accordion-item title="First">
+ *     <p>First content</p>
+ *   </tc-accordion-item>
+ *   <tc-accordion-item title="Second">
+ *     <p>Second content</p>
+ *   </tc-accordion-item>
+ * </tc-accordion>
+ */
+@Component({
+  selector: 'tc-accordion',
+  templateUrl: './tc-accordion.component.html',
+  styleUrls: ['./tc-accordion.component.scss']
+})
+export class TcAccordionComponent implements AfterContentInit {
+  /** Initialise with all panels opened - default false */
+  @Input() allOpen = false;
+  /** Initialise with first panel opened - default false */
+  @Input() firstOpen = false;
+
+  openIndexes: Set<number> = new Set();
+
+  @ContentChildren(TcAccordionItemComponent) items!: QueryList<TcAccordionItemComponent>;
+
+  ngAfterContentInit() {
+    // Auto-assign indexes to children
+    this.items.forEach((item, index) => (item.index = index));
+    if (this.allOpen) {
+      this.items.forEach((item) => this.openIndexes.add(item.index));
+    } else if (this.firstOpen) {
+      this.openIndexes.add(0);
+    }
+  }
+
+  toggle(index: number) {
+    if (this.openIndexes.has(index)) {
+      this.openIndexes.delete(index);
+    } else {
+      this.openIndexes.add(index);
+    }
+  }
+
+  isOpen(index: number): boolean {
+    return this.openIndexes.has(index);
+  }
+}

--- a/ui/admin-portal/src/app/shared/components/accordion/tc-accordion.component.ts
+++ b/ui/admin-portal/src/app/shared/components/accordion/tc-accordion.component.ts
@@ -21,10 +21,10 @@ import {TcAccordionItemComponent} from "./accordion-item/tc-accordion-item.compo
  * @example
  * <!-- All panels closed (default) -->
  * <tc-accordion>
- *   <tc-accordion-item title="First">
+ *   <tc-accordion-item header="First">
  *     <p>First content</p>
  *   </tc-accordion-item>
- *   <tc-accordion-item title="Second">
+ *   <tc-accordion-item header="Second">
  *     <p>Second content</p>
  *   </tc-accordion-item>
  * </tc-accordion>
@@ -32,10 +32,10 @@ import {TcAccordionItemComponent} from "./accordion-item/tc-accordion-item.compo
  * @example
  * <!-- Only first panel open initially -->
  * <tc-accordion [firstOpen]="true">
- *   <tc-accordion-item title="First">
+ *   <tc-accordion-item header="First">
  *     <p>First content</p>
  *   </tc-accordion-item>
- *   <tc-accordion-item title="Second">
+ *   <tc-accordion-item header="Second">
  *     <p>Second content</p>
  *   </tc-accordion-item>
  * </tc-accordion>
@@ -43,10 +43,10 @@ import {TcAccordionItemComponent} from "./accordion-item/tc-accordion-item.compo
  * @example
  * <!-- All panels open initially -->
  * <tc-accordion [allOpen]="true">
- *   <tc-accordion-item title="First">
+ *   <tc-accordion-item header="First">
  *     <p>First content</p>
  *   </tc-accordion-item>
- *   <tc-accordion-item title="Second">
+ *   <tc-accordion-item header="Second">
  *     <p>Second content</p>
  *   </tc-accordion-item>
  * </tc-accordion>

--- a/ui/admin-portal/src/app/shared/shared.module.ts
+++ b/ui/admin-portal/src/app/shared/shared.module.ts
@@ -18,9 +18,9 @@ import {NgModule} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {ButtonComponent} from './components/button/button.component';
 import {
-  NgbInputDatepicker,
   NgbAlert,
   NgbDropdownModule,
+  NgbInputDatepicker,
   NgbNavModule,
   NgbPaginationModule
 } from "@ng-bootstrap/ng-bootstrap";
@@ -65,6 +65,10 @@ import {
   TcDateRangePickerComponent
 } from './components/date-range-picker/tc-date-range-picker.component'
 import {TcIconComponent} from './components/icon-component/tc-icon.component';
+import {TcAccordionComponent} from './components/accordion/tc-accordion.component';
+import {
+  TcAccordionItemComponent
+} from './components/accordion/accordion-item/tc-accordion-item.component';
 
 @NgModule({
   declarations: [
@@ -93,7 +97,9 @@ import {TcIconComponent} from './components/icon-component/tc-icon.component';
     TcDropdownMenuComponent,
     TcDropdownDividerComponent,
     TcDateRangePickerComponent,
-    TcIconComponent
+    TcIconComponent,
+    TcAccordionComponent,
+    TcAccordionItemComponent
   ],
   imports: [
     CommonModule,
@@ -130,7 +136,9 @@ import {TcIconComponent} from './components/icon-component/tc-icon.component';
     TcDropdownMenuComponent,
     TcDropdownDividerComponent,
     TcDateRangePickerComponent,
-    TcIconComponent
+    TcIconComponent,
+    TcAccordionComponent,
+    TcAccordionItemComponent
   ]
 })
 export class SharedModule { }


### PR DESCRIPTION
How it looks:
<img width="1033" height="288" alt="Screenshot 2025-09-12 at 1 09 34 pm" src="https://github.com/user-attachments/assets/1ead5e5d-844c-435d-adcb-82587ff4b961" />

Added a primary hover color to the text - that can be changed.

Also added ability for an optional custom header to be added (eg. in intakes we have buttons in the accordion panels and display summary data).

As I mentioned in our slack channel, we are missing some font weights so despite the header using a label-md mixin and the body using a paragraph mixin, which should have different weights they appear the same. If we can get the additional font weights working in dev I think this will look great

And heres how it looks with a custom header
<img width="889" height="255" alt="Screenshot 2025-09-12 at 3 40 35 pm" src="https://github.com/user-attachments/assets/684fc2aa-a088-4a35-8b61-cd9da385c3ee" />

