### PR TITLE
explicitly handle null partner response in findPartnerByPublicApiKey as NotFound

### DIFF
--- a/server/src/main/java/org/tctalent/server/api/admin/PartnerAdminApi.java
+++ b/server/src/main/java/org/tctalent/server/api/admin/PartnerAdminApi.java
@@ -123,6 +123,9 @@ public class PartnerAdminApi implements
     @GetMapping("public-api-key/{api-key}")
     public ResponseEntity<PublicApiPartnerDto> findPartnerByPublicApiKey(@PathVariable("api-key") String apiKey) {
         PublicApiPartnerDto partner = partnerService.findPublicApiPartnerDtoByKey(apiKey);
+        if (partner == null) {
+          return ResponseEntity.notFound().build();
+        }
         return ResponseEntity.ok(partner);
     }
 


### PR DESCRIPTION
This PR -

- Updates the findPartnerByPublicApiKey method in PartnerAdminApi to explicitly return a 404 Not Found response (instead of a successful response with a null body) when the partner is not found for the given API key.
