### PR TITLE
2552 UI rollover tasks monitor list component styling

### DIFF
--- a/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.html
+++ b/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.html
@@ -657,7 +657,7 @@
                   [candidate]="candidate"
                   [completedTasks]="getCompletedMonitoredTasks(candidate)"
                   [totalTasks]="getTotalMonitoredTasks(candidate)"
-                  [size]="'sm'">
+                  [size]="'md'">
                 </app-tasks-monitor>
                 <app-potential-duplicate-icon
                   [candidate]="candidate"

--- a/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.html
+++ b/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.html
@@ -653,6 +653,7 @@
                   [color]="'primary'">
                 </app-cv-icon>
                 <app-tasks-monitor
+                  class="mx-2"
                   *ngIf="hasTaskAssignments(candidate)"
                   [candidate]="candidate"
                   [completedTasks]="getCompletedMonitoredTasks(candidate)"

--- a/ui/admin-portal/src/app/components/tasks/assign-tasks-list/assign-tasks-list.component.html
+++ b/ui/admin-portal/src/app/components/tasks/assign-tasks-list/assign-tasks-list.component.html
@@ -17,15 +17,11 @@
 <tc-modal [heading]="'Associate Task with List'"
           [disableAction]="assignForm.invalid || loading"
           (onAction)="onSave()"
+          actionText="Add Task"
           [showCancel]="true"
           [cancelText]="'Close'"
           [showClose]="true">
 
-  <div *ngIf="loading">
-    <i class="fas fa-spinner fa-spin"></i>
-  </div>
-
-  <div *ngIf="!loading">
 
     <tc-alert type="danger" *ngIf="error">
       <div><strong>{{error}}</strong></div>
@@ -66,45 +62,57 @@
       </div>
 
     </form>
-  </div>
 
-  <div class="d-block pt-lg-4">
-    <div class="paragraph-lg mb-3">Current Task Associations</div>
-    <tc-field>
-      <tc-input [type]="'text'"
-                class="mb-3"
-                [placeholder]="'Search within...'"
-                [ariaLabel]="'Search'"
-                (keyup)="search($event.target)"
-                [id]="'keyword'">
-      </tc-input>
-    </tc-field>
 
-    <div *ngFor="let t of filteredTaskAssociations;">
-      <div class="container card grey-bg" [ngClass]="{'required-task-bg': !t.optional, 'optional-task-bg': t.optional}">
-        <div class="row align-items-center">
-          <div class="col">
+
+    <tc-table [results]="filteredTaskAssociations" [loading]="loading" name="Current Task Associations">
+      <tc-loading [loading]="loading"></tc-loading>
+      <thead>
+      <tr>
+        <th>Task</th>
+        <th>Current Assignments</th>
+        <th>      <tc-field>
+          <tc-input [type]="'text'"
+                    [placeholder]="'Search current tasks...'"
+                    [ariaLabel]="'Search'"
+                    (keyup)="search($event.target)"
+                    [id]="'keyword'">
+          </tc-input>
+        </tc-field></th>
+      </tr>
+      </thead>
+      <tbody *ngFor="let t of filteredTaskAssociations;">
+        <tr>
+          <td>
             <p class="small fw-light mb-0"><span *ngIf="!t.optional">*</span>{{t.displayName}}</p>
-          </div>
-          <div class="col-auto">
+          </td>
+          <td>
             <app-tasks-monitor-list
               [task]="t"
               [list]="savedList">
             </app-tasks-monitor-list>
-          </div>
-          <div class="col-auto">
-            <div class="btn-group float-end">
-              <button type="button" class="btn" aria-label="Close" (click)="monitorTask(t)">
+          </td>
+          <td>
+            <div class="float-end">
+              <tc-icon size="md"
+                       type="button"
+                       class="me-4"
+                       aria-label="Monitor Task"
+                       [ngbTooltip]="'Zoom in to view current assignments for this task only'"
+                       (click)="monitorTask(t)">
                 <i class="fas fa-search-plus"></i>
-              </button>
-              <button type="button" class="btn" aria-label="Close" (click)="removeTask(t)">
+              </tc-icon>
+              <tc-icon size="md"
+                       type="button"
+                       aria-label="Remove Task"
+                       [ngbTooltip]="'Remove this task from the candidates in this list'"
+                       (click)="removeTask(t)">
                 <i class="far fa-trash-alt"></i>
-              </button>
+              </tc-icon>
             </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
+          </td>
+        </tr>
+      </tbody>
+    </tc-table>
 
 </tc-modal>

--- a/ui/admin-portal/src/app/components/tasks/assign-tasks-list/assign-tasks-list.component.scss
+++ b/ui/admin-portal/src/app/components/tasks/assign-tasks-list/assign-tasks-list.component.scss
@@ -14,10 +14,12 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
+@import 'src/scss/color-mixins';
+
 .required-task-bg {
-  background-color: #cdcdcd;
+  @include background-color-primary-light;
 }
 
 .optional-task-bg {
-  background-color: #e4e4e4;
+  @include background-color-light;
 }

--- a/ui/admin-portal/src/app/components/tasks/assign-tasks-list/assign-tasks-list.component.ts
+++ b/ui/admin-portal/src/app/components/tasks/assign-tasks-list/assign-tasks-list.component.ts
@@ -97,6 +97,7 @@ export class AssignTasksListComponent implements OnInit {
         //todo This should really do a search with the current filter. Can we make the search
         //part of the component so we can access the filter data in this code.
         this.filteredTaskAssociations = result.tasks;
+        this.assignForm.reset();
       }, (error) => {
         this.error = error;
       }
@@ -144,9 +145,9 @@ export class AssignTasksListComponent implements OnInit {
   }
 
   removeTask(task: Task) {
-    const confirmationModal = this.modalService.open(ConfirmationComponent, {scrollable: true});
+    const confirmationModal = this.modalService.open(ConfirmationComponent, {scrollable: true, size: 'lg'});
     confirmationModal.componentInstance.title =
-      "Are you sure you want to remove " + task.displayName + " from the associated list " + this.savedList.name + "?";
+      "Are you sure you want to remove '" + task.displayName + "' from the associated list '" + this.savedList.name + "'?";
     confirmationModal.componentInstance.message =
       "Note: Removing this task association will make the task inactive for any candidates within the list who have not completed the task. "
 

--- a/ui/admin-portal/src/app/components/util/confirm/confirmation.component.html
+++ b/ui/admin-portal/src/app/components/util/confirm/confirmation.component.html
@@ -19,11 +19,11 @@
           [actionText]="'Ok'"
           (onAction)="close()"
           [showClose]="true">
-  <span *ngIf="message">
+  <p *ngIf="message">
     {{message}}
-  </span>
+  </p>
 
-  <span *ngIf="!message">
+  <p *ngIf="!message">
     Are you sure?
-  </span>
+  </p>
 </tc-modal>

--- a/ui/admin-portal/src/app/components/util/confirm/confirmation.component.spec.ts
+++ b/ui/admin-portal/src/app/components/util/confirm/confirmation.component.spec.ts
@@ -63,13 +63,13 @@ describe('ConfirmationComponent', () => {
     component.message = 'Test message';
     fixture.detectChanges();
     const compiled = fixture.nativeElement;
-    expect(compiled.querySelector('span').textContent).toContain('Test message');
+    expect(compiled.querySelector('p').textContent).toContain('Test message');
   });
 
   it('should display "Are you sure?" if message is not provided', () => {
     component.message = null;
     fixture.detectChanges();
     const compiled = fixture.nativeElement;
-    expect(compiled.querySelector('span').textContent).toContain('Are you sure?');
+    expect(compiled.querySelector('p').textContent).toContain('Are you sure?');
   });
 });

--- a/ui/admin-portal/src/app/components/util/tasks-monitor-list/tasks-monitor-list.component.html
+++ b/ui/admin-portal/src/app/components/util/tasks-monitor-list/tasks-monitor-list.component.html
@@ -14,9 +14,7 @@
   ~ along with this program. If not, see https://www.gnu.org/licenses/.
   -->
 
-<div class="row">
-  <span class="col text-success fw-bold" [ngbTooltip]="this.completed?.length + ' completed'">{{this.completed?.length}}</span>
-  <span class="col text-warning fw-bold" [ngbTooltip]="this.abandoned?.length + ' abandoned'">{{this.abandoned?.length}}</span>
-  <span class="col fw-bold" [ngbTooltip]="this.outstandingNotOverdue?.length + ' outstanding not overdue'">{{this.outstandingNotOverdue?.length}}</span>
-  <span class="col text-danger fw-bold" [ngbTooltip]="this.outstandingOverdue?.length + ' outstanding overdue'">{{this.outstandingOverdue?.length}}</span>
-</div>
+<span class=" text-color-green fw-bold" [ngbTooltip]="this.completed?.length + ' completed'">{{this.completed?.length}}</span>
+<span class=" text-color-yellow fw-bold" [ngbTooltip]="this.abandoned?.length + ' abandoned'">{{this.abandoned?.length}}</span>
+<span class=" text-color-primary fw-bold" [ngbTooltip]="this.outstandingNotOverdue?.length + ' outstanding not overdue'">{{this.outstandingNotOverdue?.length}}</span>
+<span class=" text-color-red fw-bold" [ngbTooltip]="this.outstandingOverdue?.length + ' outstanding overdue'">{{this.outstandingOverdue?.length}}</span>

--- a/ui/admin-portal/src/app/components/util/tasks-monitor-list/tasks-monitor-list.component.scss
+++ b/ui/admin-portal/src/app/components/util/tasks-monitor-list/tasks-monitor-list.component.scss
@@ -14,3 +14,9 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
+span {
+  margin: 0 15px;
+  &:first-child {
+    margin-left: 0;
+  }
+}

--- a/ui/admin-portal/src/app/components/util/tasks-monitor/tasks-monitor.component.html
+++ b/ui/admin-portal/src/app/components/util/tasks-monitor/tasks-monitor.component.html
@@ -17,11 +17,11 @@
 <div class="d-inline-block"
      *ngIf="!hasCompleted"
      [ngClass]="sizeClass">
-  <sup class="fw-bold" [ngClass]="{'text-danger' : hasOverdue,'text-warning' : hasAbandoned}">
+  <sup class="fw-bold" [ngClass]="{'text-color-red' : hasOverdue,'text-color-yellow' : hasAbandoned}">
     {{this.completedTasks.length}}
   </sup>
   &frasl;
-  <sub class="text-muted fw-bold">
+  <sub class="text-color-secondary fw-bold">
     {{this.totalTasks.length}}
   </sub>
 </div>

--- a/ui/admin-portal/src/app/shared/components/modal/tc-modal.component.html
+++ b/ui/admin-portal/src/app/shared/components/modal/tc-modal.component.html
@@ -1,13 +1,12 @@
 <div class="tc-modal" [ngClass]="icon ? 'has-icon' : 'no-icon'">
   <!-- Optional close (X) button -->
   <tc-icon
+    id="close-btn"
     *ngIf="showClose"
     [type]="'button'"
     (click)="dismiss()"
     [color]="'gray'"
-    [size]="'md'"
-    style="position: absolute; top: 1.5rem; right: 2rem; cursor: pointer"
-  >
+    [size]="'md'">
     <i class="fa-solid fa-xmark"></i>
   </tc-icon>
 

--- a/ui/admin-portal/src/app/shared/components/modal/tc-modal.component.scss
+++ b/ui/admin-portal/src/app/shared/components/modal/tc-modal.component.scss
@@ -14,6 +14,12 @@
       text-align: end;
     }
   }
+  #close-btn {
+    position: absolute;
+    top: 1.5rem;
+    right: 2rem;
+    cursor: pointer;
+  }
 }
 
 .tc-modal-header {


### PR DESCRIPTION
Updated to use new table component and also updated colours for the tasks monitor

<img width="1167" height="1051" alt="Screenshot 2025-10-23 at 2 07 54 pm" src="https://github.com/user-attachments/assets/7bdb71bb-4a6b-4a40-8b34-161cb383f4be" />
