### PR TITLE
2653 Update candidate-mini-intake-tab.component.ts

### DIFF
--- a/ui/admin-portal/src/app/components/candidates/view/tab/candidate-mini-intake-tab/candidate-mini-intake-tab.component.ts
+++ b/ui/admin-portal/src/app/components/candidates/view/tab/candidate-mini-intake-tab/candidate-mini-intake-tab.component.ts
@@ -23,7 +23,10 @@ import {EducationLevelService} from "../../../../../services/education-level.ser
 import {OccupationService} from "../../../../../services/occupation.service";
 import {LanguageLevelService} from "../../../../../services/language-level.service";
 import {CandidateNoteService} from "../../../../../services/candidate-note.service";
-import {CandidateExamService, CreateCandidateExamRequest} from "../../../../../services/candidate-exam.service";
+import {
+  CandidateExamService,
+  CreateCandidateExamRequest
+} from "../../../../../services/candidate-exam.service";
 import {
   CandidateCitizenshipService,
   CreateCandidateCitizenshipRequest
@@ -115,7 +118,7 @@ export class CandidateMiniIntakeTabComponent extends IntakeComponentTabBase {
       backdrop: 'static'
     });
 
-    editCandidateModal.componentInstance.candidateId = this.candidate.id;
+    editCandidateModal.componentInstance.candidate = this.candidate;
 
     editCandidateModal.result
     .then((candidate) => this.candidate = candidate)


### PR DESCRIPTION
The EditCandidateContactComponent is used by both the ViewCandidateContactComponent and the CandidateMiniIntakeComponent. In the ViewCandidateContactComponent, the modal opening function correctly uses the candidate, but the CandidateMiniIntakeComponent passes only candidate.id, which causes the input fields to appear blank and behave incorrectly.

Before
<img width="871" height="789" alt="Screenshot 2025-10-28 at 3 12 39 PM" src="https://github.com/user-attachments/assets/cd9f9b00-f345-464e-9ad2-424b9f435bf1" />
After
<img width="356" height="706" alt="Screenshot 2025-10-28 at 3 51 19 PM" src="https://github.com/user-attachments/assets/792dc3c7-7238-4b56-b333-fba519297a36" />
