### PR TITLE
2534 TC Icon support button and link type

### DIFF
--- a/ui/admin-portal/src/app/components/job/jobs/jobs.component.html
+++ b/ui/admin-portal/src/app/components/job/jobs/jobs.component.html
@@ -121,6 +121,23 @@
   </form>
 </div>
 
+<!-- Default span -->
+<tc-icon size="md" color="primary">
+  <i class="fas fa-home"></i>
+</tc-icon>
+
+<!-- As button -->
+<tc-icon type="button" size="lg" color="success" >
+  <i class="fas fa-home"></i>
+  <tc-button>Hello </tc-button>
+</tc-icon>
+
+<!-- As link -->
+<tc-icon type="link" href="/dashboard" size="sm" color="info">
+  <i class="fas fa-home"></i>
+</tc-icon>
+
+
 <div class="card" *ngIf="!loading">
   <div class="card-body">
     <div class="table-responsive">

--- a/ui/admin-portal/src/app/shared/components/icon-component/tc-icon.component.html
+++ b/ui/admin-portal/src/app/shared/components/icon-component/tc-icon.component.html
@@ -1,6 +1,27 @@
-<span
-  class="tc-icon"
-  [ngClass]="classList"
-  [attr.aria-label]="ariaLabel">
+<ng-template #content>
   <ng-content></ng-content>
-</span>
+</ng-template>
+
+<ng-container [ngSwitch]="type">
+  <a *ngSwitchCase="'link'"
+     [href]="href"
+     [attr.aria-label]="ariaLabel"
+     [ngClass]="classList">
+    <ng-container *ngTemplateOutlet="content"></ng-container>
+  </a>
+
+  <button *ngSwitchCase="'button'"
+          type="button"
+          [attr.aria-label]="ariaLabel"
+          [ngClass]="classList"
+          (click)="handleClick($event)">
+    <ng-container *ngTemplateOutlet="content"></ng-container>
+  </button>
+
+  <span *ngSwitchDefault
+        [attr.aria-label]="ariaLabel"
+        [ngClass]="classList"
+        (click)="handleClick($event)">
+    <ng-container *ngTemplateOutlet="content"></ng-container>
+  </span>
+</ng-container>

--- a/ui/admin-portal/src/app/shared/components/icon-component/tc-icon.component.scss
+++ b/ui/admin-portal/src/app/shared/components/icon-component/tc-icon.component.scss
@@ -4,22 +4,18 @@
 
   &.icon-sm, &.icon-sm::ng-deep > i {
     font-size: 0.75rem;
-    margin: 0.3rem;
   }
 
   &.icon-md, &.icon-md::ng-deep > i {
     font-size: 1rem;
-    margin: 0.3rem;
   }
 
   &.icon-lg, &.icon-lg::ng-deep > i {
     font-size: 1.25rem;
-    margin: 0.3rem;
   }
 
   &.icon-xl, &.icon-lg::ng-deep > i {
     font-size: 1.5rem;
-    margin: 0.3rem;
   }
 
   // Color variations
@@ -54,4 +50,8 @@
   &.icon-warning {
     color: color(yellow, 500);
   }
+}
+
+button.tc-icon {
+  all: unset;
 }

--- a/ui/admin-portal/src/app/shared/components/icon-component/tc-icon.component.ts
+++ b/ui/admin-portal/src/app/shared/components/icon-component/tc-icon.component.ts
@@ -4,38 +4,59 @@ import {Component, Input} from '@angular/core';
  * @component IconComponent
  * @selector tc-icon
  * @description
- * A design-system icon wrapper component that applies consistent sizing and margins
- * to any projected content (FontAwesome icons, SVGs, images, etc.).
+ * A design-system icon wrapper component that can be rendered as a `<span>` (default),
+ * `<button>`, or `<a>` link. It applies consistent sizing and color variants to any
+ * projected content (FontAwesome icons, SVGs, images, etc.).
  *
  * **Features**
+ * - Render as `span` (default), `button`, or `link` via the `type` input
  * - Size presets: `sm` (12px), `md` (16px), `lg` (20px), `xl` (24px)
- * - Automatic margin calculation based on size
- * - Flexible content projection – works with any icon type
+ * - Flexible content projection – works with FontAwesome, SVG, or inline images
  * - Color variants: `primary`, `secondary`, `white`, `gray`, `success`, `info`, `warning`, `error`
  * - Accessible with optional `ariaLabel`
+ * - Automatically removes default browser styles when rendered as `<button>` or `<a>`
  *
  * **Inputs**
  * - `size: 'sm' | 'md' | 'lg' | 'xl'`
- *   Controls icon size and margin. Defaults to `'lg'`.
- *   - sm: 12px icon, 16px with margin
- *   - md: 16px icon, 20px with margin
- *   - lg: 20px icon, 24px with margin
- *   - xl: 24px icon, 28px with margin
+ *   Controls icon size. Defaults to `'lg'`.
+ *   - sm → 12px
+ *   - md → 16px
+ *   - lg → 20px
+ *   - xl → 24px
+ *
  * - `color?: 'primary' | 'secondary' | 'white' | 'gray' | 'success' | 'info' | 'warning' | 'error'`
  *   Optional color variant. Defaults to `'primary'` if not set.
- * - `ariaLabel?: string`
- *   Accessible label for screen readers.
  *
- * @examples
+ * - `ariaLabel?: string`
+ *   Accessible label for screen readers. Recommended when the icon has no visible text.
+ *
+ * - `type: 'span' | 'button' | 'link'`
+ *   Determines the rendered element. Defaults to `'span'`.
+ *   - `"span"` → non-interactive icon (default)
+ *   - `"button"` → semantic button icon (clickable, with reset styles)
+ *   - `"link"` → icon inside an anchor `<a>`
+ *
+ * - `href?: string`
+ *   Required when `type="link"`. Sets the target URL.
+ *
+ * - `onClick?: (event: MouseEvent) => void`
+ *   Optional click handler for `type="button"` or `type="span"`.
+ *
+ * **Examples**
  * ```html
- * <!-- FontAwesome icon -->
+ * <!-- FontAwesome icon as span -->
  * <tc-icon size="md" color="primary" ariaLabel="Home">
  *   <i class="fas fa-home"></i>
  * </tc-icon>
  *
- * <!-- SVG icon -->
- * <tc-icon size="lg" color="success">
+ * <!-- SVG icon as button -->
+ * <tc-icon type="button" size="lg" color="success" (onClick)="save()">
  *   <svg>...</svg>
+ * </tc-icon>
+ *
+ * <!-- Icon as link -->
+ * <tc-icon type="link" href="/settings" size="sm" color="info" ariaLabel="Settings">
+ *   <i class="fas fa-cog"></i>
  * </tc-icon>
  * ```
  */
@@ -50,11 +71,15 @@ export class TcIconComponent {
   @Input() color?: 'primary' | 'secondary' | 'white' | 'gray' | 'success' | 'info' | 'warning' | 'error' = 'primary';
   @Input() ariaLabel?: string;
 
+  @Input() type: 'link' | 'button' | 'span' = 'span';
+  @Input() href?: string;
+  @Input() onClick?: (e: MouseEvent) => void;
+
   get classList(): string[] {
-    const classes = [`icon-${this.size}`];
-    if (this.color) {
-      classes.push(`icon-${this.color}`);
-    }
-    return classes;
+    return [`tc-icon`, `icon-${this.size}`, `icon-${this.color}`];
+  }
+
+  handleClick(event: MouseEvent) {
+    if (this.onClick) this.onClick(event);
   }
 }


### PR DESCRIPTION
This PR allows the TC Icon to support both link and button options. I also removed the margin around it, as I felt that in many cases a margin is already applied. This was making the elements unnecessarily larger, removing it will make the rollover smoother.