### PR TITLE
Add spacing between left panel and candidate card in split view layout

### DIFF
--- a/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.scss
+++ b/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.scss
@@ -76,7 +76,7 @@ $candidate-card-width: 40vw;
 
 
 .split {
-  margin-right:  #{$candidate-card-width};
+  margin-right: calc(#{$candidate-card-width} + (var(--bs-gutter-x)));
 }
 
 .split-view {

--- a/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.scss
+++ b/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.scss
@@ -76,6 +76,8 @@ $candidate-card-width: 40vw;
 
 
 .split {
+  // Adds a small, consistent gap between the left panel and the candidate card,
+  // matching the horizontal gutter used by container-fluid
   margin-right: calc(#{$candidate-card-width} + (var(--bs-gutter-x)));
 }
 


### PR DESCRIPTION
Tiny PR that adds spacing between left panel and candidate card in split view layout consistent with Bootstrap’s layout rhythm