### PR TITLE
Fix a bug with the error AuthExpiryInterceptor.

### DIFF
--- a/ui/admin-portal/src/app/services/auth-expiry.interceptor.ts
+++ b/ui/admin-portal/src/app/services/auth-expiry.interceptor.ts
@@ -1,9 +1,10 @@
-import { Injectable } from '@angular/core';
+import {Injectable} from '@angular/core';
 import {
-  HttpRequest,
-  HttpHandler,
+  HttpErrorResponse,
   HttpEvent,
-  HttpInterceptor, HttpErrorResponse
+  HttpHandler,
+  HttpInterceptor,
+  HttpRequest
 } from '@angular/common/http';
 import {Observable, throwError} from 'rxjs';
 import {Router} from "@angular/router";
@@ -26,7 +27,7 @@ export class AuthExpiryInterceptor implements HttpInterceptor {
             this.router.navigate(['/login'], { queryParams: { returnUrl: currentUrl } });
           }
         }
-        return throwError(() => err);
+        return throwError(err);
       })
     );
   }

--- a/ui/admin-portal/src/app/services/error.interceptor.ts
+++ b/ui/admin-portal/src/app/services/error.interceptor.ts
@@ -18,13 +18,12 @@ import {Injectable} from '@angular/core';
 import {HttpEvent, HttpHandler, HttpInterceptor, HttpRequest} from '@angular/common/http';
 import {Observable, throwError} from 'rxjs';
 import {catchError} from 'rxjs/operators';
-import {Router} from '@angular/router';
 import {AuthenticationService} from "./authentication.service";
 
 
 @Injectable()
 export class ErrorInterceptor implements HttpInterceptor {
-  constructor(private authenticationService: AuthenticationService, private router: Router ) { }
+  constructor(private authenticationService: AuthenticationService) { }
 
   intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
     return next.handle(request).pipe(catchError(err => {
@@ -35,9 +34,9 @@ export class ErrorInterceptor implements HttpInterceptor {
       }
       console.log(err);
       let error: string;
-      if (err.error !== null && err.error.message) {
+      if (err.error != null && err.error.message) {
         error = err.error.message;
-      } else if (err.message !== null) {
+      } else if (err.message != null) {
         error = err.message;
       } else {
         error = err.status + " " + err.statusText;


### PR DESCRIPTION
It was not rethrowing the error correctly. It was using RxJS version 7+ syntax while we are currently on RxJS V6

Improved handling of undefined in ErrorInterceptor.

Removed unused Router