### PR TITLE
IT-TTH-Show Comment Field Only When Abandon Is Checked & Prevent Invalid Submissions

### DIFF
--- a/ui/candidate-portal/src/app/components/profile/view/tab/tasks/task/candidate-task.component.html
+++ b/ui/candidate-portal/src/app/components/profile/view/tab/tasks/task/candidate-task.component.html
@@ -122,7 +122,7 @@
         </div>
       </div>
 
-      <div class="mb-3">
+      <div class="mb-3" *ngIf="form.get('abandoned')?.value">
         <label class="fw-bold form-label" for="comment">
           {{ 'TASKS.COMMENT.LABEL' | translate }}
         </label>
@@ -132,7 +132,10 @@
 
       <button class="btn btn-primary mt-2 align-self-start"
               type="submit"
-              [disabled]="form.invalid || form.pristine"
+              [disabled]="
+          (form.invalid || form.pristine) ||
+          (!form.get('abandoned')?.value && !completedTask)
+        "
       >
         {{ 'TASKS.TASK.SUBMIT-COMMENT' | translate }}
         <fa-icon *ngIf="saving" [spin]="true" icon="spinner"></fa-icon>

--- a/ui/candidate-portal/src/app/components/profile/view/tab/tasks/task/candidate-task.component.html
+++ b/ui/candidate-portal/src/app/components/profile/view/tab/tasks/task/candidate-task.component.html
@@ -122,10 +122,7 @@
         </div>
       </div>
 
-      <div class="mb-3" *ngIf="
-       selectedTask.task.taskType !== TaskType.Form ||
-       form.get('abandoned')?.value
-     ">
+      <div class="mb-3" *ngIf="isCommentVisible()">
         <label class="fw-bold form-label" for="comment">
           {{ 'TASKS.COMMENT.LABEL' | translate }}
         </label>
@@ -135,15 +132,7 @@
 
       <button class="btn btn-primary mt-2 align-self-start"
               type="submit"
-              [disabled]="
-          form.invalid ||
-          form.pristine ||
-          (
-            selectedTask.task.taskType === TaskType.Form &&
-            !form.get('abandoned')?.value &&
-            !completedTask
-          )
-        "
+              [disabled]="isSubmitDisabled()"
       >
         {{ 'TASKS.TASK.SUBMIT-COMMENT' | translate }}
         <fa-icon *ngIf="saving" [spin]="true" icon="spinner"></fa-icon>

--- a/ui/candidate-portal/src/app/components/profile/view/tab/tasks/task/candidate-task.component.html
+++ b/ui/candidate-portal/src/app/components/profile/view/tab/tasks/task/candidate-task.component.html
@@ -122,7 +122,10 @@
         </div>
       </div>
 
-      <div class="mb-3" *ngIf="form.get('abandoned')?.value">
+      <div class="mb-3" *ngIf="
+       selectedTask.task.taskType !== TaskType.Form ||
+       form.get('abandoned')?.value
+     ">
         <label class="fw-bold form-label" for="comment">
           {{ 'TASKS.COMMENT.LABEL' | translate }}
         </label>
@@ -133,8 +136,13 @@
       <button class="btn btn-primary mt-2 align-self-start"
               type="submit"
               [disabled]="
-          (form.invalid || form.pristine) ||
-          (!form.get('abandoned')?.value && !completedTask)
+          form.invalid ||
+          form.pristine ||
+          (
+            selectedTask.task.taskType === TaskType.Form &&
+            !form.get('abandoned')?.value &&
+            !completedTask
+          )
         "
       >
         {{ 'TASKS.TASK.SUBMIT-COMMENT' | translate }}

--- a/ui/candidate-portal/src/app/components/profile/view/tab/tasks/task/candidate-task.component.ts
+++ b/ui/candidate-portal/src/app/components/profile/view/tab/tasks/task/candidate-task.component.ts
@@ -275,5 +275,23 @@ export class CandidateTaskComponent implements OnInit {
     )
   }
 
+  isCommentVisible(): boolean {
+    return this.selectedTask?.task?.taskType !== TaskType.Form
+      || this.form.get('abandoned')?.value === true;
+  }
+
+  isSubmitDisabled(): boolean {
+    if (this.form.invalid || this.form.pristine) {
+      return true;
+    }
+
+    // For Form tasks, submit is only allowed when abandoned or completed
+    if (this.selectedTask?.task?.taskType === TaskType.Form) {
+      return !this.form.get('abandoned')?.value && !this.completedTask;
+    }
+
+    // All other task types allow normal comment submission
+    return false;
+  }
   protected readonly TaskType = TaskType;
 }

--- a/ui/candidate-portal/src/app/components/profile/view/tab/tasks/task/candidate-task.component.ts
+++ b/ui/candidate-portal/src/app/components/profile/view/tab/tasks/task/candidate-task.component.ts
@@ -275,4 +275,5 @@ export class CandidateTaskComponent implements OnInit {
     )
   }
 
+  protected readonly TaskType = TaskType;
 }


### PR DESCRIPTION
Changes Included:

- The comment textarea is now displayed only when the "Abandoned" checkbox is checked.
- Existing validation rules remain intact, ensuring a comment is still required when a task is abandoned.
- The submit button is disabled when abandon is unchecked, preventing invalid or empty submissions.