### PR TITLE
Strip single quotes out of any key word query - messes up Postgres ts…

### DIFF
--- a/server/src/main/java/org/tctalent/server/util/CandidateSearchUtils.java
+++ b/server/src/main/java/org/tctalent/server/util/CandidateSearchUtils.java
@@ -177,6 +177,9 @@ public abstract class CandidateSearchUtils {
 
     /**
      * Builds a Postgres tsQuery string which corresponds to the given Elasticsearch Simple Query.
+     * <p>
+     *     See <a href="https://www.postgresql.org/docs/18/textsearch-intro.html">Postgres Text Search</a>
+     * </p>
      * @param esQuery Elasticsearch simple query. If null, it will return an empty string.
      * @return Postgres tsQuery SQL
      */
@@ -187,6 +190,9 @@ public abstract class CandidateSearchUtils {
 
         //Trim leading or trailing spaces - they confuse the regex below
         esQuery = esQuery.trim();
+
+        //Strip out any single quotes in the query - they mess up the tsquery syntax
+        esQuery = esQuery.replace("'", "");
 
         // Step 1: Handle quoted phrases: "quick brown" => quick <-> brown
         StringBuilder result = new StringBuilder();

--- a/ui/admin-portal/src/app/components/search/define-search/define-search.component.html
+++ b/ui/admin-portal/src/app/components/search/define-search/define-search.component.html
@@ -139,7 +139,7 @@
               </tc-button>
               <tc-input id="simpleQueryString"
                         type="text"
-                        placeholder="E.g. 'welder diesel+mechanic'"
+                        placeholder='E.g. welder "diesel mechanic"'
                         aria-label="Keyword Search"
                         formControlName="simpleQueryString"
                         (keyup.enter)="runKeywordSearchOnEnter($event)"


### PR DESCRIPTION
…query syntax.

Change Key word search placeholder which looks like single quotes are part of the syntax.