### PR TITLE
Add documentation standards for JSDoc and Javadoc in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,19 @@ See [the README for how to run locally](README.md).
 Your patch should follow the same conventions & pass the same code quality
 checks as the rest of the project.
 
+### Documentation
+To improve code readability and maintainability we aspire to document the code with clear 
+explanations of components, classes, functions and variables. The documentation standard we have 
+decided to follow is **JSDoc** for Angular and **Javadoc** for Java code.
+
+For JSDoc follow the JSDoc style using annotations like @description for useful descriptions of 
+components and @example to provide code examples. For Javadoc follow the Javadoc style using @code 
+for code examples, @link for useful links and html for easy to read formatting.
+
+See:
+[the JSDoc documentation](https://jsdoc.app/).
+[the Javadoc documentation](https://docs.oracle.com/en/java/javase/17/docs/specs/javadoc/doc-comment-spec.html).
+
 ## Make a Pull Request
 
 At this point, you should switch back to your master branch and make sure it's

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,8 +78,8 @@ checks as the rest of the project.
 
 ### Documentation
 To improve code readability and maintainability we aspire to document the code with clear 
-explanations of components, classes, functions and variables. The documentation standard we have 
-decided to follow is **JSDoc** for Angular and **Javadoc** for Java code.
+explanations of components, classes, functions and variables. The documentation standard we follow 
+is **JSDoc** for Angular and **Javadoc** for Java code.
 
 For JSDoc follow the JSDoc style using annotations like @description for useful descriptions of 
 components and @example to provide code examples. For Javadoc follow the Javadoc style using @code 


### PR DESCRIPTION
This PR adds a note about our documentation standards to the contribution guidelines