### PR TITLE
2497 create robust stage badge colour retrieval functions

### DIFF
--- a/server/src/main/java/org/tctalent/server/api/admin/JobAdminApi.java
+++ b/server/src/main/java/org/tctalent/server/api/admin/JobAdminApi.java
@@ -245,6 +245,8 @@ public class JobAdminApi implements
             .add("jobCreator", shortPartnerDto())
             .add("skipCandidateSearch")
             .add("stage")
+            .add("closed")
+            .add("won")
             .add("starringUsers", shortUserDto())
             .add("submissionDueDate")
             .add("submissionList", savedListBuilderSelector.selectBuilder())

--- a/ui/admin-portal/src/app/components/candidate-opp/view-candidate-opp/view-candidate-opp.component.ts
+++ b/ui/admin-portal/src/app/components/candidate-opp/view-candidate-opp/view-candidate-opp.component.ts
@@ -14,19 +14,27 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-import {Component, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChanges} from '@angular/core';
 import {
-  CandidateOpportunity,
-  isCandidateOpportunity,
-  isOppStageGreaterThanOrEqualTo
-} from "../../../model/candidate-opportunity";
+  Component,
+  EventEmitter,
+  Input,
+  OnChanges,
+  OnInit,
+  Output,
+  SimpleChanges
+} from '@angular/core';
+import {CandidateOpportunity, isCandidateOpportunity} from "../../../model/candidate-opportunity";
 import {EditCandidateOppComponent} from "../edit-candidate-opp/edit-candidate-opp.component";
 import {CandidateOpportunityParams} from "../../../model/candidate";
 import {NgbModal, NgbNavChangeEvent} from "@ng-bootstrap/ng-bootstrap";
 import {CandidateOpportunityService} from "../../../services/candidate-opportunity.service";
 import {SalesforceService} from "../../../services/salesforce.service";
 import {AuthorizationService} from "../../../services/authorization.service";
-import {getOpportunityStageName, Opportunity} from "../../../model/opportunity";
+import {
+  getOpportunityStageName,
+  isCvReviewStageOrMore,
+  Opportunity
+} from "../../../model/opportunity";
 import {ShortSavedList} from "../../../model/saved-list";
 import {CreateChatRequest, JobChat, JobChatType} from "../../../model/chat";
 import {AuthenticationService} from "../../../services/authentication.service";
@@ -223,7 +231,7 @@ export class ViewCandidateOppComponent implements OnInit, OnChanges {
       this.nonCandidateChats = [this.jobCreatorSourcePartnerChat, this.jobCreatorAllSourcePartnersChat];
     } else if (userIsJobCreator) {
       this.nonCandidateChats = [this.jobCreatorSourcePartnerChat, this.jobCreatorAllSourcePartnersChat];
-      if (this.cvReviewStageOrMore()) {
+      if (isCvReviewStageOrMore(this.opp?.stage)) {
         this.candidateChats = [this.candidateRecruitingChat, this.allJobCandidatesChat];
       } else {
         this.candidateChats = [];
@@ -266,13 +274,6 @@ export class ViewCandidateOppComponent implements OnInit, OnChanges {
         this.saving = false;
       }
     );
-  }
-
-  /**
-   *  Recruiters only see candidates past the CV Review stage.
-   */
-  cvReviewStageOrMore() {
-    return isOppStageGreaterThanOrEqualTo(this.opp?.stage, 'cvReview')
   }
 
   hasVisibleCandidateChats(): boolean {

--- a/ui/admin-portal/src/app/model/job.ts
+++ b/ui/admin-portal/src/app/model/job.ts
@@ -24,6 +24,7 @@ import {JobOppIntake} from "./job-opp-intake";
 import {isCandidateOpportunity, SearchOpportunityRequest} from "./candidate-opportunity";
 import {Opportunity, OpportunityProgressParams} from "./opportunity";
 import {Country} from "./country";
+import {getOrdinal} from "../util/enum";
 
 export function isJob(opp: Opportunity): opp is Job {
   return !isCandidateOpportunity(opp);
@@ -123,4 +124,11 @@ export interface UpdateJobRequest extends OpportunityProgressParams {
   skipCandidateSearch?: boolean;
   submissionDueDate?: Date;
   jobToCopyId?: number;
+}
+
+
+export function isJobOppStageGreaterThanOrEqualTo(selectedOppStageKey: string, desiredStageKey: string) {
+  let oppOrdinal: number = getOrdinal(JobOpportunityStage, selectedOppStageKey);
+  let desiredOrdinal: number = getOrdinal(JobOpportunityStage, desiredStageKey);
+  return oppOrdinal >= desiredOrdinal;
 }

--- a/ui/admin-portal/src/app/model/opportunity.ts
+++ b/ui/admin-portal/src/app/model/opportunity.ts
@@ -14,12 +14,13 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 import {
+  CandidateOpportunity,
   CandidateOpportunityStage,
   isCandidateOpportunity,
   isOppStageGreaterThanOrEqualTo
 } from "./candidate-opportunity";
 import {Auditable, HasId} from "./base";
-import {isJob, JobOpportunityStage} from "./job";
+import {isJob, Job, JobOpportunityStage} from "./job";
 import {BadgeColor} from "../shared/components/badge/badge.component";
 
 /**
@@ -68,45 +69,65 @@ export function getStageBadgeColor(opp: Opportunity): BadgeColor {
     return getCandidateOppStageBadgeColor(opp);
   }
   if (isJob(opp)) {
-    return getJobStageBadgeColor(opp.stage);
+    return getJobStageBadgeColor(opp);
   }
 }
 
-//todo complete the other badge colors, perhaps group colors by stages (early, mid, late)
-function getJobStageBadgeColor(opp: Opportunity): BadgeColor {
+/**
+ * Badge colors groups by job opp stages:
+ * - Won Stage: Yellow;
+ * - Closed Stages: Gray;
+ * - Recruiter Only Stages (stage CV Review onwards, but not closed or won): Orange;
+ * - Prospect: Purple;
+ * - Other stages (prospect to CV review): Blue;
+ * @param opp
+ */
+function getJobStageBadgeColor(opp: Job): BadgeColor {
+  if (opp.won) {
+    return "yellow"
+  } else if (opp.closed) {
+    return "gray"
+  } else if (isCvReviewStageOrMore(opp.stage)) {
+    return "orange"
+  } else if (opp.stage === "0. Prospect") {
+    return "purple"
+  } else {
+    return "blue"
+  }
+}
+
+/**
+ * Badge colors groups by candidate opp stages:
+ * - Closed Stages: Gray;
+ * - Employed Stages (stage 'training' onwards, but not closed): Green;
+ * - Recruiter Only Stages (stage CV Review onwards, but not closed or employed): Orange;
+ * - Prospect: Purple;
+ * - Other stages (prospect to CV review): Blue;
+ * @param opp
+ */
+function getCandidateOppStageBadgeColor(opp: CandidateOpportunity): BadgeColor {
   if (opp.closed) {
     return "gray"
-  } else if (isEmployed()) {
+  } else if (isEmployedStageOrMore(opp.stage)) {
     return "green"
+  } else if (isCvReviewStageOrMore(opp.stage)) {
+    return "orange"
+  } else if (opp.stage === "0. Prospect") {
+    return "purple"
+  } else {
+    return "blue"
   }
-  // switch (status) {
-  //   case 'recruitmentProcess':
-  //     return "purple";
-  //   case 'jobOffer':
-  //     return "orange";
-  //   case 'candidateSearch':
-  //     return "green";
-  //   default:
-  //     return "gray";
-  // }
 }
 
-function isEmployed(stage: string): boolean {
+export function isEmployedStageOrMore(stage: string): boolean {
   return isOppStageGreaterThanOrEqualTo(stage, "training")
 }
 
-//todo complete the other badge colors, perhaps group colors by stages (early, mid, late)
-function getCandidateOppStageBadgeColor(status: string): BadgeColor {
-  switch (status) {
-    case 'Recruitment process':
-      return "purple";
-    case "Job offer":
-      return "orange";
-    case 'Candidate search':
-      return "green";
-    default:
-      return "gray";
-  }
+/**
+ *  Recruiters only see candidates past the CV Review stage.
+ */
+export function isCvReviewStageOrMore(stage: string) {
+  return isOppStageGreaterThanOrEqualTo(stage, 'cvReview')
 }
 
 export interface OpportunityProgressParams {

--- a/ui/admin-portal/src/app/model/opportunity.ts
+++ b/ui/admin-portal/src/app/model/opportunity.ts
@@ -108,7 +108,7 @@ function getJobStageBadgeColor(opp: Job): BadgeColor {
 function getCandidateOppStageBadgeColor(opp: CandidateOpportunity): BadgeColor {
   if (opp.closed) {
     return "gray"
-  } else if (isEmployedStage(opp.stage)) {
+  } else if (isEmployedStageOrGreater(opp.stage)) {
     return "yellow"
   } else if (isCvReviewStageOrMore(opp.stage)) {
     return "orange"
@@ -119,7 +119,7 @@ function getCandidateOppStageBadgeColor(opp: CandidateOpportunity): BadgeColor {
   }
 }
 
-export function isEmployedStage(stage: string): boolean {
+export function isEmployedStageOrGreater(stage: string): boolean {
   return isOppStageGreaterThanOrEqualTo(stage, "training")
 }
 

--- a/ui/admin-portal/src/app/model/opportunity.ts
+++ b/ui/admin-portal/src/app/model/opportunity.ts
@@ -13,9 +13,14 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
-import {CandidateOpportunityStage, isCandidateOpportunity} from "./candidate-opportunity";
+import {
+  CandidateOpportunityStage,
+  isCandidateOpportunity,
+  isOppStageGreaterThanOrEqualTo
+} from "./candidate-opportunity";
 import {Auditable, HasId} from "./base";
 import {isJob, JobOpportunityStage} from "./job";
+import {BadgeColor} from "../shared/components/badge/badge.component";
 
 /**
  * Given an opportunity (job or candidate), return the string value of the opportunity's stage's
@@ -54,6 +59,54 @@ export function getOpportunityStageName(opp: Opportunity): string {
     }
   }
   return s;
+}
+
+export function getStageBadgeColor(opp: Opportunity): BadgeColor {
+  //Need to select the appropriate stage's badge color - depending on whether opp is a candidate or
+  // job opportunity.
+  if (isCandidateOpportunity(opp)) {
+    return getCandidateOppStageBadgeColor(opp);
+  }
+  if (isJob(opp)) {
+    return getJobStageBadgeColor(opp.stage);
+  }
+}
+
+//todo complete the other badge colors, perhaps group colors by stages (early, mid, late)
+function getJobStageBadgeColor(opp: Opportunity): BadgeColor {
+  if (opp.closed) {
+    return "gray"
+  } else if (isEmployed()) {
+    return "green"
+  }
+  // switch (status) {
+  //   case 'recruitmentProcess':
+  //     return "purple";
+  //   case 'jobOffer':
+  //     return "orange";
+  //   case 'candidateSearch':
+  //     return "green";
+  //   default:
+  //     return "gray";
+  // }
+}
+
+function isEmployed(stage: string): boolean {
+  return isOppStageGreaterThanOrEqualTo(stage, "training")
+}
+
+//todo complete the other badge colors, perhaps group colors by stages (early, mid, late)
+function getCandidateOppStageBadgeColor(status: string): BadgeColor {
+  switch (status) {
+    case 'Recruitment process':
+      return "purple";
+    case "Job offer":
+      return "orange";
+    case 'Candidate search':
+      return "green";
+    default:
+      return "gray";
+  }
 }
 
 export interface OpportunityProgressParams {

--- a/ui/admin-portal/src/app/model/opportunity.ts
+++ b/ui/admin-portal/src/app/model/opportunity.ts
@@ -20,7 +20,7 @@ import {
   isOppStageGreaterThanOrEqualTo
 } from "./candidate-opportunity";
 import {Auditable, HasId} from "./base";
-import {isJob, Job, JobOpportunityStage} from "./job";
+import {isJob, isJobOppStageGreaterThanOrEqualTo, Job, JobOpportunityStage} from "./job";
 import {BadgeColor} from "../shared/components/badge/badge.component";
 
 /**
@@ -77,9 +77,9 @@ export function getStageBadgeColor(opp: Opportunity): BadgeColor {
  * Badge colors groups by job opp stages:
  * - Won Stage: Yellow;
  * - Closed Stages: Gray;
- * - Recruiter Only Stages (stage CV Review onwards, but not closed or won): Orange;
- * - Prospect: Purple;
- * - Other stages (prospect to CV review): Blue;
+ * - Recruiter Stages (stage CV Review onwards, but not closed or won): Orange;
+ * - Prospect: Pink;
+ * - Other stages (prospect to CV review): Purple;
  * @param opp
  */
 function getJobStageBadgeColor(opp: Job): BadgeColor {
@@ -87,39 +87,39 @@ function getJobStageBadgeColor(opp: Job): BadgeColor {
     return "yellow"
   } else if (opp.closed) {
     return "gray"
-  } else if (isCvReviewStageOrMore(opp.stage)) {
+  } else if (isJobCvReviewStageOrMore(opp.stage)) {
     return "orange"
-  } else if (opp.stage === "0. Prospect") {
-    return "purple"
+  } else if (CandidateOpportunityStage[opp.stage] === CandidateOpportunityStage.prospect) {
+    return "pink"
   } else {
-    return "blue"
+    return "purple"
   }
 }
 
 /**
  * Badge colors groups by candidate opp stages:
  * - Closed Stages: Gray;
- * - Employed Stages (stage 'training' onwards, but not closed): Green;
- * - Recruiter Only Stages (stage CV Review onwards, but not closed or employed): Orange;
- * - Prospect: Purple;
- * - Other stages (prospect to CV review): Blue;
+ * - Employed Stages (stage 'training' onwards, but not closed): Yellow;
+ * - Recruiter Stages (stage CV Review onwards, but not closed or employed): Orange;
+ * - Prospect: Pink;
+ * - Other stages (prospect to CV review): Purple;
  * @param opp
  */
 function getCandidateOppStageBadgeColor(opp: CandidateOpportunity): BadgeColor {
   if (opp.closed) {
     return "gray"
-  } else if (isEmployedStageOrMore(opp.stage)) {
-    return "green"
+  } else if (isEmployedStage(opp.stage)) {
+    return "yellow"
   } else if (isCvReviewStageOrMore(opp.stage)) {
     return "orange"
-  } else if (opp.stage === "0. Prospect") {
-    return "purple"
+  } else if (CandidateOpportunityStage[opp.stage] === CandidateOpportunityStage.prospect) {
+    return "pink"
   } else {
-    return "blue"
+    return "purple"
   }
 }
 
-export function isEmployedStageOrMore(stage: string): boolean {
+export function isEmployedStage(stage: string): boolean {
   return isOppStageGreaterThanOrEqualTo(stage, "training")
 }
 
@@ -128,6 +128,10 @@ export function isEmployedStageOrMore(stage: string): boolean {
  */
 export function isCvReviewStageOrMore(stage: string) {
   return isOppStageGreaterThanOrEqualTo(stage, 'cvReview')
+}
+
+export function isJobCvReviewStageOrMore(stage: string) {
+  return isJobOppStageGreaterThanOrEqualTo(stage, 'cvReview');
 }
 
 export interface OpportunityProgressParams {

--- a/ui/admin-portal/src/app/model/opportunity.ts
+++ b/ui/admin-portal/src/app/model/opportunity.ts
@@ -108,7 +108,7 @@ function getJobStageBadgeColor(opp: Job): BadgeColor {
 function getCandidateOppStageBadgeColor(opp: CandidateOpportunity): BadgeColor {
   if (opp.closed) {
     return "gray"
-  } else if (isEmployedStageOrGreater(opp.stage)) {
+  } else if (isEmployedStageOrMore(opp.stage)) {
     return "yellow"
   } else if (isCvReviewStageOrMore(opp.stage)) {
     return "orange"
@@ -119,7 +119,7 @@ function getCandidateOppStageBadgeColor(opp: CandidateOpportunity): BadgeColor {
   }
 }
 
-export function isEmployedStageOrGreater(stage: string): boolean {
+export function isEmployedStageOrMore(stage: string): boolean {
   return isOppStageGreaterThanOrEqualTo(stage, "training")
 }
 


### PR DESCRIPTION
Rather than set a colour for each stage enum, I thought it would make more sense to just group the stages by appropriate/similar stages. See the way I've grouped the stages to set the colours, and let me know your thoughts.
<img width="785" height="498" alt="Screenshot 2025-09-30 at 3 29 10 pm" src="https://github.com/user-attachments/assets/4019dfc0-917f-4c6d-bbdf-7b68b091a31b" />
<img width="821" height="490" alt="Screenshot 2025-09-30 at 3 29 05 pm" src="https://github.com/user-attachments/assets/4c78922e-a4ec-4ce4-a155-f02cb72dca25" />

And how it appears as an example:
![Uploading Screenshot 2025-09-30 at 3.06.32 pm.png…]()

