### PR TITLE
2829 Update the pagination arrow color (when enabled) 

### DIFF
--- a/ui/admin-portal/src/app/shared/components/pagination/tc-pagination.component.scss
+++ b/ui/admin-portal/src/app/shared/components/pagination/tc-pagination.component.scss
@@ -21,7 +21,7 @@
         }
         .page-link {
           background-color: transparent;
-          @include text-color-secondary;
+          @include text-color-body;
         }
       }
     }


### PR DESCRIPTION
Update the pagination arrow color (when enabled) to a darker shade:
<img alt="Screenshot 2025-11-28 at 2 25 15 PM" src="https://github.com/user-attachments/assets/6fad4c71-f837-4534-bf8c-e3fc3d51a6eb" />
