### PR TITLE
2852 Fix Candidate portal menu does not display well

### DIFF
--- a/ui/candidate-portal/src/app/components/header/header.component.html
+++ b/ui/candidate-portal/src/app/components/header/header.component.html
@@ -45,7 +45,7 @@
               <h5 class="mb-0 fw-bold">{{ 'HEADER.LANG.SELECT' | translate }}</h5>
             </div>
             <div class="dropdown-divider"></div>
-            <a class="dropdown-item text-center" *ngFor="let lang of languages" (click)="setLanguage(lang.language)">{{lang.label}}</a>
+            <a class="dropdown-item text-center" *ngFor="let lang of languages" (click)="setLanguage(lang.language)" (click)="closeNavbar()">{{lang.label}}</a>
           </div>
         </div>
       </div>
@@ -58,7 +58,7 @@
             {{ 'HEADER.NAV.ACCOUNT' | translate }} {{this.candidateService?.getCandNumberStorage()}}
           </a>
           <div class="dropdown-menu dropdown-menu-right" ngbDropdownMenu>
-            <a class="dropdown-item" [routerLink]="['/profile']">
+            <a class="dropdown-item" [routerLink]="['/profile']" (click)="closeNavbar()">
               {{ 'HEADER.NAV.PROFILE' | translate }}
             </a>
 
@@ -67,19 +67,19 @@
             (e.g. if d-sm-none it is hidden from small screens upwards until/if there's another d class - but shown on xs screens).
             On a small screen we want to hide Upload File (d-none) and then show on a large screen (d-lg-block).
             We want to see Upload File/Photo so that is only hidden once we hit large screens (d-lg-none). -->
-            <a class="dropdown-item d-none d-lg-block" [routerLink]="['/profile/edit/upload']">
+            <a class="dropdown-item d-none d-lg-block" [routerLink]="['/profile/edit/upload']" (click)="closeNavbar()">
               {{ 'HEADER.NAV.UPLOAD.FILE' | translate }}
             </a>
 
-            <a class="dropdown-item d-lg-none" [routerLink]="['/profile/edit/upload']">
+            <a class="dropdown-item d-lg-none" [routerLink]="['/profile/edit/upload']" (click)="closeNavbar()">
               {{ 'HEADER.NAV.UPLOAD.PHOTO' | translate }}
             </a>
 
-            <a *ngIf="isRegistered()" class="dropdown-item" [routerLink]="['/privacy']">
+            <a *ngIf="isRegistered()" class="dropdown-item" [routerLink]="['/privacy']" (click)="closeNavbar()">
               {{ 'HEADER.NAV.PRIVACY' | translate }}
             </a>
 
-            <a class="dropdown-item" (click)="logout()">
+            <a class="dropdown-item" (click)="logout()" (click)="closeNavbar()">
               {{ 'HEADER.NAV.LOGOUT' | translate }}
             </a>
           </div>
@@ -88,7 +88,7 @@
       </div>
 
       <!-- LOGIN -->
-      <a class="btn btn-link" [routerLink]="['/login']" *ngIf="!(authenticationService.loggedInUser$ | async)">
+      <a class="btn btn-link" [routerLink]="['/login']" *ngIf="!(authenticationService.loggedInUser$ | async)" (click)="closeNavbar()">
         {{ 'HEADER.NAV.LOGIN' | translate }}
       </a>
 

--- a/ui/candidate-portal/src/app/components/header/header.component.scss
+++ b/ui/candidate-portal/src/app/components/header/header.component.scss
@@ -55,7 +55,6 @@ $navbar-height: 80px;
 
 .navbar-staging {
   background-color: #7D0101;
-  height: 80px;
   #logo {
     visibility: hidden;
   }

--- a/ui/candidate-portal/src/app/components/header/header.component.ts
+++ b/ui/candidate-portal/src/app/components/header/header.component.ts
@@ -100,4 +100,8 @@ export class HeaderComponent implements OnInit {
   isLocalEnv(): boolean {
     return window.location.host == 'localhost:4200';
   }
+
+  closeNavbar() {
+    this.isNavbarCollapsed = true;
+  }
 }


### PR DESCRIPTION
This PR include :
Adding automatic navbar closing on menu items (This ensures the mobile menu closes properly instead of staying open)
Removing the fixed height from .navbar-staging (This was causing the staging dropdown to appear transparent and overlay the content)