### PR TITLE
1174 define skills on tc database based on selected skills standard

### DIFF
--- a/.idea/sqldialects.xml
+++ b/.idea/sqldialects.xml
@@ -3,6 +3,7 @@
   <component name="SqlDialectMappings">
     <file url="file://$PROJECT_DIR$/server/src/main/resources/db/migration/V1_368__remove_unused_task_definition_drop_unused_field_on_candidate_form.sql" dialect="PostgreSQL" />
     <file url="file://$PROJECT_DIR$/server/src/main/resources/db/migration/V1_369__add_candidate_form_to_task_and_define_demo_candidate_form.sql" dialect="PostgreSQL" />
+    <file url="file://$PROJECT_DIR$/server/src/main/resources/db/migration/V1_376__add_candidate_family_members_form.sql" dialect="PostgreSQL" />
     <file url="file://$PROJECT_DIR$/server/src/main/resources/db/migration/V1_379__create_esco_skills_table.sql" dialect="PostgreSQL" />
     <file url="PROJECT" dialect="PostgreSQL" />
   </component>

--- a/.idea/sqldialects.xml
+++ b/.idea/sqldialects.xml
@@ -3,6 +3,7 @@
   <component name="SqlDialectMappings">
     <file url="file://$PROJECT_DIR$/server/src/main/resources/db/migration/V1_368__remove_unused_task_definition_drop_unused_field_on_candidate_form.sql" dialect="PostgreSQL" />
     <file url="file://$PROJECT_DIR$/server/src/main/resources/db/migration/V1_369__add_candidate_form_to_task_and_define_demo_candidate_form.sql" dialect="PostgreSQL" />
+    <file url="file://$PROJECT_DIR$/server/src/main/resources/db/migration/V1_379__create_esco_skills_table.sql" dialect="PostgreSQL" />
     <file url="PROJECT" dialect="PostgreSQL" />
   </component>
 </project>

--- a/server/src/main/java/org/tctalent/server/model/db/AbstractCandidateSource.java
+++ b/server/src/main/java/org/tctalent/server/model/db/AbstractCandidateSource.java
@@ -87,14 +87,14 @@ public abstract class AbstractCandidateSource extends AbstractAuditableDomainObj
      * The code allows for two different ways of displaying candidates of
      * a candidate source - a "long" one, and a more compact "short" one.
      */
-    @Convert(converter = DelimitedStringsConverter.class)
+    @Convert(converter = CommaDelimitedStringsConverter.class)
     @Nullable
     private List<String> displayedFieldsLong;
 
     /**
      * @see #displayedFieldsLong
      */
-    @Convert(converter = DelimitedStringsConverter.class)
+    @Convert(converter = CommaDelimitedStringsConverter.class)
     @Nullable
     private List<String> displayedFieldsShort;
 

--- a/server/src/main/java/org/tctalent/server/model/db/CommaDelimitedStringsConverter.java
+++ b/server/src/main/java/org/tctalent/server/model/db/CommaDelimitedStringsConverter.java
@@ -17,6 +17,7 @@
 package org.tctalent.server.model.db;
 
 import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -27,7 +28,8 @@ import java.util.stream.Stream;
  *
  * @author John Cameron
  */
-public class DelimitedStringsConverter
+@Converter
+public class CommaDelimitedStringsConverter
         implements AttributeConverter<List<String>, String> {
     private final static String DELIMITER = ",";
 
@@ -38,7 +40,7 @@ public class DelimitedStringsConverter
 
     @Override
     public List<String> convertToEntityAttribute(String delimitedString) {
-        return delimitedString == null || delimitedString.trim().length() == 0
+        return delimitedString == null || delimitedString.trim().isEmpty()
                 ? null
                 : Stream.of(delimitedString.split(DELIMITER))
                         .collect(Collectors.toList());

--- a/server/src/main/java/org/tctalent/server/model/db/QuestionTaskImpl.java
+++ b/server/src/main/java/org/tctalent/server/model/db/QuestionTaskImpl.java
@@ -16,18 +16,17 @@
 
 package org.tctalent.server.model.db;
 
+import jakarta.persistence.Convert;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Transient;
+import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.lang.Nullable;
 import org.tctalent.server.model.db.task.AllowedQuestionTaskAnswer;
 import org.tctalent.server.model.db.task.QuestionTask;
 import org.tctalent.server.model.db.task.TaskType;
-
-import jakarta.persistence.Convert;
-import jakarta.persistence.DiscriminatorValue;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Transient;
-import java.util.List;
 
 /**
  * Default Implementation
@@ -45,7 +44,7 @@ public class QuestionTaskImpl extends TaskImpl implements QuestionTask {
      * If exist the question task answer format will be a dropdown.
      */
     @Nullable
-    @Convert(converter = DelimitedStringsConverter.class)
+    @Convert(converter = CommaDelimitedStringsConverter.class)
     private List<String> explicitAllowedAnswers;
 
     /**

--- a/server/src/main/java/org/tctalent/server/model/db/SkillsEscoEn.java
+++ b/server/src/main/java/org/tctalent/server/model/db/SkillsEscoEn.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2025 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.model.db;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.io.Serializable;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * TODO JC Doc
+ *
+ * @author John Cameron
+ */
+@Entity
+@Table(name = "skills_esco_en")
+@Getter
+@Setter
+public class SkillsEscoEn implements Serializable {
+    @Id
+    private String concepturi;
+
+    private String concepttype;
+
+    private String skilltype;
+    private String preferredlabel;
+    private String altlabels;
+    private String hiddenlabels;
+    private String definition;
+    private String description;
+
+}

--- a/server/src/main/java/org/tctalent/server/model/db/SkillsEscoEn.java
+++ b/server/src/main/java/org/tctalent/server/model/db/SkillsEscoEn.java
@@ -24,7 +24,7 @@ import lombok.Getter;
 import lombok.Setter;
 
 /**
- * TODO JC Doc
+ * Entity corresponding to imported English language ESCO skills.
  *
  * @author John Cameron
  */

--- a/server/src/main/java/org/tctalent/server/model/db/UploadTaskImpl.java
+++ b/server/src/main/java/org/tctalent/server/model/db/UploadTaskImpl.java
@@ -16,6 +16,12 @@
 
 package org.tctalent.server.model.db;
 
+import jakarta.persistence.Convert;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.lang.NonNull;
@@ -23,9 +29,6 @@ import org.springframework.lang.Nullable;
 import org.tctalent.server.model.db.task.TaskType;
 import org.tctalent.server.model.db.task.UploadTask;
 import org.tctalent.server.model.db.task.UploadType;
-
-import jakarta.persistence.*;
-import java.util.List;
 
 /**
  * Default Implementation
@@ -55,7 +58,7 @@ public class UploadTaskImpl extends TaskImpl implements UploadTask {
      * Allowable file types (eg pdf, doc, jpg etc). If null, any file type is acceptable.
      */
     @Nullable
-    @Convert(converter = DelimitedStringsConverter.class)
+    @Convert(converter = CommaDelimitedStringsConverter.class)
     private List<String> uploadableFileTypes;
 
     /*

--- a/server/src/main/java/org/tctalent/server/repository/db/SkillsEscoEnRepository.java
+++ b/server/src/main/java/org/tctalent/server/repository/db/SkillsEscoEnRepository.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2024 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.repository.db;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.tctalent.server.model.db.SkillsEscoEn;
+
+public interface SkillsEscoEnRepository extends JpaRepository<SkillsEscoEn, String> {
+}

--- a/server/src/main/java/org/tctalent/server/repository/db/SkillsEscoEnRepository.java
+++ b/server/src/main/java/org/tctalent/server/repository/db/SkillsEscoEnRepository.java
@@ -16,8 +16,12 @@
 
 package org.tctalent.server.repository.db;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.tctalent.server.model.db.SkillsEscoEn;
 
 public interface SkillsEscoEnRepository extends JpaRepository<SkillsEscoEn, String> {
+
+    Page<SkillsEscoEn> findBySkilltype(String skilltype, Pageable pageable);
 }

--- a/server/src/main/java/org/tctalent/server/service/db/SkillsService.java
+++ b/server/src/main/java/org/tctalent/server/service/db/SkillsService.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2025 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.service.db;
+
+import java.util.List;
+import org.springframework.lang.NonNull;
+
+/**
+ * TODO JC Doc
+ *
+ * @author John Cameron
+ */
+public interface SkillsService {
+
+    /**
+     * Returns the English language skills defined by Esco.
+     * <p>
+     * Skills can be single words or short phrases. There could be around 20,000 of them. This list
+     * of skills does not change often - so the skill list will be cached.
+     *
+     * @return Skills.
+     */
+    @NonNull
+    List<String> getEscoSkills();
+}

--- a/server/src/main/java/org/tctalent/server/service/db/SkillsService.java
+++ b/server/src/main/java/org/tctalent/server/service/db/SkillsService.java
@@ -20,7 +20,7 @@ import java.util.List;
 import org.springframework.lang.NonNull;
 
 /**
- *
+ * Service related to exposing and managing skills.
  *
  * @author John Cameron
  */

--- a/server/src/main/java/org/tctalent/server/service/db/SkillsService.java
+++ b/server/src/main/java/org/tctalent/server/service/db/SkillsService.java
@@ -20,20 +20,24 @@ import java.util.List;
 import org.springframework.lang.NonNull;
 
 /**
- * TODO JC Doc
+ *
  *
  * @author John Cameron
  */
 public interface SkillsService {
 
     /**
-     * Returns the English language skills defined by Esco.
+     * Returns English language skills.
      * <p>
      * Skills can be single words or short phrases. There could be around 20,000 of them. This list
      * of skills does not change often - so the skill list will be cached.
+     * <p>
+     * These skills can come from multiple sources (for example Esco and ONet).
+     * <p>
+     * All skills are converted to lower case and duplicates are removed.
      *
-     * @return Skills.
+     * @return Immutable list of skills.
      */
     @NonNull
-    List<String> getEscoSkills();
+    List<String> getSkills();
 }

--- a/server/src/main/java/org/tctalent/server/service/db/impl/SkillsServiceImpl.java
+++ b/server/src/main/java/org/tctalent/server/service/db/impl/SkillsServiceImpl.java
@@ -43,29 +43,39 @@ public class SkillsServiceImpl implements SkillsService {
     private final static int INITIAL_CAPACITY = 25_000;
 
     @Override
-    public @NonNull List<String> getEscoSkills() {
+    public @NonNull List<String> getSkills() {
 
         if (cachedList == null) {
             Set<String> skills = new HashSet<>(INITIAL_CAPACITY);
-            PageRequest request = PageRequest.ofSize(CHUNK_SIZE);
-            request = request.first();
-            Page<SkillsEscoEn> page;
-            do {
-                //Get page of skills
-                page = skillsEscoEnRepository.findBySkilltype("knowledge", request);
-                //Process skills in page
-                final List<SkillsEscoEn> pageContent = page.getContent();
-                for (SkillsEscoEn skillsEscoEn : pageContent) {
-                    addSkills(skills, skillsEscoEn);
-                }
-                request = request.next();
-            } while (page.hasNext());
+
+            loadEscoSkills(skills);
+            loadOnetSkills(skills);
 
             //Copy into an immutable list so that it can be shared around.
             cachedList = List.copyOf(skills);
         }
 
         return cachedList;
+    }
+
+    private void loadOnetSkills(Set<String> skills) {
+        //TODO JC Implement loadOnetSkills
+    }
+
+    private void loadEscoSkills(Set<String> skills) {
+        PageRequest request = PageRequest.ofSize(CHUNK_SIZE);
+        request = request.first();
+        Page<SkillsEscoEn> page;
+        do {
+            //Get page of skills
+            page = skillsEscoEnRepository.findBySkilltype("knowledge", request);
+            //Process skills in page
+            final List<SkillsEscoEn> pageContent = page.getContent();
+            for (SkillsEscoEn skillsEscoEn : pageContent) {
+                addSkills(skills, skillsEscoEn);
+            }
+            request = request.next();
+        } while (page.hasNext());
     }
 
     private void addSkills(Collection<String> skills, SkillsEscoEn see) {

--- a/server/src/main/java/org/tctalent/server/service/db/impl/SkillsServiceImpl.java
+++ b/server/src/main/java/org/tctalent/server/service/db/impl/SkillsServiceImpl.java
@@ -19,6 +19,7 @@ package org.tctalent.server.service.db.impl;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -97,17 +98,17 @@ public class SkillsServiceImpl implements SkillsService {
 
         final String preferredlabel = see.getPreferredlabel();
         if (!ObjectUtils.isEmpty(preferredlabel)) {
-            skills.add(preferredlabel.toLowerCase());
+            skills.add(preferredlabel.toLowerCase(Locale.ENGLISH));
         }
 
         final String altLabels = see.getPreferredlabel();
         if (!ObjectUtils.isEmpty(altLabels)) {
-            addDelimitedSkills(skills, altLabels.toLowerCase());
+            addDelimitedSkills(skills, altLabels.toLowerCase(Locale.ENGLISH));
         }
 
         final String hiddenLabels = see.getPreferredlabel();
         if (!ObjectUtils.isEmpty(hiddenLabels)) {
-            addDelimitedSkills(skills, hiddenLabels.toLowerCase());
+            addDelimitedSkills(skills, hiddenLabels.toLowerCase(Locale.ENGLISH));
         }
     }
 

--- a/server/src/main/java/org/tctalent/server/service/db/impl/SkillsServiceImpl.java
+++ b/server/src/main/java/org/tctalent/server/service/db/impl/SkillsServiceImpl.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2025 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.service.db.impl;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Service;
+import org.springframework.util.ObjectUtils;
+import org.tctalent.server.model.db.SkillsEscoEn;
+import org.tctalent.server.service.db.SkillsService;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SkillsServiceImpl implements SkillsService {
+    private final SkillsService skillsService;
+    private List<String> cachedList;
+
+    private final static String DELIMITER = "\n";
+
+    @Override
+    public @NonNull List<String> getEscoSkills() {
+
+        if (cachedList == null) {
+            List<String> skills = new ArrayList<>(20_000); //todo How big should this be?
+
+            //TODO JC Get page of skills
+                //TODO JC Process skills in page
+                    SkillsEscoEn see = new SkillsEscoEn(); //todo read from page
+                    addSkills(skills, see);
+
+            cachedList = Collections.unmodifiableList(skills);
+        }
+
+        return cachedList;
+    }
+
+    private void addSkills(List<String> skills, SkillsEscoEn see) {
+        skills.add(see.getPreferredlabel());
+
+        addDelimitedSkills(skills, see.getAltlabels());
+
+        addDelimitedSkills(skills, see.getHiddenlabels());
+    }
+
+    private void addDelimitedSkills(List<String> skills, String delimitedLabels) {
+        if (ObjectUtils.isEmpty(delimitedLabels)) {
+            skills.addAll(List.of(delimitedLabels.split(DELIMITER)));
+        }
+    }
+}

--- a/server/src/main/java/org/tctalent/server/service/db/impl/SkillsServiceImpl.java
+++ b/server/src/main/java/org/tctalent/server/service/db/impl/SkillsServiceImpl.java
@@ -40,14 +40,13 @@ public class SkillsServiceImpl implements SkillsService {
 
     private final static int CHUNK_SIZE = 100;
     private final static String DELIMITER = "\n";
-    private final static int INITIAL_CAPACITY = 25_000;  //todo How big should this be?
+    private final static int INITIAL_CAPACITY = 25_000;
 
     @Override
     public @NonNull List<String> getEscoSkills() {
 
         if (cachedList == null) {
             Set<String> skills = new HashSet<>(INITIAL_CAPACITY);
-            //TODO JC Could this be a hashSet to eliminate duplicates?
             PageRequest request = PageRequest.ofSize(CHUNK_SIZE);
             request = request.first();
             Page<SkillsEscoEn> page;
@@ -62,6 +61,7 @@ public class SkillsServiceImpl implements SkillsService {
                 request = request.next();
             } while (page.hasNext());
 
+            //Copy into an immutable list so that it can be shared around.
             cachedList = List.copyOf(skills);
         }
 

--- a/server/src/main/java/org/tctalent/server/service/db/impl/SkillsServiceImpl.java
+++ b/server/src/main/java/org/tctalent/server/service/db/impl/SkillsServiceImpl.java
@@ -31,6 +31,21 @@ import org.tctalent.server.model.db.SkillsEscoEn;
 import org.tctalent.server.repository.db.SkillsEscoEnRepository;
 import org.tctalent.server.service.db.SkillsService;
 
+/**
+ * This service imports skills from
+ * <a href="https://esco.ec.europa.eu/en/use-esco/download">ESCO</a>
+ * which requires the following acknowledgements:
+ * <ul>
+ *     <li>
+ * For services, tools and applications integrating totally or partially ESCO:
+ * "This service uses the ESCO classification of the European Commission."
+ *     </li>
+ *     <li>
+ * For other documents such as studies, analysis or reports making use of ESCO:
+ * "This publication uses the ESCO classification of the European Commission."
+ *     </li>
+ * </ul>
+ */
 @Service
 @RequiredArgsConstructor
 @Slf4j

--- a/server/src/main/resources/db/migration/V1_377__create_service_resource_table.sql
+++ b/server/src/main/resources/db/migration/V1_377__create_service_resource_table.sql
@@ -1,0 +1,42 @@
+create table if not exists service_resource (
+    id bigserial primary key,
+    provider varchar(255) not null,                    -- e.g. "DUOLINGO", etc.
+    service_code varchar(255) not null,                -- e.g. "TEST_PROCTORED"
+    resource_code varchar(255),                        -- e.g. coupon ID; nullable if not applicable
+    status varchar(255) not null,                      -- e.g. AVAILABLE | RESERVED | SENT | REDEEMED | EXPIRED | DISABLED
+    expires_at timestamptz,
+    sent_at timestamptz,
+    created_at timestamptz not null default now()
+);
+
+/*
+ * Copyright (c) 2025 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+-- prevent duplicate concrete tokens per provider
+create unique index if not exists sr_provider_resource_uq_idx
+    on service_resource(provider, resource_code)
+    where resource_code is not null;
+
+-- fast allocation: for provider+service_code+status(e.g. 'AVAILABLE') then order by id
+create index if not exists sr_provider_sc_status_idx
+    on service_resource(provider, service_code, status);
+
+-- for general lookups by provider+service_code
+create index if not exists sr_provider_service_idx
+    on service_resource(provider, service_code, id);
+
+
+

--- a/server/src/main/resources/db/migration/V1_378__create_service_assignment_table.sql
+++ b/server/src/main/resources/db/migration/V1_378__create_service_assignment_table.sql
@@ -1,0 +1,37 @@
+create table if not exists service_assignment (
+    id bigserial primary key,
+    provider varchar(255) not null,                     -- e.g. "DUOLINGO", etc.
+    service_code varchar(255) not null,                 -- e.g. "TEST_PROCTORED"
+    resource_id bigint references service_resource(id) on delete set null,
+    candidate_id bigint not null references candidate(id),
+    actor_id bigint references users(id),
+    status varchar(255) not null,                     -- e.g. ASSIGNED | REDEEMED | EXPIRED | REASSIGNED
+    assigned_at timestamptz not null,
+    created_at timestamptz not null default now()
+);
+
+create index if not exists sa_resource_idx on service_assignment(resource_id);
+create index if not exists sa_candidate_idx on service_assignment(candidate_id);
+create index if not exists sa_provider_service_candidate_status_time_idx
+    on service_assignment(provider, service_code, candidate_id, status, assigned_at desc);
+
+/*
+ * Copyright (c) 2025 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+-- At most one current assignment per resource (resource-backed services)
+create unique index if not exists sa_assigned_per_resource_uq_idx
+    on service_assignment(resource_id)
+    where status = 'ASSIGNED' and resource_id is not null;

--- a/server/src/main/resources/db/migration/V1_379__create_esco_skills_table.sql
+++ b/server/src/main/resources/db/migration/V1_379__create_esco_skills_table.sql
@@ -1,7 +1,7 @@
 create table if not exists skills_esco_en
 (
     concepttype    text,
-    concepturi     text,
+    concepturi     text primary key,
     skilltype      text,
     reuselevel     text,
     preferredlabel text,

--- a/server/src/main/resources/db/migration/V1_379__create_esco_skills_table.sql
+++ b/server/src/main/resources/db/migration/V1_379__create_esco_skills_table.sql
@@ -1,0 +1,16 @@
+create table if not exists skills_esco_en
+(
+    concepttype    text,
+    concepturi     text,
+    skilltype      text,
+    reuselevel     text,
+    preferredlabel text,
+    altlabels      text,
+    hiddenlabels   text,
+    status         text,
+    modifieddate   text,
+    scopenote      text,
+    definition     text,
+    inscheme       text,
+    description    text
+);

--- a/server/src/test/java/org/tctalent/server/service/db/impl/SkillsServiceImplTest.java
+++ b/server/src/test/java/org/tctalent/server/service/db/impl/SkillsServiceImplTest.java
@@ -38,8 +38,8 @@ class SkillsServiceImplTest {
     }
 
     @Test
-    void getEscoSkills() {
-        final List<String> escoSkills = skillsService.getEscoSkills();
+    void getSkills() {
+        final List<String> escoSkills = skillsService.getSkills();
         assertNotNull(escoSkills);
     }
 }

--- a/server/src/test/java/org/tctalent/server/service/db/impl/SkillsServiceImplTest.java
+++ b/server/src/test/java/org/tctalent/server/service/db/impl/SkillsServiceImplTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2025 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.service.db.impl;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.tctalent.server.service.db.SkillsService;
+
+@Tag("skip-test-in-gradle-build")
+@SpringBootTest
+class SkillsServiceImplTest {
+
+    @Autowired
+    private SkillsService skillsService;
+
+    @BeforeEach
+    void setUp() {
+    }
+
+    @Test
+    void getEscoSkills() {
+        final List<String> escoSkills = skillsService.getEscoSkills();
+        assertNotNull(escoSkills);
+    }
+}


### PR DESCRIPTION
This PR also does a simple rename refactor of DelimitedStringsConverter to CommaDelimitedStringsConverter - although it does not actually use it. The idea was that we might have use in future for a delimiter other than comma. For example, ESCO uses new line characters to delimit some multi value strings.

That refactoring touches a number of files that are not related to the actual issue.