### PR TITLE
Make the nav inputs shrink to allow nav items to stay in row

### DIFF
--- a/ui/admin-portal/src/app/components/header/header.component.html
+++ b/ui/admin-portal/src/app/components/header/header.component.html
@@ -32,82 +32,86 @@
     </button>
 
     <div [ngbCollapse]="isNavbarCollapsed" class="collapse navbar-collapse" id="navbarsDefault">
-      <ul class="nav nav-pills me-auto">
-        <li class="nav-item" >
-          <a title="Jobs available to Talent Catalog candidates"
-             class="nav-link" [routerLink]="'/jobs'" [routerLinkActive]="'active'">Jobs</a>
-        </li>
-        <li class="nav-item" [routerLinkActive]="'active'">
-          <a title="Searches of Talent Catalog candidates"
-             class="nav-link" [routerLink]="'/searches'" [routerLinkActive]="'active'">Searches</a>
-        </li>
-        <li class="nav-item" [routerLinkActive]="'active'">
-          <a title="Lists of Talent Catalog candidates"
-             class="nav-link" [routerLink]="'/lists'" [routerLinkActive]="'active'">Lists</a>
-        </li>
-        <li class="nav-item" [routerLinkActive]="'active'" *ngIf="!isEmployerPartner()">
-          <a title="Statistics about the Talent Catalog"
-             class="nav-link" [routerLink]="'/infographics'" [routerLinkActive]="'active'">
-            Stats
-          </a>
-        </li>
-        <li class="nav-item"
-            [routerLinkActive]="'active'"
-            *ngIf="canViewCandidateName() && !isEmployerPartner()">
-          <a title="Talent Catalog data exploration and visualisation"
-             class="nav-link"
-             [routerLink]="'/intelligence'"
-             [routerLinkActive]="'active'">
-            Intelligence
-          </a>
-        </li>
-      </ul>
-
-      <div class="me-3" *ngIf="canViewCandidateName() && !isEmployerPartner()">
-        <input id="quickExternalIdSearch"
-               type="text" class="form-control" #input
-               [ngbTypeahead]="doExternalIdSearch"
-               [resultTemplate]="rt"
-               [inputFormatter]="renderCandidateRow"
-               [editable]="false"
-               (selectItem)="selectSearchResult($event, input)"
-               placeholder="External ID..."/>
-        <ng-template #rt let-r="result">
-          <ngb-highlight [result]="renderCandidateRow(r)" [term]=""></ngb-highlight>
-        </ng-template>
+      <div class="nav-items">
+        <ul class="nav nav-pills flex-column flex-md-row">
+          <li class="nav-item" >
+            <a title="Jobs available to Talent Catalog candidates"
+               class="nav-link" [routerLink]="'/jobs'" [routerLinkActive]="'active'">Jobs</a>
+          </li>
+          <li class="nav-item" [routerLinkActive]="'active'">
+            <a title="Searches of Talent Catalog candidates"
+               class="nav-link" [routerLink]="'/searches'" [routerLinkActive]="'active'">Searches</a>
+          </li>
+          <li class="nav-item" [routerLinkActive]="'active'">
+            <a title="Lists of Talent Catalog candidates"
+               class="nav-link" [routerLink]="'/lists'" [routerLinkActive]="'active'">Lists</a>
+          </li>
+          <li class="nav-item" [routerLinkActive]="'active'" *ngIf="!isEmployerPartner()">
+            <a title="Statistics about the Talent Catalog"
+               class="nav-link" [routerLink]="'/infographics'" [routerLinkActive]="'active'">
+              Stats
+            </a>
+          </li>
+          <li class="nav-item"
+              [routerLinkActive]="'active'"
+              *ngIf="canViewCandidateName() && !isEmployerPartner()">
+            <a title="Talent Catalog data exploration and visualisation"
+               class="nav-link"
+               [routerLink]="'/intelligence'"
+               [routerLinkActive]="'active'">
+              Intelligence
+            </a>
+          </li>
+        </ul>
       </div>
 
-      <div class="me-3" *ngIf="canViewCandidateName() && !isEmployerPartner()">
-        <input id="quickEmailPhoneOrWhatsappSearch"
-               type="text" class="form-control" #input
-               [ngbTypeahead]="doEmailPhoneOrWhatsappSearch"
-               [resultTemplate]="rt"
-               [inputFormatter]="renderCandidateRow"
-               [editable]="false"
-               (selectItem)="selectSearchResult($event, input)"
-               placeholder="Email/phone/whatsapp..."/>
-        <ng-template #rt let-r="result">
-          <ngb-highlight [result]="renderCandidateRow(r)" [term]=""></ngb-highlight>
-        </ng-template>
-      </div>
+      <div class="nav-inputs">
+        <div *ngIf="canViewCandidateName() && !isEmployerPartner()">
+          <input id="quickExternalIdSearch"
+                 type="text" class="form-control" #input
+                 [ngbTypeahead]="doExternalIdSearch"
+                 [resultTemplate]="rt"
+                 [inputFormatter]="renderCandidateRow"
+                 [editable]="false"
+                 (selectItem)="selectSearchResult($event, input)"
+                 placeholder="External ID..."/>
+          <ng-template #rt let-r="result">
+            <ngb-highlight [result]="renderCandidateRow(r)" [term]=""></ngb-highlight>
+          </ng-template>
+        </div>
 
-      <!-- New Public ID Search -->
-      <div class="me-3" *ngIf="canViewCandidateName() && !isEmployerPartner()">
-        <input id="quickPublicIdSearch"
-               type="text" class="form-control" #input
-               [ngbTypeahead]="doPublicIdSearch"
-               [resultTemplate]="rt"
-               [inputFormatter]="renderCandidateRow"
-               [editable]="false"
-               (selectItem)="selectSearchResult($event, input)"
-               placeholder="Public ID..."/>
-        <ng-template #rt let-r="result">
-          <ngb-highlight [result]="renderCandidateRow(r)" [term]=""></ngb-highlight>
-        </ng-template>
-      </div>
+        <div *ngIf="canViewCandidateName() && !isEmployerPartner()">
+          <input id="quickEmailPhoneOrWhatsappSearch"
+                 type="text" class="form-control" #input
+                 [ngbTypeahead]="doEmailPhoneOrWhatsappSearch"
+                 [resultTemplate]="rt"
+                 [inputFormatter]="renderCandidateRow"
+                 [editable]="false"
+                 (selectItem)="selectSearchResult($event, input)"
+                 placeholder="Email/phone/whatsapp..."/>
+          <ng-template #rt let-r="result">
+            <ngb-highlight [result]="renderCandidateRow(r)" [term]=""></ngb-highlight>
+          </ng-template>
+        </div>
 
-      <div class="me-3" *ngIf="!isEmployerPartner()">
-        <app-candidate-name-num-search></app-candidate-name-num-search>
+        <!-- New Public ID Search -->
+        <div *ngIf="canViewCandidateName() && !isEmployerPartner()">
+          <input id="quickPublicIdSearch"
+                 type="text" class="form-control" #input
+                 [ngbTypeahead]="doPublicIdSearch"
+                 [resultTemplate]="rt"
+                 [inputFormatter]="renderCandidateRow"
+                 [editable]="false"
+                 (selectItem)="selectSearchResult($event, input)"
+                 placeholder="Public ID..."/>
+          <ng-template #rt let-r="result">
+            <ngb-highlight [result]="renderCandidateRow(r)" [term]=""></ngb-highlight>
+          </ng-template>
+        </div>
+
+        <div *ngIf="!isEmployerPartner()">
+          <app-candidate-name-num-search></app-candidate-name-num-search>
+        </div>
       </div>
       <ul class="navbar-nav">
         <li ngbDropdown class="nav-item">

--- a/ui/admin-portal/src/app/components/header/header.component.scss
+++ b/ui/admin-portal/src/app/components/header/header.component.scss
@@ -21,3 +21,33 @@
   width: 100%;
 }
 
+.nav-items {
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
+.nav-inputs {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  justify-content: end;
+  gap: 0.75rem;
+}
+
+.nav-inputs input {
+  flex: 1 1 auto;
+  min-width: 100px;
+}
+
+/* Mobile layout */
+@media (max-width: 768px) {
+  #navbarsDefault {
+    background-color: white;
+    padding: 1rem;
+  }
+
+  .nav-inputs {
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+}


### PR DESCRIPTION
To resolve this issue I have made the nav inputs (search inputs) shrink upon screen reduction. This means our nav items will stay in the one row. Then once the screen becomes a mobile size, they stack in a mobile menu.
<img width="1306" height="231" alt="Screenshot 2025-09-16 at 12 05 11 pm" src="https://github.com/user-attachments/assets/8e32919d-551c-4624-b6b0-a57d1d7e9295" />
<img width="1999" height="175" alt="Screenshot 2025-09-16 at 12 12 30 pm" src="https://github.com/user-attachments/assets/485145aa-6183-495e-8623-4eeef639aada" />
