### PR TITLE
2951 remove ng bootstrap accordion dependency in candidate portal

### DIFF
--- a/ui/candidate-portal/src/app/app.module.ts
+++ b/ui/candidate-portal/src/app/app.module.ts
@@ -17,6 +17,7 @@
 import {BrowserModule} from '@angular/platform-browser';
 import {NgModule} from '@angular/core';
 import {AppRoutingModule} from './app-routing.module';
+import {SharedModule} from './shared/shared.module';
 import {AppComponent} from './components/app.component';
 import {LandingComponent} from './components/landing/landing.component';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
@@ -362,6 +363,7 @@ export function HttpLoaderFactory(http: HttpClient) {
     FormsModule,
     NgbModule,
     NgbCollapseModule,
+    SharedModule,
     TranslateModule.forRoot({
       defaultLanguage: 'en',
       loader: {

--- a/ui/candidate-portal/src/app/components/register/education/registration-education.component.html
+++ b/ui/candidate-portal/src/app/components/register/education/registration-education.component.html
@@ -58,7 +58,7 @@
     </div>
 
     <p *ngIf="addingEducation && !candidateEducationItems.length">
-      {{ 'REGISTRATION.EDUCATION.MESSAGE' | translate }}}
+      {{ 'REGISTRATION.EDUCATION.MESSAGE' | translate }}
     </p>
 
     <!-- CREATE NEW EDUCATION -->

--- a/ui/candidate-portal/src/app/components/register/upload-file/registration-upload-file.component.html
+++ b/ui/candidate-portal/src/app/components/register/upload-file/registration-upload-file.component.html
@@ -20,43 +20,35 @@
   </ng-template>
 
     <div id="upload">
-      <ngb-accordion #a="ngbAccordion" [activeIds]="activeIds">
-        <ngb-panel id="upload-cv">
-          <ng-template ngbPanelTitle>
-            <div class="container">
-              <strong class="link underline"> {{ 'REGISTRATION.ATTACHMENTS.CV.NAME' | translate }}
-                <span triggers="mouseenter:mouseleave" [autoClose]="false" placement="end"
-                      [ngbPopover]="cvWarningHtml">
-                  <fa-icon icon="circle-question" class="fa-s"
-                           style="color: #10B0E3;"></fa-icon></span></strong>
-              <p class="mb-0 small">{{ 'REGISTRATION.ATTACHMENTS.CV.EXPLANATION' | translate }}  </p>
-            </div>
-          </ng-template>
-          <ng-template ngbPanelContent>
-            <app-candidate-attachments
-              [cv]="true">
-            </app-candidate-attachments>
-          </ng-template>
-        </ngb-panel>
-      </ngb-accordion>
+      <tc-accordion [activeIndexes]="activeIndexes" [showOpenCloseAll]="false">
+        <tc-accordion-item>
+          <div custom-header class="container">
+            <strong class="link underline"> {{ 'REGISTRATION.ATTACHMENTS.CV.NAME' | translate }}
+              <span triggers="mouseenter:mouseleave" [autoClose]="false" placement="end"
+                    [ngbPopover]="cvWarningHtml">
+                <fa-icon icon="circle-question" class="fa-s"
+                         style="color: #10B0E3;"></fa-icon></span></strong>
+            <p class="mb-0 small">{{ 'REGISTRATION.ATTACHMENTS.CV.EXPLANATION' | translate }}  </p>
+          </div>
+          <app-candidate-attachments
+            [cv]="true">
+          </app-candidate-attachments>
+        </tc-accordion-item>
+      </tc-accordion>
 
       <br>
 
-      <ngb-accordion #b="ngbAccordion">
-        <ngb-panel id="upload-file">
-          <ng-template ngbPanelTitle>
-            <div class="container">
-              <strong class="link underline">{{ 'REGISTRATION.ATTACHMENTS.OTHER.NAME' | translate }}</strong>
-              <p class="mb-0 small">{{ 'REGISTRATION.ATTACHMENTS.OTHER.EXPLANATION' | translate }}</p>
-            </div>
-          </ng-template>
-          <ng-template ngbPanelContent>
-            <app-candidate-attachments
-              [cv]="false">
-            </app-candidate-attachments>
-          </ng-template>
-        </ngb-panel>
-      </ngb-accordion>
+      <tc-accordion [showOpenCloseAll]="false">
+        <tc-accordion-item>
+          <div custom-header class="container">
+            <strong class="link underline">{{ 'REGISTRATION.ATTACHMENTS.OTHER.NAME' | translate }}</strong>
+            <p class="mb-0 small">{{ 'REGISTRATION.ATTACHMENTS.OTHER.EXPLANATION' | translate }}</p>
+          </div>
+          <app-candidate-attachments
+            [cv]="false">
+          </app-candidate-attachments>
+        </tc-accordion-item>
+      </tc-accordion>
     </div>
 
 </div>

--- a/ui/candidate-portal/src/app/components/register/upload-file/registration-upload-file.component.spec.ts
+++ b/ui/candidate-portal/src/app/components/register/upload-file/registration-upload-file.component.spec.ts
@@ -15,6 +15,11 @@
  */
 
 import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {TranslateModule, TranslateService} from '@ngx-translate/core';
+import {HttpClientTestingModule} from '@angular/common/http/testing';
+import {RouterTestingModule} from '@angular/router/testing';
+import {RegistrationService} from '../../../services/registration.service';
+import {SharedModule} from '../../../shared/shared.module';
 
 import {RegistrationUploadFileComponent} from './registration-upload-file.component';
 
@@ -24,7 +29,17 @@ describe('UploadFileComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ RegistrationUploadFileComponent ]
+      declarations: [ RegistrationUploadFileComponent ],
+      imports: [
+        SharedModule,
+        HttpClientTestingModule,
+        RouterTestingModule,
+        TranslateModule.forRoot()
+      ],
+      providers: [
+        RegistrationService,
+        TranslateService
+      ]
     })
     .compileComponents();
   });
@@ -37,5 +52,17 @@ describe('UploadFileComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should initialize activeIndexes to 0 when edit is false', () => {
+    component.edit = false;
+    component.ngOnInit();
+    expect(component.activeIndexes).toBe(0);
+  });
+
+  it('should initialize activeIndexes to null when edit is true', () => {
+    component.edit = true;
+    component.ngOnInit();
+    expect(component.activeIndexes).toBeNull();
   });
 });

--- a/ui/candidate-portal/src/app/components/register/upload-file/registration-upload-file.component.ts
+++ b/ui/candidate-portal/src/app/components/register/upload-file/registration-upload-file.component.ts
@@ -36,7 +36,7 @@ export class RegistrationUploadFileComponent implements OnInit {
   error: any;
   // Component states
   saving: boolean;
-  activeIds: string;
+  activeIndexes: number | null;
 
 
   constructor(public registrationService: RegistrationService, private translateService: TranslateService) {
@@ -44,10 +44,11 @@ export class RegistrationUploadFileComponent implements OnInit {
 
   ngOnInit() {
     // Make the accordions closed if editing (to allow better view of footer navigation)
+    // For tc-accordion, activeIndexes uses 0-based index: 0 = first panel, null = all closed
     if (!this.edit) {
-      this.activeIds = 'upload-cv'
+      this.activeIndexes = 0; // 'upload-cv' corresponds to the first panel (index 0)
     } else {
-      this.activeIds = ''
+      this.activeIndexes = null; // '' corresponds to all panels closed
     }
 
     this.translateService.get('REGISTRATION.ATTACHMENTS.CV.WARNING').subscribe((translated: string) => {

--- a/ui/candidate-portal/src/app/shared/components/accordion/accordion-item/tc-accordion-item.component.html
+++ b/ui/candidate-portal/src/app/shared/components/accordion/accordion-item/tc-accordion-item.component.html
@@ -1,0 +1,17 @@
+<div class="tc-accordion-item" [class.open]="isOpen">
+  <a class="tc-accordion-header" (click)="toggle()">
+    <!-- If exists custom header projected using attribute selector -->
+    <ng-content select="[custom-header]"></ng-content>
+
+    <span>{{ header }}</span>
+
+    <tc-icon size="sm" color="gray">
+      <i *ngIf="!isOpen" class="fa-solid fa-chevron-down"></i>
+      <i *ngIf="isOpen" class="fa-solid fa-chevron-up"></i>
+    </tc-icon>
+  </a>
+
+  <div class="tc-accordion-body" *ngIf="isOpen">
+    <ng-content></ng-content>
+  </div>
+</div>

--- a/ui/candidate-portal/src/app/shared/components/accordion/accordion-item/tc-accordion-item.component.scss
+++ b/ui/candidate-portal/src/app/shared/components/accordion/accordion-item/tc-accordion-item.component.scss
@@ -1,0 +1,61 @@
+@import 'src/scss/typography-mixins';
+@import 'src/scss/color-mixins';
+@import 'src/scss/support-colors';
+
+.tc-accordion-item {
+  margin-top: 2rem;
+  border: none;
+  border-radius: 1rem;
+  @include shadow-lg;
+  margin-bottom: 1rem;
+  background-color: white;
+  overflow: hidden;
+
+  .tc-accordion-header {
+    @include label-lg;
+    @include text-color-body;
+    min-height: 3.25rem;
+    width: 100%;
+    text-align: left;
+    cursor: pointer;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+
+
+    @include background-color-light;
+    padding: 0.75rem 1rem;
+    border-radius: 1rem;
+    transition: border 0.1s ease, border-radius 0.1s ease;
+    text-decoration: none;
+    color: inherit;
+    &:hover {
+      background-color: color(gray,300);
+    }
+  }
+
+  .tc-accordion-body {
+    @include paragraph-md;
+    padding: 1rem;
+    border-top: none;
+    line-height: 1.5;
+  }
+
+  &.open {
+    overflow: visible;
+
+    .tc-accordion-header {
+      border-bottom: none;
+      border-bottom-left-radius: 0;
+      border-bottom-right-radius: 0;
+    }
+  }
+}
+
+/* Remove border on the last accordion item */
+:host:last-of-type {
+  .tc-accordion-item {
+    border-bottom: none;
+    overflow: visible;
+  }
+}

--- a/ui/candidate-portal/src/app/shared/components/accordion/accordion-item/tc-accordion-item.component.spec.ts
+++ b/ui/candidate-portal/src/app/shared/components/accordion/accordion-item/tc-accordion-item.component.spec.ts
@@ -1,0 +1,31 @@
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+
+import {TcAccordionItemComponent} from './tc-accordion-item.component';
+import {TcAccordionComponent} from "../tc-accordion.component";
+
+describe('TcAccordionItemComponent', () => {
+  let component: TcAccordionItemComponent;
+  let fixture: ComponentFixture<TcAccordionItemComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [TcAccordionItemComponent],
+      providers: [
+        {
+          provide: TcAccordionComponent,
+          useValue: {
+            toggle: () => {},
+            isOpen: (index: number) => false
+          }
+        }
+      ]
+    });
+    fixture = TestBed.createComponent(TcAccordionItemComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/ui/candidate-portal/src/app/shared/components/accordion/accordion-item/tc-accordion-item.component.ts
+++ b/ui/candidate-portal/src/app/shared/components/accordion/accordion-item/tc-accordion-item.component.ts
@@ -1,0 +1,72 @@
+import {Component, ContentChild, ElementRef, Input} from '@angular/core';
+import {TcAccordionComponent} from "../tc-accordion.component";
+
+/**
+ * @component TcAccordionItemComponent
+ * @selector tc-accordion-item
+ *
+ * @description
+ * Represents a single collapsible item inside an Accordion.
+ * Contains a header and a body. Can be expanded or collapsed by the parent AccordionComponent.
+ *
+ * **How it works**
+ * - Text only accordion header: use the [header] input to pass the string for the accordion header.
+ * - Custom accordion header: if need more flexibility in the accordion header
+ * (e.g. display another component, buttons) then add the 'custom-header' element ref to a div in the
+ * TcAccordionItemComponent. Within that `<div custom-header>` you can customize what will appear in the header (see example below)
+ *
+ * **Inputs**
+ * - Header: The text displayed in the accordion header
+ * - This component must be used inside a <tc-accordion>, as its open/close state is controlled by the parent using the item's index.
+ *
+ * @example
+ * <!-- Simple text header -->
+ * <tc-accordion-item header="Panel Header">
+ *   <p>Panel content goes here.</p>
+ * </tc-accordion-item>
+ *
+ * @example
+ * <!-- Custom header -->
+ *  <tc-accordion-item>
+ *     <div custom-header>
+ *       <div class="row">
+ *         <div class="col">
+ *           <p>My Custom Header</p>
+ *           <small>This is an example of a customized accordion header</small>
+ *         </div>
+ *         <div class="col-1">
+ *           <tc-button>
+ *             <i class="fas fa-plus"></i>
+ *           </tc-button>
+ *         </div>
+ *       </div>
+ *     </div>
+ *     <p>You can sign up to the TC following these simple steps 1,2</p>
+ *   </tc-accordion-item>
+ *
+ **/
+@Component({
+  selector: 'tc-accordion-item',
+  templateUrl: './tc-accordion-item.component.html',
+  styleUrls: ['./tc-accordion-item.component.scss']
+})
+export class TcAccordionItemComponent {
+  /** The text displayed in the accordion header */
+  @Input() header = '';
+  index: number;
+
+  /** Reference to projected custom header */
+  @ContentChild('[custom-header]', { read: ElementRef }) customHeader?: ElementRef;
+
+  constructor(public accordion: TcAccordionComponent) {}
+
+  toggle() {
+    if (this.accordion) {
+      this.accordion.toggle(this.index);
+    }
+  }
+
+  get isOpen(): boolean {
+    return this.accordion ? this.accordion.isOpen(this.index) : false;
+  }
+}

--- a/ui/candidate-portal/src/app/shared/components/accordion/tc-accordion.component.html
+++ b/ui/candidate-portal/src/app/shared/components/accordion/tc-accordion.component.html
@@ -1,0 +1,4 @@
+<div class="tc-accordion" [class.allow-overflow]="allowOverflow">
+  <tc-button *ngIf="showOpenCloseAll" class="toggle-all-panels" size="xs" type="outline" color="secondary" (onClick)="toggleAll()">Open/Close All</tc-button>
+  <ng-content></ng-content>
+</div>

--- a/ui/candidate-portal/src/app/shared/components/accordion/tc-accordion.component.scss
+++ b/ui/candidate-portal/src/app/shared/components/accordion/tc-accordion.component.scss
@@ -1,0 +1,17 @@
+.tc-accordion {
+  padding: 0 16px;
+  border-radius: 6px;
+  overflow: hidden;
+
+  &.allow-overflow {
+    overflow: visible;
+  }
+
+  .toggle-all-panels {
+    display: flex;
+    gap: 16px;
+    justify-content: flex-end;
+    margin-bottom: -10px;
+    padding-top: 5px;
+  }
+}

--- a/ui/candidate-portal/src/app/shared/components/accordion/tc-accordion.component.spec.ts
+++ b/ui/candidate-portal/src/app/shared/components/accordion/tc-accordion.component.spec.ts
@@ -1,0 +1,21 @@
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+
+import {TcAccordionComponent} from './tc-accordion.component';
+
+describe('TcAccordionComponent', () => {
+  let component: TcAccordionComponent;
+  let fixture: ComponentFixture<TcAccordionComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [TcAccordionComponent]
+    });
+    fixture = TestBed.createComponent(TcAccordionComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/ui/candidate-portal/src/app/shared/components/accordion/tc-accordion.component.ts
+++ b/ui/candidate-portal/src/app/shared/components/accordion/tc-accordion.component.ts
@@ -1,0 +1,195 @@
+import {
+  AfterContentInit,
+  Component,
+  ContentChildren,
+  EventEmitter,
+  Input,
+  Output,
+  QueryList
+} from '@angular/core';
+import {TcAccordionItemComponent} from "./accordion-item/tc-accordion-item.component";
+
+/**
+ * @component TcAccordionComponent
+ * @selector tc-accordion
+ * @description
+ * A reusable Accordion component that contains multiple collapsible panels (TcAccordionItemComponents).
+ * Panels can start all open, first open or default to all closed.
+ *
+ * **How it works**
+ * - Wraps the TcAccordionItem components
+ * - Sets the default open/close state of the panels
+ * - Keeps track of which panels are opened and closed on click
+ * - Each <tc-accordion-item> inside this component is automatically assigned an index, which is used to control its open/close state.
+ *
+ * **Inputs**
+ * - allOpen: if true initializes accordion with all panels opened, defaults to false.
+ * - firstOpen: if true initializes accordion with first panel opened, defaults to false.
+ * - showOpenCloseAll: if true displays a button which toggles all panels to open/close.
+ *  - `activeIndexes`: Controls which panels are open (single index or array of indexes).
+ *    Supports two-way binding using `[(activeIndexes)]`.
+ *
+ * **State persistence**
+ *  When used with `[(activeIndexes)]`, the accordion’s open state can be stored
+ *  in component state, URL parameters, or browser storage, allowing the UI to
+ *  restore the same open panels after navigation or page reload.
+ *
+ * @example
+ * <!-- All panels closed (default) -->
+ * <tc-accordion>
+ *   <tc-accordion-item header="First">
+ *     <p>First content</p>
+ *   </tc-accordion-item>
+ *   <tc-accordion-item header="Second">
+ *     <p>Second content</p>
+ *   </tc-accordion-item>
+ * </tc-accordion>
+ *
+ * @example
+ * <!-- Only first panel open initially -->
+ * <tc-accordion [firstOpen]="true">
+ *   <tc-accordion-item header="First">
+ *     <p>First content</p>
+ *   </tc-accordion-item>
+ *   <tc-accordion-item header="Second">
+ *     <p>Second content</p>
+ *   </tc-accordion-item>
+ * </tc-accordion>
+ *
+ * @example
+ * <!-- All panels open initially -->
+ * <tc-accordion [allOpen]="true">
+ *   <tc-accordion-item header="First">
+ *     <p>First content</p>
+ *   </tc-accordion-item>
+ *   <tc-accordion-item header="Second">
+ *     <p>Second content</p>
+ *   </tc-accordion-item>
+ * </tc-accordion>
+ *
+ * @example
+ * <!-- Controlled accordion with persisted open state -->
+ * <tc-accordion [(activeIndexes)]="openIndexes">
+ *   <tc-accordion-item header="First">
+ *     <p>First content</p>
+ *   </tc-accordion-item>
+ *   <tc-accordion-item header="Second">
+ *     <p>Second content</p>
+ *   </tc-accordion-item>
+ * </tc-accordion>
+ *
+ * // Component TS
+ * openIndexes = [0];
+ */
+@Component({
+  selector: 'tc-accordion',
+  templateUrl: './tc-accordion.component.html',
+  styleUrls: ['./tc-accordion.component.scss']
+})
+export class TcAccordionComponent implements AfterContentInit {
+  /** Initialise with all panels opened - default false */
+  @Input() allOpen = false;
+  /** Initialise with first panel opened - default false */
+  @Input() firstOpen = false;
+  /** Display the open all and close all panel buttons - default true */
+  @Input() showOpenCloseAll: boolean = true;
+  /** Enables passing true when visible overflow is required (e.g. dropdown options cut off by next element */
+  @Input() allowOverflow = false;
+
+  /**
+   * Controls which accordion panels are currently open.
+   *
+   * This input allows the open state of the accordion to be controlled
+   * from outside the component and kept in sync with the parent.
+   *
+   * It supports:
+   * - a single panel index (number)
+   * - multiple panel indexes (number[])
+   * - null or undefined to close all panels
+   *
+   * Using two-way binding with [(activeIndexes)] makes it possible to
+   * persist the open panels (for example in component state, URL params,
+   * or browser storage) so the accordion can restore its open state
+   * after navigation or page reload.
+   */
+  @Input() set activeIndexes(val: number[] | number | null | undefined) {
+    this.openIndexes.clear();
+    if (Array.isArray(val)) {
+      val.forEach(i => this.openIndexes.add(i));
+    } else if (val !== null && val !== undefined) {
+      this.openIndexes.add(val as number);
+    }
+  }
+  /**
+   * Returns the indexes of the panels that are currently open.
+   *
+   * This getter is used by Angular as part of the [(activeIndexes)]
+   * two-way binding to expose the current accordion state.
+   */
+  get activeIndexes(): number[] {
+    return Array.from(this.openIndexes.values());
+  }
+  /**
+   * Emits the current open panel indexes whenever the accordion state changes.
+   *
+   * This allows parent components to react to changes and optionally
+   * store the open state (for example so the browser "remembers"
+   * which panels were open).
+   */
+  @Output() activeIndexesChange = new EventEmitter<number[]>();
+
+  openIndexes: Set<number> = new Set();
+
+  @ContentChildren(TcAccordionItemComponent) items!: QueryList<TcAccordionItemComponent>;
+
+  ngAfterContentInit() {
+    // Auto-assign indexes to children
+    this.items.forEach((item, index) => (item.index = index));
+    if (this.allOpen) {
+      this.items.forEach((item) => this.openIndexes.add(item.index));
+    } else if (this.firstOpen) {
+      this.openIndexes.add(0);
+    }
+  }
+
+  /**
+   * Emits the current open panel indexes.
+   *
+   * Called internally after any state change (toggle, openAll, closeAll)
+   * to keep external bindings in sync.
+   */
+  private emitActiveIndexes() {
+    this.activeIndexesChange.emit(Array.from(this.openIndexes.values()));
+  }
+
+  toggle(index: number) {
+    if (this.openIndexes.has(index)) {
+      this.openIndexes.delete(index);
+    } else {
+      this.openIndexes.add(index);
+    }
+    this.emitActiveIndexes();
+  }
+
+  isOpen(index: number): boolean {
+    return this.openIndexes.has(index);
+  }
+
+  toggleAll() {
+    if (this.openIndexes.size > 0) {
+      this.closeAll();
+    } else {
+      this.openAll();
+    }
+  }
+
+  openAll() {
+    this.items.forEach((item) => this.openIndexes.add(item.index));
+    this.emitActiveIndexes();
+  }
+
+  closeAll() {
+    this.openIndexes.clear();
+    this.emitActiveIndexes();
+  }
+}

--- a/ui/candidate-portal/src/app/shared/components/button/button.component.html
+++ b/ui/candidate-portal/src/app/shared/components/button/button.component.html
@@ -1,0 +1,8 @@
+<button class="btn"
+        [ngClass]="classList"
+        [disabled]="disabled"
+        [attr.aria-label]="ariaLabel"
+        [routerLink]="routerLink"
+        (click)="clicked($event)">
+  <ng-content></ng-content>
+</button>

--- a/ui/candidate-portal/src/app/shared/components/button/button.component.scss
+++ b/ui/candidate-portal/src/app/shared/components/button/button.component.scss
@@ -1,0 +1,406 @@
+@import '../../../../scss/typography-mixins';
+@import "../../../../scss/color-mixins";
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  justify-items: center;
+  border-radius: 8px;
+  border: none;
+  transition: background-color 0.2s ease-in-out, box-shadow 0.2s;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+  gap: 0.5rem;
+
+  &[disabled] {
+    @include background-color-light;
+    @include text-color-secondary;
+    pointer-events: none;
+    cursor: not-allowed;
+    border: none;
+  }
+}
+
+:host(.disabled) {
+  pointer-events: none;
+}
+
+.btn-xs {
+  @include paragraph-xs;
+  height: 1.5rem;
+  padding: 0.25rem 0.5rem;
+}
+
+.btn-sm {
+  @include paragraph-sm;
+  height: 1.75rem;
+  padding: 0.25rem 0.5rem;
+}
+
+.btn-default {
+  @include paragraph-md;
+  height: 2rem;
+  padding: 0.375rem 0.625rem;
+}
+
+.btn-lg {
+  @include paragraph-md;
+  height: 2.25rem;
+  padding: 0.5rem 0.75rem;
+}
+
+.btn-xl {
+  @include paragraph-lg;
+  height: 2.5rem;
+  padding: 0.5rem 1rem;
+}
+
+.btn-solid {
+  &.btn-primary {
+    @include background-color-primary;
+    @include text-color-white;
+
+    &:hover {
+      background-color: color(primary, 600);
+    }
+    &:focus-visible {
+      outline: 2px solid color(primary, 500);
+      outline-offset: 2px;
+    }
+    &:active {
+      background-color: color(primary, 800);
+    }
+  }
+
+  &.btn-secondary {
+    @include background-color-secondary;
+    @include text-color-white;
+
+    &:hover {
+      background-color: color(secondary, 600);
+    }
+    &:focus-visible {
+      outline: 2px solid color(secondary, 500);
+      outline-offset: 2px;
+    }
+    &:active {
+      background-color: color(secondary, 800);
+    }
+  }
+
+  &.btn-success {
+    @include background-color-success;
+    @include text-color-success;
+
+    &:hover {
+      background-color: color(green, 200);
+    }
+    &:focus-visible {
+      outline: 2px solid color(green, 500);
+      outline-offset: 2px;
+    }
+    &:active {
+      background-color: color(green, 300);
+    }
+  }
+
+  &.btn-warning {
+    @include background-color-warning;
+    @include text-color-warning;
+
+    &:hover {
+      background-color: color(yellow, 200);
+    }
+    &:focus-visible {
+      outline: 2px solid color(yellow, 500);
+      outline-offset: 2px;
+    }
+    &:active {
+      background-color: color(yellow, 300);
+    }
+  }
+
+  &.btn-error {
+    @include background-color-error;
+    @include text-color-error;
+
+    &:hover {
+      background-color: color(red, 200);
+    }
+    &:focus-visible {
+      outline: 2px solid color(red, 500);
+      outline-offset: 2px;
+    }
+    &:active {
+      background-color: color(red, 300);
+    }
+  }
+
+  &.btn-info {
+    @include background-color-info;
+    @include text-color-info;
+
+    &:hover {
+      background-color: color(blue, 200);
+    }
+    &:focus-visible {
+      outline: 2px solid color(blue, 500);
+      outline-offset: 2px;
+    }
+    &:active {
+      background-color: color(blue, 300);
+    }
+  }
+
+  &.btn-gray {
+    background-color: color(gray, 200);
+    color: color(gray, 700);
+
+    &:hover {
+      background-color: color(gray, 300);
+    }
+    &:focus-visible {
+      outline: 2px solid color(gray, 400);
+      outline-offset: 2px;
+    }
+    &:active {
+      background-color: color(gray, 400);
+    }
+  }
+}
+
+// Outline type styles
+.btn-outline {
+  background-color: transparent;
+  border: 1px solid;
+
+  &.btn-primary {
+    color: color(primary, 500);
+    border-color: color(primary, 500);
+
+    &:hover {
+      background-color: color(primary, 50);
+    }
+    &:focus-visible {
+      outline: 2px solid color(primary, 500);
+      outline-offset: 2px;
+    }
+    &:active {
+      background-color: color(primary, 100);
+    }
+  }
+
+  &.btn-secondary {
+    color: color(secondary, 500);
+    border-color: color(secondary, 500);
+
+    &:hover {
+      background-color: color(secondary, 50);
+    }
+    &:focus-visible {
+      outline: 2px solid color(secondary, 500);
+      outline-offset: 2px;
+    }
+    &:active {
+      background-color: color(secondary, 100);
+    }
+  }
+
+  &.btn-success {
+    color: color(green, 500);
+    border-color: color(green, 500);
+
+    &:hover {
+      background-color: color(green, 50);
+    }
+    &:focus-visible {
+      outline: 2px solid color(green, 500);
+      outline-offset: 2px;
+    }
+    &:active {
+      background-color: color(green, 100);
+    }
+  }
+
+  &.btn-warning {
+    color: color(yellow, 500);
+    border-color: color(yellow, 500);
+
+    &:hover {
+      background-color: color(yellow, 50);
+    }
+    &:focus-visible {
+      outline: 2px solid color(yellow, 500);
+      outline-offset: 2px;
+    }
+    &:active {
+      background-color: color(yellow, 100);
+    }
+  }
+
+  &.btn-error {
+    color: color(red, 500);
+    border-color: color(red, 500);
+
+    &:hover {
+      background-color: color(red, 50);
+    }
+    &:focus-visible {
+      outline: 2px solid color(red, 500);
+      outline-offset: 2px;
+    }
+    &:active {
+      background-color: color(red, 100);
+    }
+  }
+
+  &.btn-info {
+    color: color(blue, 500);
+    border-color: color(blue, 500);
+
+    &:hover {
+      background-color: color(blue, 50);
+    }
+    &:focus-visible {
+      outline: 2px solid color(blue, 500);
+      outline-offset: 2px;
+    }
+    &:active {
+      background-color: color(blue, 100);
+    }
+  }
+
+  &.btn-gray {
+    color: color(gray, 500);
+    border-color: color(gray, 300);
+
+    &:hover {
+      background-color: color(gray, 50);
+    }
+    &:focus-visible {
+      outline: 2px solid color(gray, 400);
+      outline-offset: 2px;
+    }
+    &:active {
+      background-color: color(gray, 100);
+    }
+  }
+}
+
+// Plain type styles
+.btn-plain {
+  background-color: transparent;
+  border: none;
+  box-shadow: none;
+  padding: 0;
+
+  &.btn-primary {
+    color: color(primary, 500);
+
+    &:hover {
+      color: color(primary, 800);
+      transform: scale(1.1);
+    }
+    &:focus-visible {
+      outline: 2px solid color(primary, 500);
+      outline-offset: 2px;
+    }
+    &:active {
+      color: color(primary, 800);
+      transform: scale(1.1);
+       background-color: transparent;
+    }
+  }
+
+  &.btn-secondary {
+    color: color(secondary, 500);
+
+    &:hover {
+      color: color(secondary, 800);
+    }
+    &:focus-visible {
+      outline: 2px solid color(secondary, 500);
+      outline-offset: 2px;
+    }
+    &:active {
+      color: color(secondary, 800);
+    }
+  }
+
+  &.btn-success {
+    color: color(green, 500);
+
+    &:hover {
+      color: color(green, 800);
+    }
+    &:focus-visible {
+      outline: 2px solid color(green, 500);
+      outline-offset: 2px;
+    }
+    &:active {
+      color: color(green, 800);
+    }
+  }
+
+  &.btn-warning {
+    color: color(yellow, 500);
+
+    &:hover {
+      color: color(yellow, 800);
+    }
+    &:focus-visible {
+      outline: 2px solid color(yellow, 500);
+      outline-offset: 2px;
+    }
+    &:active {
+      color: color(yellow, 800);
+    }
+  }
+
+  &.btn-error {
+    color: color(red, 500);
+
+    &:hover {
+      color: color(red, 800);
+    }
+    &:focus-visible {
+      outline: 2px solid color(red, 500);
+      outline-offset: 2px;
+    }
+    &:active {
+      color: color(red, 800);
+    }
+  }
+
+  &.btn-info {
+    color: color(blue, 500);
+
+    &:hover {
+      color: color(blue, 800);
+    }
+    &:focus-visible {
+      outline: 2px solid color(blue, 500);
+      outline-offset: 2px;
+    }
+    &:active {
+      color: color(blue, 800);
+    }
+  }
+
+  &.btn-gray {
+    color: color(gray, 500);
+
+    &:hover {
+      color: color(gray, 800);
+    }
+
+    &:focus-visible {
+      outline: 2px solid color(blue, 500);
+      outline-offset: 2px;
+    }
+
+    &:active {
+      color: color(gray, 800);
+    }
+  }
+}

--- a/ui/candidate-portal/src/app/shared/components/button/button.component.spec.ts
+++ b/ui/candidate-portal/src/app/shared/components/button/button.component.spec.ts
@@ -1,0 +1,53 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Component } from '@angular/core';
+import { ButtonComponent } from './button.component';
+import { By } from '@angular/platform-browser';
+
+describe('ButtonComponent', () => {
+  let component: ButtonComponent;
+  let fixture: ComponentFixture<ButtonComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [ButtonComponent]
+    });
+    fixture = TestBed.createComponent(ButtonComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create the component', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should apply correct classes based on size and type inputs', () => {
+    component.size = 'sm';
+    component.type = 'outline';
+    fixture.detectChanges();
+
+    const buttonElement: HTMLButtonElement = fixture.nativeElement.querySelector('button');
+    expect(buttonElement.classList).toContain('btn-sm');
+    expect(buttonElement.classList).toContain('btn-outline');
+  });
+
+  it('should apply "disabled" attribute when disabled is true', () => {
+    component.disabled = true;
+    fixture.detectChanges();
+
+    const buttonElement: HTMLButtonElement = fixture.nativeElement.querySelector('button');
+    expect(buttonElement.disabled).toBeTrue();
+  });
+
+  describe('aria-label support', () => {
+    beforeEach(() => {
+      // Only needed if you implement @Input() ariaLabel
+      (component as any).ariaLabel = 'Refresh';
+      fixture.detectChanges();
+    });
+
+    it('should set aria-label when ariaLabel input is provided', () => {
+      const buttonDebug = fixture.debugElement.query(By.css('button'));
+      expect(buttonDebug.attributes['aria-label']).toBe('Refresh');
+    });
+  });
+});

--- a/ui/candidate-portal/src/app/shared/components/button/button.component.ts
+++ b/ui/candidate-portal/src/app/shared/components/button/button.component.ts
@@ -1,0 +1,111 @@
+import {Component, EventEmitter, HostBinding, Input, Output} from '@angular/core';
+
+/**
+ * @component ButtonComponent
+ * @selector tc-button
+ * @description
+ * A design-system button that wraps a native `<button>` element and applies
+ * consistent sizing, variants, and accessibility. Content is projected via
+ * `<ng-content>` so you can place text, icons, or both.
+ *
+ * **Features**
+ * - Size presets: `xs`, `sm`, `default`, `lg`, `xl`
+ * - Visual variants: `primary`, `secondary`, `outline`, `plain`
+ * - Disabled state styling & pointer-lock
+ * - Focus-visible outline for keyboard accessibility
+ * - Optional `ariaLabel` for icon-only buttons
+ * - Optional Angular `routerLink` support for navigation
+ *
+ * **Inputs**
+ * - `size: 'xs' | 'sm' | 'default' | 'lg' | 'xl'`
+ *   Controls height and padding. Defaults to `'default'`.
+ * - `type: 'primary' | 'secondary' | 'outline' | 'plain'`
+ *   Visual style variant. Defaults to `'primary'`.
+ *   - `color: 'primary' | 'secondary' | 'success' | 'warning' | 'error' | 'info' | 'gray'`
+ *   Controls the button’s color scheme. Defaults to `'primary'`.
+ * - `disabled: boolean`
+ *   Disables the button and applies muted styling. Defaults to `false`.
+ * - `ariaLabel?: string`
+ *   Accessible label for icon-only or ambiguous buttons.
+ *    * - `routerLink?: string | any[]`
+ *  *   Optional Angular Router `routerLink`. When provided, the internal `<button>`
+ *  *   also receives `[routerLink]`, allowing `<tc-button>` to be used as a
+ *  *   navigation trigger:
+ *
+ * **Outputs**
+ * - `(onClick)`
+ * Instead of re-emitting the native (click) event, this component provides its own (onClick) output.
+ * Using (click) directly on <tc-button> works at runtime (because the event bubbles), but IDE
+ * type-checking flags it as invalid since Angular can’t see a declared @Output('click').
+ * To avoid false errors in IntelliJ/Angular Language Service, we use (onClick) as the explicit output.
+ *
+ * @examples
+ * ```html
+ * <!-- Primary (default size) -->
+ * <tc-button type="primary">Save changes</tc-button>
+ *
+ * <!-- Secondary, large -->
+ * <tc-button type="secondary" size="lg">Continue</tc-button>
+ *
+ * <!-- Outline, small -->
+ * <tc-button type="outline" size="sm">Learn more</tc-button>
+ *
+ * <!-- Plain (text-only look) -->
+ * <tc-button type="plain">Cancel</tc-button>
+ *
+ * <!-- Disabled -->
+ * <tc-button type="primary" [disabled]="true">Processing…</tc-button>
+
+ * ```
+ */
+
+@Component({
+  selector: 'tc-button',
+  templateUrl: './button.component.html',
+  styleUrls: ['./button.component.scss'],
+})
+export class ButtonComponent {
+  @Input() size: 'xs' | 'sm' | 'default' | 'lg' | 'xl'  = 'default';
+  @Input() type: 'solid' | 'outline' | 'plain' = 'solid';
+  @Input() color: 'primary' | 'secondary' | 'success' | 'warning' | 'error' | 'info' | 'gray'= 'primary';
+  @Input() disabled = false;
+  @Input() ariaLabel?: string;
+  @Input() routerLink?: string | any[];
+  /**
+   * Whether to prevent the native `click` event from bubbling up the DOM.
+   *
+   * By default, this is `true`, which means the component calls
+   * `event.stopPropagation()` when clicked. This prevents unintended side
+   * effects in contexts like accordion headers, nested buttons, or clickable
+   * containers.
+   *
+   * Set this to `false` if you need the native click to bubble — for example,
+   * when using `<tc-button>` as a trigger for directives that depend on the
+   * native event, such as `ngbDropdownToggle` or other third-party UI controls.
+   *
+   * @default true
+   */
+  @Input() stopNativeClickPropagation: boolean = true;
+
+  @Output() onClick = new EventEmitter();
+
+  @HostBinding('class.disabled') get isDisabled() {
+    return this.disabled;
+  }
+
+  get classList(): string[] {
+    return [
+      `btn-${this.size}`,
+      `btn-${this.color}`,
+      `btn-${this.type}`,
+    ];
+  }
+
+  clicked(e: MouseEvent): void {
+    if (this.stopNativeClickPropagation) {
+      e.stopPropagation();
+    }
+    this.onClick.emit();
+  }
+
+}

--- a/ui/candidate-portal/src/app/shared/components/icon-component/tc-icon.component.html
+++ b/ui/candidate-portal/src/app/shared/components/icon-component/tc-icon.component.html
@@ -1,0 +1,40 @@
+<ng-template #content>
+  <ng-content></ng-content>
+</ng-template>
+
+<ng-container [ngSwitch]="type">
+  <ng-container *ngSwitchCase="'link'">
+    <ng-container *ngIf="routerLink">
+      <a [routerLink]="routerLink"
+         [attr.aria-label]="ariaLabel"
+         [ngClass]="classList"
+      >
+        <ng-container *ngTemplateOutlet="content"></ng-container>
+      </a>
+    </ng-container>
+    <ng-container *ngIf="!routerLink">
+      <a [href]="href"
+         [attr.aria-label]="ariaLabel"
+         [ngClass]="classList"
+         [target]="target"
+      >
+        <ng-container *ngTemplateOutlet="content"></ng-container>
+      </a>
+    </ng-container>
+  </ng-container>
+
+  <button *ngSwitchCase="'button'"
+          type="button"
+          [attr.aria-label]="ariaLabel"
+          [ngClass]="classList"
+          (click)="handleClick($event)">
+    <ng-container *ngTemplateOutlet="content"></ng-container>
+  </button>
+
+  <span *ngSwitchDefault
+        [attr.aria-label]="ariaLabel"
+        [ngClass]="classList"
+        (click)="handleClick($event)">
+    <ng-container *ngTemplateOutlet="content"></ng-container>
+  </span>
+</ng-container>

--- a/ui/candidate-portal/src/app/shared/components/icon-component/tc-icon.component.scss
+++ b/ui/candidate-portal/src/app/shared/components/icon-component/tc-icon.component.scss
@@ -1,0 +1,71 @@
+@import "../../../../scss/color-mixins";
+
+.tc-icon {
+
+  &.icon-sm, &.icon-sm::ng-deep > i {
+    font-size: 0.75rem;
+  }
+
+  &.icon-md, &.icon-md::ng-deep > i {
+    font-size: 1rem;
+  }
+
+  &.icon-lg, &.icon-lg::ng-deep > i {
+    font-size: 1.25rem;
+  }
+
+  &.icon-xl, &.icon-lg::ng-deep > i {
+    font-size: 1.5rem;
+  }
+
+  &.icon-inherit, &.icon-inherit::ng-deep > i {
+    font-size: inherit;
+  }
+
+  // Color variations
+  &.icon-primary {
+    @include text-color-primary;
+  }
+
+  &.icon-secondary {
+    color: color(secondary, 500);
+  }
+
+  &.icon-white {
+    @include text-color-white;
+  }
+
+  &.icon-gray {
+    @include text-color-secondary;
+  }
+
+  &.icon-error {
+    color: color(red, 500);
+  }
+
+  &.icon-info {
+    color: color(blue, 500);
+  }
+
+  &.icon-success {
+    color: color(green, 500);
+  }
+
+  &.icon-warning {
+    color: color(yellow, 500);
+  }
+  &:hover {
+    filter: brightness(0.6);
+  }
+}
+
+button.tc-icon {
+  all: unset;
+  display: flex;
+  justify-content: center;
+}
+
+// No hover-over effect for non-interactive icon type
+span.tc-icon:hover {
+  filter: none;
+}

--- a/ui/candidate-portal/src/app/shared/components/icon-component/tc-icon.component.spec.ts
+++ b/ui/candidate-portal/src/app/shared/components/icon-component/tc-icon.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TcIconComponent } from './tc-icon.component';
+
+describe('TcIconComponent', () => {
+  let component: TcIconComponent;
+  let fixture: ComponentFixture<TcIconComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [TcIconComponent]
+    });
+    fixture = TestBed.createComponent(TcIconComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/ui/candidate-portal/src/app/shared/components/icon-component/tc-icon.component.ts
+++ b/ui/candidate-portal/src/app/shared/components/icon-component/tc-icon.component.ts
@@ -1,0 +1,95 @@
+import {Component, Input} from '@angular/core';
+
+/**
+ * @component IconComponent
+ * @selector tc-icon
+ * @description
+ * A design-system icon wrapper component that can be rendered as a `<span>` (default),
+ * `<button>`, or `<a>` link. It applies consistent sizing and color variants to any
+ * projected content (FontAwesome icons, SVGs, images, etc.).
+ *
+ * **Features**
+ * - Render as `span` (default), `button`, or `link` via the `type` input
+ * - Size presets: `sm` (12px), `md` (16px), `lg` (20px), `xl` (24px)
+ * - Flexible content projection – works with FontAwesome, SVG, or inline images
+ * - Color variants: `primary`, `secondary`, `white`, `gray`, `success`, `info`, `warning`, `error`
+ * - Accessible with optional `ariaLabel`
+ * - Automatically removes default browser styles when rendered as `<button>` or `<a>`
+ *
+ * **Inputs**
+ * - `size: 'sm' | 'md' | 'lg' | 'xl' | 'inherit'`
+ *   Controls icon size. Defaults to `'inherit'`.
+ *   - sm → 12px
+ *   - md → 16px
+ *   - lg → 20px
+ *   - xl → 24px
+ *   - inherit → inherits from parents font size
+ *
+ * - `color?: 'primary' | 'secondary' | 'white' | 'gray' | 'success' | 'info' | 'warning' | 'error'`
+ *   Optional color variant. Defaults to `'primary'` if not set.
+ *
+ * - `ariaLabel?: string`
+ *   Accessible label for screen readers. Recommended when the icon has no visible text.
+ *
+ * - `type: 'span' | 'button' | 'link'`
+ *   Determines the rendered element. Defaults to `'span'`.
+ *   - `"span"` → non-interactive icon (default)
+ *   - `"button"` → semantic button icon (clickable, with reset styles)
+ *   - `"link"` → icon inside an anchor `<a>`
+ *
+ * - `href?: string`
+ * - `routerLink?: any[] | string`
+ *   Required when `type="link"`. Sets the target URL/route.
+ *
+ *   - `target?: string` — sets the link target when using `href` (defaults to `"_blank"`).**
+ *
+ * - `onClick?: (event: MouseEvent) => void`
+ *   Optional click handler for `type="button"` or `type="span"`.
+ *
+ * **Examples**
+ * ```html
+ * <!-- FontAwesome icon as span -->
+ * <tc-icon size="md" color="primary" ariaLabel="Home">
+ *   <i class="fas fa-home"></i>
+ * </tc-icon>
+ *
+ * <!-- SVG icon as button -->
+ * <tc-icon type="button" size="lg" color="success" (onClick)="save()">
+ *   <svg>...</svg>
+ * </tc-icon>
+ *
+ * <!-- Icon as link -->
+ * <tc-icon type="link" href="/settings" size="sm" color="info" ariaLabel="Settings">
+ *   <i class="fas fa-cog"></i>
+ * </tc-icon>
+ *
+ * <tc-icon type="link" [routerLink]="['/list', 123]" size="sm" color="info" ariaLabel="Settings">
+ *   <i class="fas fa-cog"></i>
+ * </tc-icon>
+ * ```
+ */
+
+@Component({
+  selector: 'tc-icon',
+  templateUrl: './tc-icon.component.html',
+  styleUrls: ['./tc-icon.component.scss']
+})
+export class TcIconComponent {
+  @Input() size: 'sm' | 'md' | 'lg' | 'xl' | 'inherit' = 'inherit';
+  @Input() color?: 'primary' | 'secondary' | 'white' | 'gray' | 'success' | 'info' | 'warning' | 'error' = 'primary';
+  @Input() ariaLabel?: string;
+
+  @Input() type: 'link' | 'button' | 'span' = 'span';
+  @Input() href?: string;
+  @Input() target: string = "_blank";
+  @Input() routerLink?: any[] | string | null;
+  @Input() onClick?: (e: MouseEvent) => void;
+
+  get classList(): string[] {
+    return [`tc-icon`, `icon-${this.size}`, `icon-${this.color}`];
+  }
+
+  handleClick(event: MouseEvent) {
+    if (this.onClick) this.onClick(event);
+  }
+}

--- a/ui/candidate-portal/src/app/shared/shared.module.ts
+++ b/ui/candidate-portal/src/app/shared/shared.module.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2024 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+import {NgModule} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {RouterLink} from '@angular/router';
+import {ButtonComponent} from './components/button/button.component';
+import {TcIconComponent} from './components/icon-component/tc-icon.component';
+import {TcAccordionComponent} from './components/accordion/tc-accordion.component';
+import {TcAccordionItemComponent} from './components/accordion/accordion-item/tc-accordion-item.component';
+
+@NgModule({
+  declarations: [
+    ButtonComponent,
+    TcIconComponent,
+    TcAccordionComponent,
+    TcAccordionItemComponent
+  ],
+  imports: [
+    CommonModule,
+    RouterLink
+  ],
+  exports: [
+    ButtonComponent,
+    TcIconComponent,
+    TcAccordionComponent,
+    TcAccordionItemComponent
+  ]
+})
+export class SharedModule { }
+

--- a/ui/candidate-portal/src/scss/_color-mixins.scss
+++ b/ui/candidate-portal/src/scss/_color-mixins.scss
@@ -1,0 +1,105 @@
+@import './support-colors';
+
+// ==========================
+// TEXT COLOR MIXINS
+// ==========================
+
+// --- Base Text Colors ---
+// Use these for normal text on light backgrounds
+@mixin text-color-body    { color: color(gray, 900); } //  Primary text on light backgrounds; best for body content and high readability.
+@mixin text-color-secondary   { color: color(gray, 500); } //  For secondary text like descriptions, hints, or helper text on light backgrounds. On dark backgrounds, use for small labels or subtle captions.
+@mixin text-color-caption { color: color(gray, 400); } //  For tertiary text like captions, timestamps and placeholders. On dark backgrounds, can be used as muted text.
+@mixin text-color-white   { color: color(core, white); } // Use on dark backgrounds for maximum legibility and contrast.
+@mixin text-color-primary  { color: color(primary, 500); } //  For primary text like highlighted text in nav tabs
+@mixin text-color-brand-secondary  { color: color(secondary, 500); }
+
+// --- Semantic Text Colors ---
+@mixin text-color-success  { color: color(green, 700); }
+@mixin text-color-warning  { color: color(yellow, 700); }
+@mixin text-color-error    { color: color(red, 700); }
+@mixin text-color-info     { color: color(blue, 700); }
+@mixin text-color-disabled   { color: color(gray, 500); }
+@mixin text-color-primary   { color: color(primary, 500); }
+
+// --- Descriptive Text Colors ---
+@mixin text-color-red      { color: color(red, 700); }
+@mixin text-color-orange   { color: color(orange, 700); }
+@mixin text-color-yellow   { color: color(yellow, 700); }
+@mixin text-color-green    { color: color(green, 700); }
+@mixin text-color-blue     { color: color(blue, 700); }
+@mixin text-color-purple   { color: color(purple, 700); }
+@mixin text-color-pink     { color: color(pink, 700); }
+
+// ==========================
+  // BORDER COLOR MIXINS
+  // ==========================
+
+  // --- Base Border Colors ---
+  @mixin border-color-base      { border-color: color(gray, 300); }    // Standard subtle border
+  @mixin  border-color-light     { border-color: color(gray, 100); }  // Softer, for nested containers
+  @mixin  border-color-soft      { border-color: color(gray, 50); }         // Very light, for subtle outlines
+
+  @mixin  border-color-base-dark  { border-color: color(gray, 700); }      // Default border on dark bg
+  @mixin  border-color-light-dark { border-color: color(gray, 800); }   // Standard subtle border on dark bg
+  @mixin  border-color-soft-dark  { border-color: color(gray, 900); }       // Very light, for subtle outlines on dark bg
+
+
+  // --- Semantic Border Colors ---
+  @mixin border-color-primary  { border-color: color(primary, 500); }
+  @mixin border-color-success  { border-color: color(green, 500); }
+  @mixin border-color-warning  { border-color: color(yellow, 500); }
+  @mixin border-color-error    { border-color: color(red, 500); }
+  @mixin border-color-info     { border-color: color(blue, 500); }
+
+  // --- Descriptive Border Colors ---
+  @mixin border-color-red      { border-color: color(red, 500); }
+  @mixin border-color-orange   { border-color: color(orange, 500); }
+  @mixin border-color-yellow   { border-color: color(yellow, 500); }
+  @mixin border-color-green    { border-color: color(green, 500); }
+  @mixin border-color-blue     { border-color: color(blue, 500); }
+  @mixin border-color-purple   { border-color: color(purple, 500); }
+  @mixin border-color-pink     { border-color: color(pink, 500); }
+
+
+  // ==========================
+  // BACKGROUND COLOR MIXINS
+  // ==========================
+
+  // --- Base Background Colors ---
+  @mixin background-color-primary    { background-color: color(primary, 500); }            // Primary blue color
+  @mixin background-color-secondary  { background-color: color(secondary, 500); }       // Secondary teal color
+  @mixin background-color-white      { background-color: color(core, white); }                // Page or section backgrounds
+  @mixin background-color-light      { background-color: color(gray, 200); }                          // Slightly gray bg
+  @mixin background-color-soft       { background-color: color(gray, 100); }                   // Soft background (cards)
+  @mixin background-color-primary-light    { background-color: color(primary, 100); }
+
+  @mixin background-color-dark        { background-color: color(gray, 900); }         // Full dark background (almost black)
+  @mixin background-color-light-dark  { background-color: color(gray, 600); }          // For less contrast on dark bg
+  @mixin background-color-soft-dark   { background-color: color(gray, 800); }      // Slightly lighter than primary
+
+  // --- Semantic Background Colors ---
+  @mixin background-color-success  { background-color: color(green, 100); }
+  @mixin background-color-warning  { background-color: color(yellow, 100); }
+  @mixin background-color-error    { background-color: color(red, 100); }
+  @mixin background-color-info     { background-color: color(blue, 100); }
+  @mixin background-color-disabled   { background-color: color(gray, 100); }
+
+  // --- Descriptive Background Colors ---
+  @mixin background-color-red      { background-color: color(red, 100); }
+  @mixin background-color-orange   { background-color: color(orange, 100); }
+  @mixin background-color-yellow   { background-color: color(yellow, 100); }
+  @mixin background-color-green    { background-color: color(green, 100); }
+  @mixin background-color-blue     { background-color: color(blue, 100); }
+  @mixin background-color-purple   { background-color: color(purple, 100); }
+  @mixin background-color-pink     { background-color: color(pink, 100); }
+
+
+// ==========================
+// SHADOW COLOR MIXINS
+// ==========================
+
+@mixin shadow-lg {
+  box-shadow:
+    0 4px 6px -4px rgba(0, 0, 0, 0.1),
+    0 10px 15px -3px rgba(0, 0, 0, 0.1);
+}

--- a/ui/candidate-portal/src/scss/_support-colors.scss
+++ b/ui/candidate-portal/src/scss/_support-colors.scss
@@ -1,0 +1,142 @@
+$colors: (
+  core: (
+    white: #FFFFFF,
+    black: #000000,
+  ),
+  primary: (
+    50:  #f0f9fc,
+    100: #e5f3fa,
+    200: #cce6f6,
+    300: #aad7f0,
+    400: #99ceed,
+    500: #0084d1,  // Main color shade
+    600: #339dda,
+    800: #006aa7,
+    900: #004f7d
+  ),
+  secondary: (
+      50:  #f3fcfc,
+      100: #ebf8f8,
+      200: #d6f1f1,
+      300: #bfeaea,
+      400: #a7dede,
+      500: #33bbbb,  // Main color shade
+      600: #85d6d6,
+      800: #299696,
+      900: #1f7070
+  ),
+  gray: (
+    50:  #FAFAFA,
+    100: #F5F5F5,
+    200: #E5E5E5,
+    300: #D4D4D4,
+    400: #A3A3A3,
+    500: #737373,
+    600: #525252,
+    700: #404040,
+    800: #262626,
+    900: #171717,
+  ),
+  red: (
+    50:  #FEF2F2,
+    100: #FEE2E2,
+    200: #FECACA,
+    300: #FCA5A5,
+    400: #F87171,
+    500: #EF4444,
+    600: #DC2626,
+    700: #B91C1C,
+    800: #991B1B,
+    900: #7F1D1D,
+  ),
+  blue: (
+    50:  #EFF6FF,
+    100: #DBEAFE,
+    200: #BFDBFE,
+    300: #93C5FD,
+    400: #60A5FA,
+    500: #3B82F6,
+    600: #2563EB,
+    700: #1D4ED8,
+    800: #1E40AF,
+    900: #1E3A8A,
+  ),
+  purple: (
+    50:  #FAF5FF,
+    100: #EDE9FE,
+    200: #DDD6FF,
+    300: #C4B4FF,
+    400: #A684FF,
+    500: #8E51FF,
+    600: #7F22FE,
+    700: #7008E7,
+    800: #5D0EC0,
+  ),
+  pink: (
+    50:  #FDF2F8,
+    100: #FCE7F3,
+    200: #FCCEE8,
+    300: #FDA5D5,
+    400: #FB64B6,
+    500: #F6339A,
+    600: #E60076,
+    700: #C6005C,
+    800: #A3004C,
+  ),
+  orange: (
+    50:  #FFF7ED,
+    100: #FFEDD4,
+    200: #FFD6A7,
+    300: #FFB86A,
+    400: #FF8904,
+    500: #FF6900,
+    600: #EA580C,
+    700: #CA3500,
+    800: #9F2D00,
+    900: #7C2D12,
+  ),
+  yellow: (
+    50:  #FFFBEB,
+    100: #FEF3C7,
+    200: #FDE68A,
+    300: #FCD34D,
+    400: #FBBF24,
+    500: #F59E0B,
+    600: #D97706,
+    700: #B45309,
+    800: #92400E,
+    900: #713F12,
+  ),
+  green: (
+    50:  #ECFDF5,
+    100: #D0FAE5,
+    200: #A4F4CF,
+    300: #5EE9B5,
+    400: #00D492,
+    500: #00BC7D,
+    600: #009966,
+    700: #007A55,
+    800: #006045,
+    900: #064E3B,
+  ),
+);
+
+
+/*
+  Helper function
+  Example Usage of the `color()` Helper Function
+body {
+  background-color: color(core, white);
+  color: color(core, black);
+}
+
+.button {
+  background-color: color(primary, 500);
+}
+*/
+
+@function color($category, $shade: 500) {
+  @return map-get(map-get($colors, $category), $shade);
+}
+
+

--- a/ui/candidate-portal/src/scss/_typography-mixins.scss
+++ b/ui/candidate-portal/src/scss/_typography-mixins.scss
@@ -1,0 +1,47 @@
+@import url('https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&family=Merriweather:ital,opsz,wght@0,18..144,300..900;1,18..144,300..900&display=swap');
+
+$font-lato: 'Lato', sans-serif;
+
+@mixin font-style($size, $weight, $line-height, $family) {
+  font-size: $size;
+  font-weight: $weight;
+  line-height: $line-height;
+  font-family: $family;
+}
+
+// =====================
+// Paragraph
+// =====================
+
+@mixin paragraph-lg { @include font-style(18px, 400, 1.125rem,  $font-lato); }
+@mixin paragraph-md { @include font-style(16px, 400, 1rem,  $font-lato); }
+@mixin paragraph-sm { @include font-style(14px, 400, 1rem,  $font-lato); }
+@mixin paragraph-xs { @include font-style(12px, 400, 1rem,  $font-lato); }
+
+// =====================
+// Display
+// =====================
+
+@mixin display-xl { @include font-style(128px, 800, 8rem, $font-lato); }
+@mixin display-lg { @include font-style(96px, 800, 6rem, $font-lato); }
+@mixin display-md { @include font-style(72px, 800, 4.5rem, $font-lato); }
+@mixin display-sm { @include font-style(60px, 800, 3.75rem, $font-lato); }
+@mixin display-xs { @include font-style(48px, 800, 3rem, $font-lato); }
+
+// =====================
+// Headings
+// =====================
+
+@mixin heading-lg { @include font-style(40px, 700, 2.25rem, $font-lato); }
+@mixin heading-md { @include font-style(30px, 700, 1.875rem, $font-lato); }
+@mixin heading-sm { @include font-style(24px, 500, 1.5rem, $font-lato); }
+@mixin heading-xs { @include font-style(20px, 500, 1.25rem, $font-lato); }
+
+// =====================
+// Labels
+// =====================
+
+@mixin label-lg { @include font-style(18px, 500, 1.125rem, $font-lato); }
+@mixin label-md { @include font-style(16px, 500, 1rem, $font-lato); }
+@mixin label-sm { @include font-style(14px, 500, 0.875rem, $font-lato); }
+@mixin label-xs { @include font-style(12px, 500, 0.75rem, $font-lato); }


### PR DESCRIPTION
This PR replaces the use of ngb-accordion in the candidate-portal registration upload UI with the existing custom accordion components (tc-accordion and tc-accordion-item).

@ng-bootstrap/ng-bootstrap v16 is required for Angular 17 and no longer supports ngb-accordion. This PR should be reviewed and merged before the Angular upgrade proceeds.

The minimum required accordion components have been copied from the admin-portal into a shared module in the candidate-portal, following the same implementation pattern already in use there.

There are more robust approaches for sharing common component libraries across portals; a separate spike ticket (#25) exists in the backlog to explore the longer-term solution.