### PR TITLE
2593 add loading state to tc-button and remove duplicate spinners

### DIFF
--- a/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.html
+++ b/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.html
@@ -290,9 +290,9 @@
            class="d-flex align-items-center gap-2"
       >
         <tc-button [type]="'outline'"
+                   [loading]="savingSelection"
                    (onClick)="saveSelectionAgain()"
         >
-          <i class="fas fa-spinner fa-spin" *ngIf="savingSelection"></i>
           {{ targetListReplace ? 'Replace' : 'Save' }} Again
         </tc-button>
         <span class="d-flex align-items-center gap-2">
@@ -340,10 +340,10 @@
         <div class="d-flex flex-wrap gap-2 align-items-center mb-2">
           <tc-button [color]="'primary'"
                      [disabled]="!isSelection()"
+                     [loading]="savingSelection"
                      (onClick)="saveSelection()"
                      title="Save selected candidates to a list"
                      class="save-selection-btn">
-            <i class="fas fa-spinner fa-spin" *ngIf=savingSelection></i>
             <i class="fas fa-user-check"></i> to
             <i class="fas fa-list"></i>
           </tc-button>
@@ -359,28 +359,28 @@
 
           <tc-button [color]="'primary'"
                      *ngIf="canUpdateStatuses()"
+                     [loading]="updatingStatuses"
                      [disabled]="!isSelection()"
                      (onClick)="updateStatusOfSelection()"
                      title="Update statuses of selected candidates">
-            <i class="fas fa-spinner fa-spin" *ngIf=updatingStatuses></i>
             <i class="fas fa-user-check"></i>
             Status change
           </tc-button>
 
           <tc-button [color]="'primary'"
                      *ngIf="canResolveTasks()"
+                     [loading]="updatingTasks"
                      [disabled]="!isSelection()"
                      (onClick)="resolveTaskAssignments()"
                      title="Resolve any outstanding tasks">
-            <i class="fas fa-spinner fa-spin" *ngIf=updatingTasks></i>
             <i class="fas fa-user-check"></i> Resolve tasks
           </tc-button>
 
           <tc-button [color]="'primary'"
                      *ngIf="isSubmissionList() && isSalesforceUpdatable()"
+                     [loading]="updating"
                      (onClick)="createUpdateSalesforce()"
                      title="Create or update selected candidate cases">
-            <i class="fas fa-spinner fa-spin" *ngIf=updating></i>
             <i class="fas fa-user-check"></i> Update Case/s <i class="fa-solid fa-address-book"></i>
           </tc-button>
 
@@ -395,9 +395,9 @@
           <tc-button [color]="'primary'"
                      *ngIf="isSubmissionList() && isSalesforceUpdatable()"
                      [disabled]="!isSelection()"
+                     [loading]="closing"
                      (onClick)="closeSelectedOpportunities()"
                      title="Close selected candidate cases. Not removed from list but hidden unless 'Show closed cases' checkbox is checked.">
-            <i class="fas fa-spinner fa-spin" *ngIf=closing></i>
             <i class="fas fa-user-check"></i> Remove (Close)
           </tc-button>
 
@@ -423,35 +423,35 @@
         <div class="d-flex flex-wrap gap-2 align-items-center mb-2">
           <tc-button [type]="'outline'"
                      *ngIf="isImportable()"
+                     [loading]="importing"
                      (onClick)="importCandidates()"
                      title="Import candidates"
                      class="import-candidates-btn">
-            <i class="fas fa-spinner fa-spin" *ngIf=importing></i>
             Import <i class="fas fa-file-excel"></i>
           </tc-button>
 
           <tc-button [type]="'outline'"
+                     [loading]="exporting"
                      *ngIf="!isSavedList() && isExportable()"
                      (onClick)="exportCandidates()"
                      title="Export candidates">
-            <i class="fas fa-spinner fa-spin" *ngIf=exporting></i>
             Export <i class="fas fa-file-excel"></i>
           </tc-button>
 
           <tc-button [type]="'outline'"
                      *ngIf="isPublishable()"
+                     [loading]="publishing"
                      (onClick)="modifyExportColumns()"
                      title="Publish candidates to be shared externally - eg with employers">
-            <i class="fas fa-spinner fa-spin" *ngIf=publishing></i>
             Publish <i class="fas fa-globe"></i>
           </tc-button>
 
           <tc-button [type]="'outline'"
                      *ngIf= "hasPublishedDoc() && isContentModifiable()
                      && salesforceService.joblink(candidateSource)"
+                     [loading]="importingFeedback"
                      (onClick)="importEmployerFeedback()"
                      title="Import employer feedback from published list">
-            <i class="fas fa-spinner fa-spin" *ngIf=importingFeedback></i>
             Feedback <i class="fas fa-globe"></i>
           </tc-button>
         </div>

--- a/ui/admin-portal/src/app/components/candidates/view/tab/candidate-intake-tab/candidate-intake-tab.component.html
+++ b/ui/admin-portal/src/app/components/candidates/view/tab/candidate-intake-tab/candidate-intake-tab.component.html
@@ -44,9 +44,9 @@
         <tc-button [color]="'warning'"
                    (onClick)="createIntakeNote('Full Intake', 'update')"
                    [disabled]="saving"
+                   [loading]="saving"
                    [size]="'sm'"
         >
-          <i *ngIf="saving" class="fas fa-spinner fa-spin" ></i>
           Update
         </tc-button>
       </div>
@@ -64,17 +64,17 @@
         <tc-button [color]="'warning'"
                    (onClick)="inputOldIntake(true)"
                    [disabled]="saving"
+                   [loading]="saving"
                    [size]="'sm'"
         >
-          <i *ngIf="saving" class="fas fa-spinner fa-spin" ></i>
           Input External Intake
         </tc-button>
         <tc-button [color]="'success'"
                    (onClick)="completeIntake(true)"
                    [disabled]="candidate.fullIntakeCompletedDate != null"
+                   [loading]="saving"
                    [size]="'sm'"
         >
-          <i *ngIf="saving" class="fas fa-spinner fa-spin" ></i>
           Complete
         </tc-button>
       </ng-template>

--- a/ui/admin-portal/src/app/components/candidates/view/tab/candidate-mini-intake-tab/candidate-mini-intake-tab.component.html
+++ b/ui/admin-portal/src/app/components/candidates/view/tab/candidate-mini-intake-tab/candidate-mini-intake-tab.component.html
@@ -60,17 +60,17 @@
         <tc-button [color]="'warning'"
                    (onClick)="inputOldIntake(false)"
                    [disabled]="saving"
+                   [loading]="saving"
                    [size]="'sm'"
         >
-          <i *ngIf="saving" class="fas fa-spinner fa-spin" ></i>
           Input External Intake
         </tc-button>
         <tc-button [color]="'success'"
                    (onClick)="completeIntake(false)"
+                   [loading]="saving"
                    [disabled]="candidate.miniIntakeCompletedDate != null"
                    [size]="'sm'"
         >
-          <i *ngIf="saving" class="fas fa-spinner fa-spin"></i>
           Complete
         </tc-button>
       </ng-template>

--- a/ui/admin-portal/src/app/components/settings/import-duolingo-coupons/import-duolingo-coupons.component.html
+++ b/ui/admin-portal/src/app/components/settings/import-duolingo-coupons/import-duolingo-coupons.component.html
@@ -51,6 +51,6 @@
   </tc-table>
 </div>
 
-<tc-button class="float-end" (onClick)="importCSV()" [disabled]="!csvData.length || working">
-  <i class="fas fa-spinner fa-spin" *ngIf="working"></i>Import
+<tc-button class="float-end" [loading]="working" (onClick)="importCSV()" [disabled]="!csvData.length || working">
+  Import
 </tc-button>

--- a/ui/admin-portal/src/app/components/util/export-pdf/export-pdf.component.html
+++ b/ui/admin-portal/src/app/components/util/export-pdf/export-pdf.component.html
@@ -16,9 +16,9 @@
 
 <tc-button [color]="'secondary'"
            [size]="'sm'"
+           [loading]="saving"
            (onClick)="exportAsPdf(idToExport)"
            [disabled]="saving"
 >
-  <i *ngIf="saving" class="fas fa-spinner fa-spin" ></i>
   Export PDF
 </tc-button>

--- a/ui/admin-portal/src/app/components/util/partner-dpa/partner-dpa.component.html
+++ b/ui/admin-portal/src/app/components/util/partner-dpa/partner-dpa.component.html
@@ -32,12 +32,12 @@
       </p>
       <div class="d-flex gap-2">
         <tc-button
-          type="primary"
+          type="solid"
           size="lg"
           [disabled]="!termsRead || loading"
+          [loading]="loading"
           (onClick)="acceptTerms()">
 
-          <i class="fas fa-spinner fa-spin" *ngIf="loading"></i>
           Accept Agreement
         </tc-button>
 

--- a/ui/admin-portal/src/app/shared/components/button/button.component.html
+++ b/ui/admin-portal/src/app/shared/components/button/button.component.html
@@ -1,8 +1,10 @@
 <button class="btn"
         [ngClass]="classList"
-        [disabled]="disabled"
+        [disabled]="isDisabled"
         [attr.aria-label]="ariaLabel"
         [routerLink]="routerLink"
         (click)="clicked($event)">
+
+  <i class="fas fa-spinner fa-spin" *ngIf="loading"></i>
   <ng-content></ng-content>
 </button>

--- a/ui/admin-portal/src/app/shared/components/button/button.component.spec.ts
+++ b/ui/admin-portal/src/app/shared/components/button/button.component.spec.ts
@@ -1,7 +1,6 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { Component } from '@angular/core';
-import { ButtonComponent } from './button.component';
-import { By } from '@angular/platform-browser';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {ButtonComponent} from './button.component';
+import {By} from '@angular/platform-browser';
 
 describe('ButtonComponent', () => {
   let component: ButtonComponent;
@@ -48,6 +47,57 @@ describe('ButtonComponent', () => {
     it('should set aria-label when ariaLabel input is provided', () => {
       const buttonDebug = fixture.debugElement.query(By.css('button'));
       expect(buttonDebug.attributes['aria-label']).toBe('Refresh');
+    });
+  });
+
+  describe('loading state', () => {
+    it('should render spinner icon when loading is true', () => {
+      component.loading = true;
+      fixture.detectChanges();
+
+      const spinner = fixture.debugElement.query(By.css('i.fas.fa-spinner.fa-spin'));
+      expect(spinner).toBeTruthy();
+    });
+
+    it('should disable the native button when loading is true', () => {
+      component.loading = true;
+      fixture.detectChanges();
+
+      const buttonElement: HTMLButtonElement = fixture.nativeElement.querySelector('button');
+      expect(buttonElement.disabled).toBeTrue();
+    });
+
+    it('should add btn-loading class when loading is true', () => {
+      component.loading = true;
+      fixture.detectChanges();
+
+      const buttonElement: HTMLButtonElement = fixture.nativeElement.querySelector('button');
+      expect(buttonElement.classList).toContain('btn-loading');
+    });
+
+    it('should not emit onClick when loading is true', () => {
+      component.loading = true;
+      fixture.detectChanges();
+
+      spyOn(component.onClick, 'emit');
+
+      const buttonDebug = fixture.debugElement.query(By.css('button'));
+      buttonDebug.triggerEventHandler('click', new MouseEvent('click'));
+
+      expect(component.onClick.emit).not.toHaveBeenCalled();
+    });
+
+    it('should emit onClick when loading is false and disabled is false', () => {
+      component.loading = false;
+      component.disabled = false;
+      fixture.detectChanges();
+
+      spyOn(component.onClick, 'emit');
+
+      const buttonDebug = fixture.debugElement.query(By.css('button'));
+      buttonDebug.triggerEventHandler('click', new MouseEvent('click'));
+
+      expect(component.onClick.emit).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/ui/admin-portal/src/app/shared/components/button/button.component.ts
+++ b/ui/admin-portal/src/app/shared/components/button/button.component.ts
@@ -69,6 +69,7 @@ export class ButtonComponent {
   @Input() type: 'solid' | 'outline' | 'plain' = 'solid';
   @Input() color: 'primary' | 'secondary' | 'success' | 'warning' | 'error' | 'info' | 'gray'= 'primary';
   @Input() disabled = false;
+  @Input() loading = false;
   @Input() ariaLabel?: string;
   @Input() routerLink?: string | any[];
   /**
@@ -90,7 +91,7 @@ export class ButtonComponent {
   @Output() onClick = new EventEmitter();
 
   @HostBinding('class.disabled') get isDisabled() {
-    return this.disabled;
+    return this.disabled || this.loading;
   }
 
   get classList(): string[] {
@@ -98,6 +99,7 @@ export class ButtonComponent {
       `btn-${this.size}`,
       `btn-${this.color}`,
       `btn-${this.type}`,
+      ...(this.loading ? ['btn-loading'] : [])
     ];
   }
 
@@ -105,7 +107,9 @@ export class ButtonComponent {
     if (this.stopNativeClickPropagation) {
       e.stopPropagation();
     }
-    this.onClick.emit();
+    if (!this.isDisabled) {
+      this.onClick.emit();
+    }
   }
 
 }


### PR DESCRIPTION
This PR adds loading indicator logic into tc-button:
1-Removes manual spinner icon across 6 files.
2-Adds [loading] input to automatically disable button and show spinner.
3-Adds unit tests covering the new behavior