### PR TITLE
2589 download of autogenerated cv not working for candidate 289669 on production

### DIFF
--- a/server/src/main/java/org/tctalent/server/service/db/util/PdfHelper.java
+++ b/server/src/main/java/org/tctalent/server/service/db/util/PdfHelper.java
@@ -28,6 +28,7 @@ import org.springframework.stereotype.Service;
 import org.tctalent.server.exception.PdfGenerationException;
 import org.tctalent.server.logging.LogBuilder;
 import org.tctalent.server.model.db.Candidate;
+import org.tctalent.server.util.html.HtmlSanitizer;
 import org.tctalent.server.util.html.StringSanitizer;
 import org.thymeleaf.TemplateEngine;
 import org.thymeleaf.context.Context;
@@ -117,12 +118,18 @@ public class PdfHelper {
 
 
     private static void cleanCandidateJobDescriptions(Candidate candidate) {
-        candidate.getCandidateJobExperiences().forEach(jobExperience ->
-            jobExperience.setDescription(
-                StringSanitizer.replaceLsepWithBr(jobExperience.getDescription())
-            )
-        );
+        candidate.getCandidateJobExperiences().forEach(jobExperience -> {
+            jobExperience.setRole(StringSanitizer.normalizeUnicodeText(jobExperience.getRole()));
+            jobExperience.setCompanyName(
+                StringSanitizer.normalizeUnicodeText(jobExperience.getCompanyName()));
+
+            String description = StringSanitizer.normalizeUnicodeText(jobExperience.getDescription());
+            String sanitizedDescription = HtmlSanitizer.sanitize(description);
+            sanitizedDescription = StringSanitizer.replaceLsepWithBr(sanitizedDescription);
+            jobExperience.setDescription(sanitizedDescription);
+        });
     }
+
 
     private static String convertToXhtml(String html) {
         Tidy tidy = new Tidy();

--- a/server/src/main/java/org/tctalent/server/util/html/StringSanitizer.java
+++ b/server/src/main/java/org/tctalent/server/util/html/StringSanitizer.java
@@ -127,4 +127,23 @@ public class StringSanitizer {
     return cleaned;
   }
 
+  /**
+   * Normalizes smart quotes, dashes, and other problematic Unicode punctuation
+   * into ASCII-safe equivalents for XHTML/PDF rendering.
+   */
+  public static String normalizeUnicodeText(@Nullable String input) {
+    if (input == null) {
+      return null;
+    }
+    return input
+        .replace("’", "'")
+        .replace("‘", "'")
+        .replace("“", "\"")
+        .replace("”", "\"")
+        .replace("–", "-")
+        .replace("—", "-")
+        .replace("…", "...");
+  }
+
+
 }


### PR DESCRIPTION
The issue was caused by unnormalized or unescaped Unicode characters (such as smart quotes ’) and raw HTML content within candidate job experience fields.
During PDF generation, these characters made the XHTML invalid, which caused Flying Saucer’s XML parser to throw a SAXParseException (“well-formed character data” error).
To fix this, I updated the cleanCandidateJobDescriptions method to normalize and sanitize text fields before PDF rendering.
Normalized Unicode punctuation in role, companyName, and description to prevent invalid XML characters.