### PR TITLE
2696 Unifying Icons in tables and adding striped columns

### DIFF
--- a/ui/admin-portal/src/app/shared/components/table/tc-table.component.scss
+++ b/ui/admin-portal/src/app/shared/components/table/tc-table.component.scss
@@ -8,6 +8,16 @@
   border-radius: 12px;
   padding: 32px 0 48px;
 
+  .table-responsive table.table {
+    tbody tr:nth-child(odd) {
+      @include background-color-white;
+    }
+
+    tbody tr:nth-child(even) {
+      background-color: color(gray, 50);
+    }
+  }
+
   .table-name {
     @include label-md;
     font-weight: 600;
@@ -73,5 +83,13 @@
   .alert-warning {
     background-color: color(yellow, 50) !important;
     --bs-alert-bg:  color(yellow, 50);
+  }
+
+  .tc-icon {
+    color: color(secondary, 500) !important;
+  }
+
+  .tc-icon > i {
+    font-size: 1rem !important;
   }
 }


### PR DESCRIPTION
This is an issue mentioned in the UI Rollover inconsistencies to review #2634 

> Icons in tables
color? I like the gray (or alternate to primary) as I think it leaves the focus on the primary elsewhere
size? I think the size sm seems to be quite small and might be trickier to view/click, so I suggest a bit bigger or inherited from the font size

According to the notes above I made the icons small and added an alternate color the secondary. I thought of adding gray but then I thought maybe it might be too much gray in the page. 
<img alt="Screenshot 2025-11-05 at 7 40 14 AM" src="https://github.com/user-attachments/assets/57db87b2-7c94-42a1-a5db-3ab7f15e5a3b" />
