### PR TITLE
2967 use cached candidate dto fetching used in search to also fetch candidates in list

### DIFF
--- a/server/src/main/java/org/tctalent/server/api/admin/CandidateAdminApi.java
+++ b/server/src/main/java/org/tctalent/server/api/admin/CandidateAdminApi.java
@@ -106,7 +106,7 @@ public class CandidateAdminApi {
 
     @PostMapping("search")
     public Map<String, Object> search(@RequestBody SearchCandidateRequest request) {
-        Page<Candidate> candidates = savedSearchService.searchCandidates(request);
+        Page<CandidateReadDto> candidates = savedSearchService.searchCandidateDtos(request);
 
         long start = System.currentTimeMillis();
         long end;
@@ -125,9 +125,9 @@ public class CandidateAdminApi {
         return stringObjectMap;
     }
 
-    @PostMapping("search-fast")
-    public Map<String, Object> searchFast(@RequestBody SearchCandidateRequest request) {
-        Page<CandidateReadDto> candidates = savedSearchService.searchCandidateDtos(request);
+    @PostMapping("search-old-fetch")
+    public Map<String, Object> searchOldFetch(@RequestBody SearchCandidateRequest request) {
+        Page<Candidate> candidates = savedSearchService.searchCandidates(request);
 
         long start = System.currentTimeMillis();
         long end;

--- a/server/src/main/java/org/tctalent/server/api/admin/SavedListCandidateAdminApi.java
+++ b/server/src/main/java/org/tctalent/server/api/admin/SavedListCandidateAdminApi.java
@@ -174,8 +174,12 @@ public class SavedListCandidateAdminApi implements
 
         savedListService.setCandidateContext(savedListId, candidates);
 
+        //TODO JC Review how this is done. Commented out for now. See issue 2989
         // Populate the transient answers for question tasks to display in search card 'Tasks' tab
-        candidateService.populateCandidatesTransientTaskAssignments(candidates);
+//        for (Candidate candidate : candidates) {
+//            taskAssignmentService.populateTransientTaskAssignmentFields(
+//                candidate.getTaskAssignments());
+//        }
 
         DtoBuilder builder = candidateBuilderSelector.selectBuilder(request.getDtoType());
         return builder.buildPage(candidates);
@@ -191,9 +195,14 @@ public class SavedListCandidateAdminApi implements
 
         savedListService.setCandidateDtoContext(savedListId, candidates);
 
-        //TODO JC Not sure I like this - but it could be done by passing in task assignment dtos, not candidates.
+        //TODO JC Review how this is done. Commented out for now. See issue 2989
         // Populate the transient answers for question tasks to display in search card 'Tasks' tab
-//        candidateService.populateCandidatesTransientTaskAssignments(candidates);
+//        for (CandidateReadDto candidate : candidates) {
+//            final List<TaskAssignmentReadDto> tas = candidate.getTaskAssignments();
+//            for (TaskAssignmentReadDto ta : tas) {
+//                taskAssignmentService.populateTransientTaskAssignmentDtoFields(ta);
+//            }
+//        }
 
         DtoBuilder builder = candidateBuilderSelector.selectBuilder(request.getDtoType());
         return builder.buildPage(candidates);

--- a/server/src/main/java/org/tctalent/server/api/admin/SavedListCandidateAdminApi.java
+++ b/server/src/main/java/org/tctalent/server/api/admin/SavedListCandidateAdminApi.java
@@ -16,14 +16,11 @@
 
 package org.tctalent.server.api.admin;
 
-import static org.tctalent.server.configuration.SystemAdminConfiguration.PENDING_TERMS_ACCEPTANCE_LIST_ID;
-
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -32,7 +29,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.MediaType;
 import org.springframework.lang.NonNull;
-import org.springframework.lang.Nullable;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -50,18 +46,14 @@ import org.tctalent.server.exception.ExportFailedException;
 import org.tctalent.server.exception.InvalidSessionException;
 import org.tctalent.server.exception.NoSuchObjectException;
 import org.tctalent.server.model.db.Candidate;
-import org.tctalent.server.model.db.CandidateAttachment;
-import org.tctalent.server.model.db.CandidateSavedList;
 import org.tctalent.server.model.db.SavedList;
-import org.tctalent.server.model.db.mapper.CandidateAttachmentMapper;
-import org.tctalent.server.repository.db.read.dto.CandidateAttachmentReadDto;
-import org.tctalent.server.repository.db.read.dto.CandidateDependantReadDto;
 import org.tctalent.server.repository.db.read.dto.CandidateReadDto;
 import org.tctalent.server.request.candidate.SavedListGetRequest;
 import org.tctalent.server.request.candidate.UpdateCandidateStatusInfo;
 import org.tctalent.server.request.candidate.UpdateCandidateStatusRequest;
 import org.tctalent.server.request.list.ContentUpdateType;
 import org.tctalent.server.request.list.UpdateExplicitSavedListContentsRequest;
+import org.tctalent.server.service.db.CandidateDtoService;
 import org.tctalent.server.service.db.CandidateSavedListService;
 import org.tctalent.server.service.db.CandidateService;
 import org.tctalent.server.service.db.SavedListService;
@@ -93,9 +85,9 @@ import org.tctalent.server.util.dto.DtoBuilder;
 public class SavedListCandidateAdminApi implements
     IManyToManyApi<SavedListGetRequest, UpdateExplicitSavedListContentsRequest> {
 
+    private final CandidateDtoService candidateDtoService;
     private final CandidateService candidateService;
     private final CandidateSavedListService candidateSavedListService;
-    private final CandidateAttachmentMapper attachmentMapper;
     private final SavedListService savedListService;
     private final SavedSearchService savedSearchService;
     private final CandidateBuilderSelector candidateBuilderSelector;
@@ -179,31 +171,10 @@ public class SavedListCandidateAdminApi implements
             long savedListId, @Valid SavedListGetRequest request) throws NoSuchObjectException {
         SavedList savedList = savedListService.get(savedListId);
 
-        Page<Candidate> candidates = candidateService
-            .getSavedListCandidates(savedList, request);
-
-        savedListService.setCandidateContext(savedListId, candidates);
-
-        //TODO JC Review how this is done. Commented out for now. See issue 2989
-        // Populate the transient answers for question tasks to display in search card 'Tasks' tab
-//        for (Candidate candidate : candidates) {
-//            taskAssignmentService.populateTransientTaskAssignmentFields(
-//                candidate.getTaskAssignments());
-//        }
-
-        DtoBuilder builder = candidateBuilderSelector.selectBuilder(request.getDtoType());
-        return builder.buildPage(candidates);
-    }
-
-    @PostMapping("{id}/search-paged-fast")
-    public @NotNull Map<String, Object> searchPagedFast(
-        @PathVariable("id") long savedListId, @Valid @RequestBody SavedListGetRequest request) throws NoSuchObjectException {
-        SavedList savedList = savedListService.get(savedListId);
-
         Page<CandidateReadDto> candidates = savedListService
             .getSavedListCandidateDtos(savedList, request);
 
-        populateComputedFields(candidates, savedListId);
+        candidateDtoService.populateComputedFields(candidates, savedListId);
 
         //TODO JC Review how this is done. Commented out for now. See issue 2989
         // Populate the transient answers for question tasks to display in search card 'Tasks' tab
@@ -218,49 +189,25 @@ public class SavedListCandidateAdminApi implements
         return builder.buildPage(candidates);
     }
 
-    //TODO JC This needs to be shared with SavedSearch - there it uses the selection list of the
-    // saved search, only updating candidates in the selection list.
-    private void populateComputedFields(Iterable<CandidateReadDto> candidates, long savedListId) {
+    @PostMapping("{id}/search-paged-old-fetch")
+    public @NotNull Map<String, Object> searchPagedOldFetch(
+        @PathVariable("id") long savedListId, @Valid @RequestBody SavedListGetRequest request) throws NoSuchObjectException {
+        SavedList savedList = savedListService.get(savedListId);
 
-        //Get all CandidateSavedList objects in a single db access.
-        Set<Long> ids = new HashSet<>();
-        for (CandidateReadDto candidate : candidates) {
-            ids.add(candidate.getId());
-        }
-        Map<Long, CandidateSavedList> csls =
-            candidateSavedListService.findByCandidateIds(ids, savedListId);
+        Page<Candidate> candidates = candidateService
+            .getSavedListCandidates(savedList, request);
 
-        //Load all candidates in pending terms list
-        Set<Long> pendingTermsIds = savedListService.fetchCandidateIds(PENDING_TERMS_ACCEPTANCE_LIST_ID);
+        savedListService.setCandidateContext(savedListId, candidates);
 
-        //Populate the computed fields
-        for (CandidateReadDto candidate : candidates) {
-            //Retrieve list context for this candidate
-            CandidateSavedList csl = csls.get(candidate.getId());
+        //TODO JC Review how this is done. Commented out for now. See issue 2989
+        // Populate the transient answers for question tasks to display in search card 'Tasks' tab
+//        for (Candidate candidate : candidates) {
+//            taskAssignmentService.populateTransientTaskAssignmentFields(
+//                candidate.getTaskAssignments());
+//        }
 
-            //If the candidate is in the list then we need to retrieve the list dependant context.
-            if (csl != null) {
-                //Set any context note
-                candidate.setContextNote(csl.getContextNote());
-
-                //Need to retrieve the list dependant attachments if they exist
-                candidate.setListShareableCv(createDto(csl.getShareableCv()));
-                candidate.setListShareableDoc(createDto(csl.getShareableDoc()));
-            }
-
-            //Check whether the candidate is in the pending terms list
-            candidate.setPendingTerms(pendingTermsIds.contains(candidate.getId()));
-
-            //Compute the number of dependants
-            final List<CandidateDependantReadDto> dependants = candidate.getCandidateDependants();
-            candidate.setNumberDependants(dependants == null ? 0 : dependants.size());
-        }
-    }
-
-    @Nullable
-    private CandidateAttachmentReadDto createDto(@Nullable CandidateAttachment attachment) {
-        //TODO JC Will this copy the createdBy user?
-        return attachment == null ? null : attachmentMapper.toDto(attachment);
+        DtoBuilder builder = candidateBuilderSelector.selectBuilder(request.getDtoType());
+        return builder.buildPage(candidates);
     }
 
     @Override

--- a/server/src/main/java/org/tctalent/server/api/admin/SavedListCandidateAdminApi.java
+++ b/server/src/main/java/org/tctalent/server/api/admin/SavedListCandidateAdminApi.java
@@ -47,6 +47,7 @@ import org.tctalent.server.exception.InvalidSessionException;
 import org.tctalent.server.exception.NoSuchObjectException;
 import org.tctalent.server.model.db.Candidate;
 import org.tctalent.server.model.db.SavedList;
+import org.tctalent.server.repository.db.read.dto.CandidateReadDto;
 import org.tctalent.server.request.candidate.SavedListGetRequest;
 import org.tctalent.server.request.candidate.UpdateCandidateStatusInfo;
 import org.tctalent.server.request.candidate.UpdateCandidateStatusRequest;
@@ -173,6 +174,25 @@ public class SavedListCandidateAdminApi implements
 
         savedListService.setCandidateContext(savedListId, candidates);
 
+        // Populate the transient answers for question tasks to display in search card 'Tasks' tab
+        candidateService.populateCandidatesTransientTaskAssignments(candidates);
+
+        DtoBuilder builder = candidateBuilderSelector.selectBuilder(request.getDtoType());
+        return builder.buildPage(candidates);
+    }
+
+    @PostMapping("{id}/search-paged-fast")
+    public @NotNull Map<String, Object> searchPagedFast(
+            long savedListId, @Valid SavedListGetRequest request) throws NoSuchObjectException {
+        SavedList savedList = savedListService.get(savedListId);
+
+        Page<CandidateReadDto> candidates = candidateService
+            .getSavedListCandidateDtos(savedList, request);
+
+        savedListService.setCandidateDtoContext(savedListId, candidates);
+
+        //TODO JC Not sure I like this - but it could be done by passing in task assignment dtos, not candidates.
+        //Also I think we may replace QuestionTasks with FormTasks 
         // Populate the transient answers for question tasks to display in search card 'Tasks' tab
         candidateService.populateCandidatesTransientTaskAssignments(candidates);
 

--- a/server/src/main/java/org/tctalent/server/api/admin/SavedListCandidateAdminApi.java
+++ b/server/src/main/java/org/tctalent/server/api/admin/SavedListCandidateAdminApi.java
@@ -183,18 +183,17 @@ public class SavedListCandidateAdminApi implements
 
     @PostMapping("{id}/search-paged-fast")
     public @NotNull Map<String, Object> searchPagedFast(
-            long savedListId, @Valid SavedListGetRequest request) throws NoSuchObjectException {
+        @PathVariable("id") long savedListId, @Valid @RequestBody SavedListGetRequest request) throws NoSuchObjectException {
         SavedList savedList = savedListService.get(savedListId);
 
-        Page<CandidateReadDto> candidates = candidateService
+        Page<CandidateReadDto> candidates = savedListService
             .getSavedListCandidateDtos(savedList, request);
 
         savedListService.setCandidateDtoContext(savedListId, candidates);
 
         //TODO JC Not sure I like this - but it could be done by passing in task assignment dtos, not candidates.
-        //Also I think we may replace QuestionTasks with FormTasks 
         // Populate the transient answers for question tasks to display in search card 'Tasks' tab
-        candidateService.populateCandidatesTransientTaskAssignments(candidates);
+//        candidateService.populateCandidatesTransientTaskAssignments(candidates);
 
         DtoBuilder builder = candidateBuilderSelector.selectBuilder(request.getDtoType());
         return builder.buildPage(candidates);

--- a/server/src/main/java/org/tctalent/server/api/admin/SavedListCandidateAdminApi.java
+++ b/server/src/main/java/org/tctalent/server/api/admin/SavedListCandidateAdminApi.java
@@ -204,9 +204,6 @@ public class SavedListCandidateAdminApi implements
             .getSavedListCandidateDtos(savedList, request);
 
         populateComputedFields(candidates, savedListId);
-//todo The above call replaces this...
-//      savedListService.setCandidateDtoContext(savedListId, candidates);
-//todo That is because the population of completed fields in not done in the entity object code.
 
         //TODO JC Review how this is done. Commented out for now. See issue 2989
         // Populate the transient answers for question tasks to display in search card 'Tasks' tab

--- a/server/src/main/java/org/tctalent/server/api/admin/SavedListCandidateAdminApi.java
+++ b/server/src/main/java/org/tctalent/server/api/admin/SavedListCandidateAdminApi.java
@@ -16,11 +16,14 @@
 
 package org.tctalent.server.api.admin;
 
+import static org.tctalent.server.configuration.SystemAdminConfiguration.PENDING_TERMS_ACCEPTANCE_LIST_ID;
+
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -29,6 +32,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.MediaType;
 import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -46,7 +50,12 @@ import org.tctalent.server.exception.ExportFailedException;
 import org.tctalent.server.exception.InvalidSessionException;
 import org.tctalent.server.exception.NoSuchObjectException;
 import org.tctalent.server.model.db.Candidate;
+import org.tctalent.server.model.db.CandidateAttachment;
+import org.tctalent.server.model.db.CandidateSavedList;
 import org.tctalent.server.model.db.SavedList;
+import org.tctalent.server.model.db.mapper.CandidateAttachmentMapper;
+import org.tctalent.server.repository.db.read.dto.CandidateAttachmentReadDto;
+import org.tctalent.server.repository.db.read.dto.CandidateDependantReadDto;
 import org.tctalent.server.repository.db.read.dto.CandidateReadDto;
 import org.tctalent.server.request.candidate.SavedListGetRequest;
 import org.tctalent.server.request.candidate.UpdateCandidateStatusInfo;
@@ -86,6 +95,7 @@ public class SavedListCandidateAdminApi implements
 
     private final CandidateService candidateService;
     private final CandidateSavedListService candidateSavedListService;
+    private final CandidateAttachmentMapper attachmentMapper;
     private final SavedListService savedListService;
     private final SavedSearchService savedSearchService;
     private final CandidateBuilderSelector candidateBuilderSelector;
@@ -193,7 +203,10 @@ public class SavedListCandidateAdminApi implements
         Page<CandidateReadDto> candidates = savedListService
             .getSavedListCandidateDtos(savedList, request);
 
-        savedListService.setCandidateDtoContext(savedListId, candidates);
+        populateComputedFields(candidates, savedListId);
+//todo The above call replaces this...
+//      savedListService.setCandidateDtoContext(savedListId, candidates);
+//todo That is because the population of completed fields in not done in the entity object code.
 
         //TODO JC Review how this is done. Commented out for now. See issue 2989
         // Populate the transient answers for question tasks to display in search card 'Tasks' tab
@@ -206,6 +219,51 @@ public class SavedListCandidateAdminApi implements
 
         DtoBuilder builder = candidateBuilderSelector.selectBuilder(request.getDtoType());
         return builder.buildPage(candidates);
+    }
+
+    //TODO JC This needs to be shared with SavedSearch - there it uses the selection list of the
+    // saved search, only updating candidates in the selection list.
+    private void populateComputedFields(Iterable<CandidateReadDto> candidates, long savedListId) {
+
+        //Get all CandidateSavedList objects in a single db access.
+        Set<Long> ids = new HashSet<>();
+        for (CandidateReadDto candidate : candidates) {
+            ids.add(candidate.getId());
+        }
+        Map<Long, CandidateSavedList> csls =
+            candidateSavedListService.findByCandidateIds(ids, savedListId);
+
+        //Load all candidates in pending terms list
+        Set<Long> pendingTermsIds = savedListService.fetchCandidateIds(PENDING_TERMS_ACCEPTANCE_LIST_ID);
+
+        //Populate the computed fields
+        for (CandidateReadDto candidate : candidates) {
+            //Retrieve list context for this candidate
+            CandidateSavedList csl = csls.get(candidate.getId());
+
+            //If the candidate is in the list then we need to retrieve the list dependant context.
+            if (csl != null) {
+                //Set any context note
+                candidate.setContextNote(csl.getContextNote());
+
+                //Need to retrieve the list dependant attachments if they exist
+                candidate.setListShareableCv(createDto(csl.getShareableCv()));
+                candidate.setListShareableDoc(createDto(csl.getShareableDoc()));
+            }
+
+            //Check whether the candidate is in the pending terms list
+            candidate.setPendingTerms(pendingTermsIds.contains(candidate.getId()));
+
+            //Compute the number of dependants
+            final List<CandidateDependantReadDto> dependants = candidate.getCandidateDependants();
+            candidate.setNumberDependants(dependants == null ? 0 : dependants.size());
+        }
+    }
+
+    @Nullable
+    private CandidateAttachmentReadDto createDto(@Nullable CandidateAttachment attachment) {
+        //TODO JC Will this copy the createdBy user?
+        return attachment == null ? null : attachmentMapper.toDto(attachment);
     }
 
     @Override

--- a/server/src/main/java/org/tctalent/server/api/admin/SavedSearchCandidateAdminApi.java
+++ b/server/src/main/java/org/tctalent/server/api/admin/SavedSearchCandidateAdminApi.java
@@ -38,8 +38,8 @@ import org.tctalent.server.logging.LogBuilder;
 import org.tctalent.server.model.db.Candidate;
 import org.tctalent.server.request.candidate.SavedSearchGetRequest;
 import org.tctalent.server.request.list.UpdateSavedListContentsRequest;
-import org.tctalent.server.service.db.CandidateService;
 import org.tctalent.server.service.db.SavedSearchService;
+import org.tctalent.server.service.db.TaskAssignmentService;
 import org.tctalent.server.util.dto.DtoBuilder;
 
 /**
@@ -55,9 +55,9 @@ import org.tctalent.server.util.dto.DtoBuilder;
 public class SavedSearchCandidateAdminApi implements
     IManyToManyApi<SavedSearchGetRequest, UpdateSavedListContentsRequest> {
 
-    private final SavedSearchService savedSearchService;
-    private final CandidateService candidateService;
     private final CandidateBuilderSelector builderSelector;
+    private final SavedSearchService savedSearchService;
+    private final TaskAssignmentService taskAssignmentService;
 
     @Override
     public @NotNull Map<String, Object> searchPaged(
@@ -70,7 +70,9 @@ public class SavedSearchCandidateAdminApi implements
         savedSearchService.setCandidateContext(savedSearchId, candidates);
 
         // Populate the transient answers for question tasks to display in search card 'Tasks' tab
-        candidateService.populateCandidatesTransientTaskAssignments(candidates);
+        for (Candidate candidate : candidates) {
+            taskAssignmentService.populateTransientTaskAssignmentFields(candidate.getTaskAssignments());
+        }
 
         long start = System.currentTimeMillis();
         long end;

--- a/server/src/main/java/org/tctalent/server/api/admin/SavedSearchCandidateAdminApi.java
+++ b/server/src/main/java/org/tctalent/server/api/admin/SavedSearchCandidateAdminApi.java
@@ -36,8 +36,11 @@ import org.tctalent.server.exception.ExportFailedException;
 import org.tctalent.server.exception.NoSuchObjectException;
 import org.tctalent.server.logging.LogBuilder;
 import org.tctalent.server.model.db.Candidate;
+import org.tctalent.server.model.db.SavedList;
+import org.tctalent.server.repository.db.read.dto.CandidateReadDto;
 import org.tctalent.server.request.candidate.SavedSearchGetRequest;
 import org.tctalent.server.request.list.UpdateSavedListContentsRequest;
+import org.tctalent.server.service.db.CandidateDtoService;
 import org.tctalent.server.service.db.SavedSearchService;
 import org.tctalent.server.util.dto.DtoBuilder;
 
@@ -55,15 +58,50 @@ public class SavedSearchCandidateAdminApi implements
     IManyToManyApi<SavedSearchGetRequest, UpdateSavedListContentsRequest> {
 
     private final CandidateBuilderSelector builderSelector;
+    private final CandidateDtoService candidateDtoService;
     private final SavedSearchService savedSearchService;
 
     @Override
     public @NotNull Map<String, Object> searchPaged(
             long savedSearchId, @Valid SavedSearchGetRequest request)
+        throws NoSuchObjectException {
+
+        Page<CandidateReadDto> candidates =
+            savedSearchService.searchCandidateDtos(savedSearchId, request);
+
+        //The selection list provides context for candidates selected from the search results.
+        SavedList selectionList = savedSearchService.getSelectionListForLoggedInUser(savedSearchId);
+        candidateDtoService.populateComputedFields(candidates, selectionList.getId());
+
+        //TODO JC Review how this is done. Commented out for now. See issue 2989
+        // Populate the transient answers for question tasks to display in search card 'Tasks' tab
+//        for (Candidate candidate : candidates) {
+//            taskAssignmentService.populateTransientTaskAssignmentFields(candidate.getTaskAssignments());
+//        }
+
+        long start = System.currentTimeMillis();
+        long end;
+
+        DtoBuilder builder = builderSelector.selectBuilder(request.getDtoType());
+        final Map<String, Object> stringObjectMap = builder.buildPage(candidates);
+
+        end = System.currentTimeMillis();
+        long computeDtoTime = end - start;
+
+        LogBuilder.builder(log).action("findCandidates")
+            .message("Timings: computeDto: " + computeDtoTime
+            ).logInfo();
+
+        return stringObjectMap;
+    }
+
+    @PostMapping("{id}/search-paged-old-fetch")
+    public @NotNull Map<String, Object> searchPagedOldFetch(
+        @PathVariable("id") long savedSearchId, @Valid  @RequestBody SavedSearchGetRequest request)
             throws NoSuchObjectException {
 
         Page<Candidate> candidates =
-                savedSearchService.searchCandidates(savedSearchId, request);
+            savedSearchService.searchCandidates(savedSearchId, request);
 
         savedSearchService.setCandidateContext(savedSearchId, candidates);
 

--- a/server/src/main/java/org/tctalent/server/api/admin/SavedSearchCandidateAdminApi.java
+++ b/server/src/main/java/org/tctalent/server/api/admin/SavedSearchCandidateAdminApi.java
@@ -39,7 +39,6 @@ import org.tctalent.server.model.db.Candidate;
 import org.tctalent.server.request.candidate.SavedSearchGetRequest;
 import org.tctalent.server.request.list.UpdateSavedListContentsRequest;
 import org.tctalent.server.service.db.SavedSearchService;
-import org.tctalent.server.service.db.TaskAssignmentService;
 import org.tctalent.server.util.dto.DtoBuilder;
 
 /**
@@ -57,7 +56,6 @@ public class SavedSearchCandidateAdminApi implements
 
     private final CandidateBuilderSelector builderSelector;
     private final SavedSearchService savedSearchService;
-    private final TaskAssignmentService taskAssignmentService;
 
     @Override
     public @NotNull Map<String, Object> searchPaged(
@@ -69,10 +67,11 @@ public class SavedSearchCandidateAdminApi implements
 
         savedSearchService.setCandidateContext(savedSearchId, candidates);
 
+        //TODO JC Review how this is done. Commented out for now. See issue 2989
         // Populate the transient answers for question tasks to display in search card 'Tasks' tab
-        for (Candidate candidate : candidates) {
-            taskAssignmentService.populateTransientTaskAssignmentFields(candidate.getTaskAssignments());
-        }
+//        for (Candidate candidate : candidates) {
+//            taskAssignmentService.populateTransientTaskAssignmentFields(candidate.getTaskAssignments());
+//        }
 
         long start = System.currentTimeMillis();
         long end;

--- a/server/src/main/java/org/tctalent/server/model/db/QuestionTaskAssignmentImpl.java
+++ b/server/src/main/java/org/tctalent/server/model/db/QuestionTaskAssignmentImpl.java
@@ -36,6 +36,8 @@ import org.tctalent.server.model.db.task.QuestionTaskAssignment;
 public class QuestionTaskAssignmentImpl extends TaskAssignmentImpl implements
     QuestionTaskAssignment {
 
+    //TODO JC Shouldn't this have an implementation that fetches the answer using the logic
+    //described in the JavaDoc for QuestionTask.getCandidateAnswerField
     @Transient
     @Nullable
     String answer;

--- a/server/src/main/java/org/tctalent/server/model/db/QuestionTaskImpl.java
+++ b/server/src/main/java/org/tctalent/server/model/db/QuestionTaskImpl.java
@@ -47,8 +47,11 @@ public class QuestionTaskImpl extends TaskImpl implements QuestionTask {
     @Convert(converter = CommaDelimitedStringsConverter.class)
     private List<String> explicitAllowedAnswers;
 
+    //TODO JC This needs to be better documented. It is saying that the type of the Candidate
+    //field specified in candidateAnswerField can be used to limit allowable answers.
     /**
-     * Set by candidate answer field if present, otherwise if explicit answer is not null will be set as the explicit answers.
+     * Set by candidate answer field if present, otherwise if explicit answer is not null will be
+     * set as the explicit answers.
      * If allowedAnswers is not null, the quesiton task answer format will be a dropdown.
      * If allowedAnswers is null, the question answer format will be a text box.
      */

--- a/server/src/main/java/org/tctalent/server/model/db/mapper/CandidateAttachmentMapper.java
+++ b/server/src/main/java/org/tctalent/server/model/db/mapper/CandidateAttachmentMapper.java
@@ -17,29 +17,15 @@
 package org.tctalent.server.model.db.mapper;
 
 import org.mapstruct.Mapper;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.tctalent.server.model.db.partner.Partner;
-import org.tctalent.server.repository.db.read.dto.PartnerReadDto;
-import org.tctalent.server.service.db.PartnerService;
+import org.tctalent.server.model.db.CandidateAttachment;
+import org.tctalent.server.repository.db.read.dto.CandidateAttachmentReadDto;
 
 /**
- * Maps public object to equivalent entity form local database.
- * <p/>
- * For MapStruct Mapper we need to us abstract class instead of interface so that we can inject in
- * service.
+ * Map CandidateAttachment to a DTO
  *
  * @author John Cameron
  */
 @Mapper
-public abstract class PartnerMapper {
-
-    @Autowired
-    protected PartnerService service;
-
-    public Partner lookUpFromService(
-        org.tctalent.anonymization.model.IdentifiablePartner publicValue) {
-        return publicValue == null ? null : service.findByPublicId(publicValue.getPublicId());
-    }
-
-    abstract public PartnerReadDto toDto(Partner partner);
+public interface CandidateAttachmentMapper {
+  CandidateAttachmentReadDto toDto(CandidateAttachment attachment);
 }

--- a/server/src/main/java/org/tctalent/server/model/db/mapper/UserMapper.java
+++ b/server/src/main/java/org/tctalent/server/model/db/mapper/UserMapper.java
@@ -18,6 +18,7 @@ package org.tctalent.server.model.db.mapper;
 
 import org.mapstruct.Mapper;
 import org.tctalent.server.model.db.User;
+import org.tctalent.server.repository.db.read.dto.UserReadDto;
 
 /**
  * User related mappings.
@@ -27,4 +28,6 @@ import org.tctalent.server.model.db.User;
 @Mapper
 public interface UserMapper {
     User userIdentityToUser(org.tctalent.anonymization.model.User user);
+
+    UserReadDto toDto(User user);
 }

--- a/server/src/main/java/org/tctalent/server/repository/db/CandidateSavedListRepository.java
+++ b/server/src/main/java/org/tctalent/server/repository/db/CandidateSavedListRepository.java
@@ -16,6 +16,7 @@
 
 package org.tctalent.server.repository.db;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.tctalent.server.model.db.CandidateSavedList;
 import org.tctalent.server.model.db.CandidateSavedListKey;
@@ -25,4 +26,6 @@ import org.tctalent.server.model.db.CandidateSavedListKey;
  */
 public interface CandidateSavedListRepository extends
         JpaRepository<CandidateSavedList, CandidateSavedListKey> {
+
+    List<CandidateSavedList> findBySavedList_Id(Long savedListId);
 }

--- a/server/src/main/java/org/tctalent/server/repository/db/read/annotation/SqlColumn.java
+++ b/server/src/main/java/org/tctalent/server/repository/db/read/annotation/SqlColumn.java
@@ -21,7 +21,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Specifies the database column that a DTO field is associated with (defaulting to the name of 
+ * Specifies the database column that a DTO field is associated with (defaulting to the name of
  * the annotated field, converted to snake case.
  *
  * @author John Cameron
@@ -39,4 +39,25 @@ public @interface SqlColumn {
      * Defaults to the name.
      */
     String jsonKey() default "";
+
+    /**
+     * <p>
+     * Optional SQL transform applied to the resolved column expression.
+     * </p>
+     *
+     * <p>
+     * The transform must contain exactly one {@code %s}, which will be replaced
+     * with the fully-qualified column reference (e.g. {@code ctask.uploadable_file_types}).
+     * </p>
+     *
+     * <p>
+     * Example:
+     * </p>
+     *
+     * <pre>{@code
+     * @SqlColumn(transform = "to_jsonb(string_to_array(%s, ','))")
+     * private List<String> uploadableFileTypes;
+     * }</pre>
+     */
+    String transform() default "";
 }

--- a/server/src/main/java/org/tctalent/server/repository/db/read/dto/AllowedQuestionTaskAnswerReadDto.java
+++ b/server/src/main/java/org/tctalent/server/repository/db/read/dto/AllowedQuestionTaskAnswerReadDto.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2025 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.repository.db.read.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Not associated with a table.
+ * It is computed.
+ *
+ * @author John Cameron
+ */
+@Getter
+@Setter
+public class AllowedQuestionTaskAnswerReadDto {
+    private String name;
+    private String displayName;
+}

--- a/server/src/main/java/org/tctalent/server/repository/db/read/dto/CandidateFormReadDto.java
+++ b/server/src/main/java/org/tctalent/server/repository/db/read/dto/CandidateFormReadDto.java
@@ -16,32 +16,16 @@
 
 package org.tctalent.server.repository.db.read.dto;
 
-import java.time.OffsetDateTime;
 import lombok.Getter;
 import lombok.Setter;
-import org.tctalent.server.model.db.Status;
-import org.tctalent.server.model.db.task.TaskType;
-import org.tctalent.server.repository.db.read.annotation.JsonOneToOne;
 import org.tctalent.server.repository.db.read.annotation.SqlDefaults;
-import org.tctalent.server.repository.db.read.annotation.SqlIgnore;
 import org.tctalent.server.repository.db.read.annotation.SqlTable;
 
 @Getter
 @Setter
-@SqlTable(name="task_assignment", alias = "ctaska")
+@SqlTable(name="candidate_form", alias = "cform")
 @SqlDefaults(mapUnannotatedColumns = true)
-public class TaskAssignmentReadDto {
-    private OffsetDateTime abandonedDate;
-
-    @SqlIgnore //Could be manually populated - but for now it is not being populated
-    private String answer;
-    private String candidateNotes;
-    private OffsetDateTime completedDate;
-    private OffsetDateTime dueDate;
-    private Long id;
-    private Status status;
-
-    @JsonOneToOne(joinColumn = "task_id")
-    private TaskReadDto task;
-    private TaskType taskType;
+public class CandidateFormReadDto {
+    private String name;
+    private String description;
 }

--- a/server/src/main/java/org/tctalent/server/repository/db/read/dto/CandidateReadDto.java
+++ b/server/src/main/java/org/tctalent/server/repository/db/read/dto/CandidateReadDto.java
@@ -40,7 +40,7 @@ public class CandidateReadDto {
 
     private OffsetDateTime acceptedPrivacyPolicyDate;
     private String acceptedPrivacyPolicyId;
-    
+
     @JsonOneToOne(joinColumn = "accepted_privacy_policy_partner_id")
     private PartnerReadDto acceptedPrivacyPolicyPartner;
     private String additionalInfo;
@@ -78,15 +78,17 @@ public class CandidateReadDto {
     private List<CandidateReviewStatusItemReadDto> candidateReviewStatusItems;
     @JsonOneToMany(joinColumn = "candidate_id")
     private List<CandidateSkillReadDto> candidateSkills;
-    
+
     @SqlIgnore //TODO JC Doesnt seem to handle these
 //    @JsonOneToMany(joinColumn = "candidate_id")
     private List<CandidateVisaCheckReadDto> candidateVisaChecks;
     private String candidateNumber;
     private String city;
     private String conflict;
-    @SqlIgnore //todo Computed field
+    @SqlIgnore //todo Computed field - computed using contextSavedListId below
     private String contextNote;
+    @SqlIgnore //todo manually set before sending
+    private Long contextSavedListId;
     @JsonOneToOne(joinColumn = "country_id")
     private CountryReadDto country;
     private OffsetDateTime createdDate;
@@ -128,7 +130,7 @@ public class CandidateReadDto {
     private String muted;
     @JsonOneToOne(joinColumn = "nationality_id")
     private CountryReadDto nationality;
-    
+
     @SqlIgnore //todo Computed field
     private String numberDependants;
     private String partnerRef;
@@ -170,7 +172,7 @@ public class CandidateReadDto {
     @JsonOneToOne(joinColumn = "survey_type_id")
     private SurveyTypeReadDto surveyType;
     private String surveyComment;
-    
+
     @SqlIgnore //TODO JC Not done yet
 //    @JsonOneToMany(joinColumn = "candidate_id")
     private List<TaskAssignmentReadDto> taskAssignments;
@@ -181,10 +183,10 @@ public class CandidateReadDto {
     private String unrwaNumber;
     private String unrwaRegistered;
     private OffsetDateTime updatedDate;
-    
+
     @JsonOneToOne(joinColumn = "user_id")
     private UserReadDto user;
     private String videolink;
     private String whatsapp;
-    
+
 }

--- a/server/src/main/java/org/tctalent/server/repository/db/read/dto/CandidateReadDto.java
+++ b/server/src/main/java/org/tctalent/server/repository/db/read/dto/CandidateReadDto.java
@@ -79,7 +79,7 @@ public class CandidateReadDto {
     @JsonOneToMany(joinColumn = "candidate_id")
     private List<CandidateSkillReadDto> candidateSkills;
 
-    @SqlIgnore //TODO JC Doesnt seem to handle these
+    @SqlIgnore //TODO JC Doesnt seem to handle these - see issue 2950
 //    @JsonOneToMany(joinColumn = "candidate_id")
     private List<CandidateVisaCheckReadDto> candidateVisaChecks;
     private String candidateNumber;

--- a/server/src/main/java/org/tctalent/server/repository/db/read/dto/CandidateReadDto.java
+++ b/server/src/main/java/org/tctalent/server/repository/db/read/dto/CandidateReadDto.java
@@ -22,6 +22,7 @@ import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
+import org.tctalent.server.model.db.CandidateStatus;
 import org.tctalent.server.repository.db.read.annotation.JsonOneToMany;
 import org.tctalent.server.repository.db.read.annotation.JsonOneToOne;
 import org.tctalent.server.repository.db.read.annotation.SqlDefaults;
@@ -171,7 +172,7 @@ public class CandidateReadDto {
     private CandidateAttachmentReadDto shareableDoc;
     private String shareableNotes;
     private String state;
-    private String status;
+    private CandidateStatus status;
     @JsonOneToOne(joinColumn = "survey_type_id")
     private SurveyTypeReadDto surveyType;
     private String surveyComment;

--- a/server/src/main/java/org/tctalent/server/repository/db/read/dto/CandidateReadDto.java
+++ b/server/src/main/java/org/tctalent/server/repository/db/read/dto/CandidateReadDto.java
@@ -173,8 +173,7 @@ public class CandidateReadDto {
     private SurveyTypeReadDto surveyType;
     private String surveyComment;
 
-    @SqlIgnore //TODO JC Not done yet
-//    @JsonOneToMany(joinColumn = "candidate_id")
+    @JsonOneToMany(joinColumn = "candidate_id")
     private List<TaskAssignmentReadDto> taskAssignments;
     private String unhcrConsent;
     private String unhcrNumber;

--- a/server/src/main/java/org/tctalent/server/repository/db/read/dto/CandidateReadDto.java
+++ b/server/src/main/java/org/tctalent/server/repository/db/read/dto/CandidateReadDto.java
@@ -19,6 +19,7 @@ package org.tctalent.server.repository.db.read.dto;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.util.List;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import org.tctalent.server.repository.db.read.annotation.JsonOneToMany;
@@ -34,6 +35,7 @@ import org.tctalent.server.repository.db.read.annotation.SqlTable;
  */
 @Getter
 @Setter
+@Builder //Useful for constructing unit tests
 @SqlTable(name="candidate", alias = "c")
 @SqlDefaults(mapUnannotatedColumns = true)
 public class CandidateReadDto {

--- a/server/src/main/java/org/tctalent/server/repository/db/read/dto/CandidateReadDto.java
+++ b/server/src/main/java/org/tctalent/server/repository/db/read/dto/CandidateReadDto.java
@@ -85,10 +85,10 @@ public class CandidateReadDto {
     private String candidateNumber;
     private String city;
     private String conflict;
-    @SqlIgnore //todo Computed field - computed using contextSavedListId below
+
+    @SqlIgnore //Loaded later if there is a list context
     private String contextNote;
-    @SqlIgnore //todo manually set before sending
-    private Long contextSavedListId;
+
     @JsonOneToOne(joinColumn = "country_id")
     private CountryReadDto country;
     private OffsetDateTime createdDate;
@@ -116,10 +116,10 @@ public class CandidateReadDto {
     private String intRecruitReasons;
     private String intRecruitRural;
     private String linkedInLink;
-    @SqlIgnore //todo Computed field
-    private String listShareableCv;
-    @SqlIgnore //todo Computed field
-    private String listShareableDoc;
+    @SqlIgnore //todo Computed field based on list context
+    private CandidateAttachmentReadDto listShareableCv;
+    @SqlIgnore //todo Computed field based on list context
+    private CandidateAttachmentReadDto listShareableDoc;
     private String maritalStatus;
     @JsonOneToOne(joinColumn = "max_education_level_id")
     private EducationLevelReadDto maxEducationLevel;
@@ -131,11 +131,11 @@ public class CandidateReadDto {
     @JsonOneToOne(joinColumn = "nationality_id")
     private CountryReadDto nationality;
 
-    @SqlIgnore //todo Computed field
-    private String numberDependants;
+    @SqlIgnore //Computed field
+    private int numberDependants;
     private String partnerRef;
-    @SqlIgnore //todo Computed field
-    private String pendingTerms;
+    @SqlIgnore //Computed field
+    private boolean pendingTerms;
     private String phone;
     private String potentialDuplicate;
     private String publicId;
@@ -162,10 +162,11 @@ public class CandidateReadDto {
     @SqlIgnore
     private boolean selected;
     private String sflink;
-    @SqlIgnore //todo Computed field
-    private String shareableCv;
-    @SqlIgnore //todo Computed field
-    private String shareableDoc;
+
+    @JsonOneToOne(joinColumn = "shareable_cv_attachment_id")
+    private CandidateAttachmentReadDto shareableCv;
+    @JsonOneToOne(joinColumn = "shareable_doc_attachment_id")
+    private CandidateAttachmentReadDto shareableDoc;
     private String shareableNotes;
     private String state;
     private String status;

--- a/server/src/main/java/org/tctalent/server/repository/db/read/dto/CandidateReviewStatusItemReadDto.java
+++ b/server/src/main/java/org/tctalent/server/repository/db/read/dto/CandidateReviewStatusItemReadDto.java
@@ -18,6 +18,7 @@ package org.tctalent.server.repository.db.read.dto;
 
 import lombok.Getter;
 import lombok.Setter;
+import org.tctalent.server.model.db.ReviewStatus;
 import org.tctalent.server.repository.db.read.annotation.JsonOneToOne;
 import org.tctalent.server.repository.db.read.annotation.SqlDefaults;
 import org.tctalent.server.repository.db.read.annotation.SqlTable;
@@ -33,7 +34,7 @@ import org.tctalent.server.repository.db.read.annotation.SqlTable;
 @SqlDefaults(mapUnannotatedColumns = true)
 public class CandidateReviewStatusItemReadDto {
     private Long id;
-    private String reviewStatus;
+    private ReviewStatus reviewStatus;
     @JsonOneToOne(joinColumn = "saved_search_id")
     private SavedSearchReadDto savedSearch;
 }

--- a/server/src/main/java/org/tctalent/server/repository/db/read/dto/CountryReadDto.java
+++ b/server/src/main/java/org/tctalent/server/repository/db/read/dto/CountryReadDto.java
@@ -16,8 +16,10 @@
 
 package org.tctalent.server.repository.db.read.dto;
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
+import org.tctalent.server.model.db.Status;
 import org.tctalent.server.repository.db.read.annotation.SqlDefaults;
 import org.tctalent.server.repository.db.read.annotation.SqlTable;
 
@@ -28,11 +30,12 @@ import org.tctalent.server.repository.db.read.annotation.SqlTable;
  */
 @Getter
 @Setter
+@Builder //Useful for constructing unit tests
 @SqlTable(name="country", alias = "cou")
 @SqlDefaults(mapUnannotatedColumns = true)
 public class CountryReadDto {
     private Long id;
     private String isoCode;
     private String name;
-    private String status;
+    private Status status;
 }

--- a/server/src/main/java/org/tctalent/server/repository/db/read/dto/TaskAssignmentReadDto.java
+++ b/server/src/main/java/org/tctalent/server/repository/db/read/dto/TaskAssignmentReadDto.java
@@ -20,7 +20,6 @@ import java.time.OffsetDateTime;
 import lombok.Getter;
 import lombok.Setter;
 import org.tctalent.server.model.db.Status;
-import org.tctalent.server.model.db.task.TaskType;
 import org.tctalent.server.repository.db.read.annotation.JsonOneToOne;
 import org.tctalent.server.repository.db.read.annotation.SqlDefaults;
 import org.tctalent.server.repository.db.read.annotation.SqlIgnore;
@@ -43,5 +42,7 @@ public class TaskAssignmentReadDto {
 
     @JsonOneToOne(joinColumn = "task_id")
     private TaskReadDto task;
-    private TaskType taskType;
+
+    //TODO JC Can't map to TaskType because TaskType values don't match fields in db.
+    private String taskType;
 }

--- a/server/src/main/java/org/tctalent/server/repository/db/read/dto/TaskReadDto.java
+++ b/server/src/main/java/org/tctalent/server/repository/db/read/dto/TaskReadDto.java
@@ -20,7 +20,6 @@ import java.time.OffsetDateTime;
 import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
-import org.tctalent.server.model.db.task.TaskType;
 import org.tctalent.server.model.db.task.UploadType;
 import org.tctalent.server.repository.db.read.annotation.JsonOneToOne;
 import org.tctalent.server.repository.db.read.annotation.SqlColumn;
@@ -54,7 +53,9 @@ public class TaskReadDto {
     private Long id;
     private String name;
     private boolean optional;
-    private TaskType taskType;
+
+    //TODO JC Can't map to TaskType because TaskType values don't match fields in db.
+    private String taskType;
 
     @SqlColumn(transform = "to_jsonb(string_to_array(%s, ','))") //Convert csv string to jsonb array
     private List<String> uploadableFileTypes;

--- a/server/src/main/java/org/tctalent/server/repository/db/read/dto/TaskReadDto.java
+++ b/server/src/main/java/org/tctalent/server/repository/db/read/dto/TaskReadDto.java
@@ -17,31 +17,47 @@
 package org.tctalent.server.repository.db.read.dto;
 
 import java.time.OffsetDateTime;
+import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
-import org.tctalent.server.model.db.Status;
 import org.tctalent.server.model.db.task.TaskType;
+import org.tctalent.server.model.db.task.UploadType;
 import org.tctalent.server.repository.db.read.annotation.JsonOneToOne;
+import org.tctalent.server.repository.db.read.annotation.SqlColumn;
 import org.tctalent.server.repository.db.read.annotation.SqlDefaults;
 import org.tctalent.server.repository.db.read.annotation.SqlIgnore;
 import org.tctalent.server.repository.db.read.annotation.SqlTable;
 
 @Getter
 @Setter
-@SqlTable(name="task_assignment", alias = "ctaska")
+@SqlTable(name="task", alias = "ctask")
 @SqlDefaults(mapUnannotatedColumns = true)
-public class TaskAssignmentReadDto {
-    private OffsetDateTime abandonedDate;
+public class TaskReadDto {
+    @SqlIgnore  //This is manually populated (from explicitAllowedAnswers)
+    private List<AllowedQuestionTaskAnswerReadDto> allowedAnswers;
+    private String candidateAnswerField;
 
-    @SqlIgnore //Could be manually populated - but for now it is not being populated
-    private String answer;
-    private String candidateNotes;
-    private OffsetDateTime completedDate;
-    private OffsetDateTime dueDate;
+    @JsonOneToOne(joinColumn = "candidate_form_id")
+    private CandidateFormReadDto candidateForm;
+
+    @JsonOneToOne(joinColumn = "created_by")
+    private UserShortReadDto createdBy;
+    private OffsetDateTime createdDate;
+    private Integer daysToComplete;
+    private String description;
+    private String displayName;
+    private String docLink;
+
+    @SqlColumn(transform = "to_jsonb(string_to_array(%s, ','))") //Convert csv string to jsonb array
+    private List<String> explicitAllowedAnswers;
+
     private Long id;
-    private Status status;
-
-    @JsonOneToOne(joinColumn = "task_id")
-    private TaskReadDto task;
+    private String name;
+    private boolean optional;
     private TaskType taskType;
+
+    @SqlColumn(transform = "to_jsonb(string_to_array(%s, ','))") //Convert csv string to jsonb array
+    private List<String> uploadableFileTypes;
+    private String uploadSubfolderName;
+    private UploadType uploadType;
 }

--- a/server/src/main/java/org/tctalent/server/repository/db/read/dto/UserReadDto.java
+++ b/server/src/main/java/org/tctalent/server/repository/db/read/dto/UserReadDto.java
@@ -17,6 +17,7 @@
 package org.tctalent.server.repository.db.read.dto;
 
 import java.time.OffsetDateTime;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import org.tctalent.server.repository.db.read.annotation.JsonOneToOne;
@@ -30,6 +31,7 @@ import org.tctalent.server.repository.db.read.annotation.SqlTable;
  */
 @Getter
 @Setter
+@Builder //Useful for constructing unit tests
 @SqlTable(name="users", alias = "u")
 @SqlDefaults(mapUnannotatedColumns = true)
 public class UserReadDto {

--- a/server/src/main/java/org/tctalent/server/repository/db/read/dto/UserShortReadDto.java
+++ b/server/src/main/java/org/tctalent/server/repository/db/read/dto/UserShortReadDto.java
@@ -16,32 +16,17 @@
 
 package org.tctalent.server.repository.db.read.dto;
 
-import java.time.OffsetDateTime;
 import lombok.Getter;
 import lombok.Setter;
-import org.tctalent.server.model.db.Status;
-import org.tctalent.server.model.db.task.TaskType;
-import org.tctalent.server.repository.db.read.annotation.JsonOneToOne;
 import org.tctalent.server.repository.db.read.annotation.SqlDefaults;
-import org.tctalent.server.repository.db.read.annotation.SqlIgnore;
 import org.tctalent.server.repository.db.read.annotation.SqlTable;
 
 @Getter
 @Setter
-@SqlTable(name="task_assignment", alias = "ctaska")
+@SqlTable(name="users", alias = "ushort")
 @SqlDefaults(mapUnannotatedColumns = true)
-public class TaskAssignmentReadDto {
-    private OffsetDateTime abandonedDate;
-
-    @SqlIgnore //Could be manually populated - but for now it is not being populated
-    private String answer;
-    private String candidateNotes;
-    private OffsetDateTime completedDate;
-    private OffsetDateTime dueDate;
+public class UserShortReadDto {
+    private String firstName;
     private Long id;
-    private Status status;
-
-    @JsonOneToOne(joinColumn = "task_id")
-    private TaskReadDto task;
-    private TaskType taskType;
+    private String lastName;
 }

--- a/server/src/main/java/org/tctalent/server/repository/db/read/sql/SqlJsonQueryBuilder.java
+++ b/server/src/main/java/org/tctalent/server/repository/db/read/sql/SqlJsonQueryBuilder.java
@@ -41,27 +41,27 @@ import org.tctalent.server.repository.db.read.annotation.SqlTable;
  *     The result set consists of one row per candidate. Each row contains:
  *     <ul>
  *         <li>id (long) - candidate id</li>
- *         <li>json (string) - candidate data encoded as a JSON object</li>*         
+ *         <li>json (string) - candidate data encoded as a JSON object</li>*
  *     </ul>
  * </p>
  * <p>
  *     The SQL is automatically generated from the candidate related dtos.
- *     The root candidate DTO is 
+ *     The root candidate DTO is
  *     {@link org.tctalent.server.repository.db.read.dto.CandidateReadDto CandidateReadDto}.
  *     It relates to the {@link org.tctalent.server.model.db.Candidate Candidate} JPA entity.
  * </p>
  * <p>
- *     CandidateReadDTO is constructed from other DTOs corresponding to the other equivalent 
+ *     CandidateReadDTO is constructed from other DTOs corresponding to the other equivalent
  *     candidate related entities.
  * </p>
  * <p>
  *     Below is an example of what the generated SQL can look like. This is generated from a
  *     simplified CandidateReadDto in that a lot of standard fields have been removed.
  *     But it shows how nesting works - in that it encodes a Candidate, including its nested User,
- *     which in turn has a nested Partner.*     
+ *     which in turn has a nested Partner.*
  * </p>
  * <p>
- *     It also shows how it constructs the encoding of the 1-many job experiences associated with 
+ *     It also shows how it constructs the encoding of the 1-many job experiences associated with
  *     the candidate.
  * </p>
  * <pre>{@code
@@ -166,7 +166,7 @@ public class SqlJsonQueryBuilder {
         //to drive the SQL generation.
         SqlTable rootTable = requireSqlTable(rootDtoClass);
 
-        //This is the database table associated with the root DTO. 
+        //This is the database table associated with the root DTO.
         //For example, the Candidate table for the CandidateReadDTO. You will see this table
         //specified on the @SQLTable annotation on the CandidateReadDTO.
         String rootTableAlias = rootTable.alias();
@@ -178,7 +178,7 @@ public class SqlJsonQueryBuilder {
         String jsonExpr = buildJsonExpression(rootDtoClass, rootTableAlias, ctx);
 
         //The SQL is just a select where id matches one of the ids passed in.
-        //There is a row for each id. Each row just has two fields: the id and the JSON encoded data. 
+        //There is a row for each id. Each row just has two fields: the id and the JSON encoded data.
         //The json string field encodes a single object encoding an instance of the rootDtoClass.
         return """
             select
@@ -319,7 +319,16 @@ public class SqlJsonQueryBuilder {
                     ? camelToSnakeCase(field.getName())
                     : sqlColumn.name();
 
-                pairs.add(new Pair(field.getName(), tableAlias + "." + columnName));
+                String columnRef = tableAlias + "." + columnName;
+
+                String valueExpr = applyTransformIfPresent(
+                    dtoType,
+                    field,
+                    columnRef,
+                    sqlColumn.transform()
+                );
+
+                pairs.add(new Pair(field.getName(), valueExpr));
                 continue;
             }
 
@@ -636,7 +645,7 @@ public class SqlJsonQueryBuilder {
         SqlDefaults d = dtoType.getAnnotation(SqlDefaults.class);
         return d != null && d.mapUnannotatedColumns();
     }
-    
+
     /**
      * <p>
      * Maintains SQL alias uniqueness during recursive SQL generation.
@@ -684,6 +693,53 @@ public class SqlJsonQueryBuilder {
             aliasCounts.put(baseAlias, next);
             return baseAlias + next;
         }
+    }
+
+    /**
+     * <p>
+     * Applies an optional {@code @SqlColumn.transform} to a resolved column reference.
+     * </p>
+     *
+     * <p>
+     * The transform must contain exactly one {@code %s}, which will be replaced
+     * with the fully-qualified column reference.
+     * </p>
+     *
+     * @param dtoType DTO containing the field
+     * @param field DTO field being mapped
+     * @param columnRef fully-qualified column reference (e.g. {@code c.skills_csv})
+     * @param transform transform template from {@code @SqlColumn.transform}
+     * @return SQL expression for the field value
+     */
+    private String applyTransformIfPresent(
+        Class<?> dtoType,
+        Field field,
+        String columnRef,
+        String transform
+    ) {
+        if (transform == null || transform.isBlank()) {
+            return columnRef;
+        }
+
+        int placeholders = countOccurrences(transform, "%s");
+        if (placeholders != 1) {
+            throw new IllegalStateException(
+                "Invalid @SqlColumn.transform on " + dtoType.getSimpleName() + "." + field.getName()
+                    + " - transform must contain exactly one %s placeholder. Found: " + placeholders
+            );
+        }
+
+        return String.format(transform, columnRef);
+    }
+
+    private int countOccurrences(String s, String token) {
+        int count = 0;
+        int idx = 0;
+        while ((idx = s.indexOf(token, idx)) >= 0) {
+            count++;
+            idx += token.length();
+        }
+        return count;
     }
 
     private static final class Pair {

--- a/server/src/main/java/org/tctalent/server/service/db/CandidateDtoFetchService.java
+++ b/server/src/main/java/org/tctalent/server/service/db/CandidateDtoFetchService.java
@@ -26,7 +26,10 @@ import org.tctalent.server.exception.NoSuchObjectException;
 import org.tctalent.server.repository.db.read.dto.CandidateReadDto;
 
 /**
- * Service interface for managing Candidate DTOs.
+ * Service interface for fetching Candidate DTOs from the database.
+ * <p>
+ *     Supports caching of CandidateDTOs.
+ * </p>
  * <p>
  *     CandidateDTOs are different to Candidate entities in that they are intended to be
  *     used as read-only objects. They can be changed but there will be no side effects,
@@ -36,7 +39,7 @@ import org.tctalent.server.repository.db.read.dto.CandidateReadDto;
  *
  * @author John Cameron
  */
-public interface CandidateDtoService {
+public interface CandidateDtoFetchService {
 
     /**
      * Fetches a page of Candidate DTOs from the database by executing the given SQL queries.
@@ -46,11 +49,11 @@ public interface CandidateDtoService {
      * @param pageRequest Page request specifying the page number and page size and sort (if any).
      * @return Page of Candidate DTOs
      */
-    Page<CandidateReadDto> doFetchCandidateDtos(
+    Page<CandidateReadDto> fetchPage(
         String fetchIdsSql, String countSql, @NonNull PageRequest pageRequest);
 
     /**
-     * Loads Candidate DTOs into a Map of ids to CandidateReadDto objects
+     * Fetches Candidate DTOs into a Map of ids to CandidateReadDto objects
      * for the given candidate IDs.
      *
      * @param ids Ids of candidates to be fetched
@@ -59,7 +62,7 @@ public interface CandidateDtoService {
      * @throws NoSuchObjectException if any of the ids are bad - ie do not correspond a candidate.
      */
     @NonNull
-    Map<Long, CandidateReadDto> loadByIds(Collection<Long> ids)
+    Map<Long, CandidateReadDto> fetchByIds(Collection<Long> ids)
         throws NoSuchObjectException, JsonProcessingException;
 
 }

--- a/server/src/main/java/org/tctalent/server/service/db/CandidateDtoFetchService.java
+++ b/server/src/main/java/org/tctalent/server/service/db/CandidateDtoFetchService.java
@@ -16,7 +16,6 @@
 
 package org.tctalent.server.service.db;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import java.util.Collection;
 import java.util.Map;
 import org.springframework.data.domain.Page;
@@ -58,11 +57,9 @@ public interface CandidateDtoFetchService {
      *
      * @param ids Ids of candidates to be fetched
      * @return Map of candidate ids to CandidateDTOs
-     * @throws JsonProcessingException if JSON cannot be processed
      * @throws NoSuchObjectException if any of the ids are bad - ie do not correspond a candidate.
      */
     @NonNull
-    Map<Long, CandidateReadDto> fetchByIds(Collection<Long> ids)
-        throws NoSuchObjectException, JsonProcessingException;
+    Map<Long, CandidateReadDto> fetchByIds(Collection<Long> ids) throws NoSuchObjectException;
 
 }

--- a/server/src/main/java/org/tctalent/server/service/db/CandidateDtoService.java
+++ b/server/src/main/java/org/tctalent/server/service/db/CandidateDtoService.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2025 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.service.db;
+
+import org.springframework.lang.Nullable;
+import org.tctalent.server.repository.db.read.dto.CandidateReadDto;
+
+/**
+ * Service interface for processing Candidate DTOs.
+ * <p>
+ *     CandidateDTOs are different to Candidate entities in that they are intended to be
+ *     used as read-only objects. They can be changed but there will be no side effects,
+ *     unlike Candidate entities where changes typically generate SQL requests to update the
+ *     associated database.
+ * </p>
+ *
+ * @author John Cameron
+ */
+public interface CandidateDtoService {
+
+
+    /**
+     * Populates computed fields on the given candidates.
+     * @param candidates Candidates to be updated
+     * @param savedListId Optional id of a saved list serving as the "context" for
+     *                    candidates in that list.
+     *                    Some populated fields - such as "context notes" are populated
+     *                    in the context of a saved list. Candidates who appear in this savedList
+     *                    will have their "context" fields populated.
+     */
+    void populateComputedFields(Iterable<CandidateReadDto> candidates, @Nullable Long savedListId);
+}

--- a/server/src/main/java/org/tctalent/server/service/db/CandidateDtoService.java
+++ b/server/src/main/java/org/tctalent/server/service/db/CandidateDtoService.java
@@ -19,6 +19,8 @@ package org.tctalent.server.service.db;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.util.Collection;
 import java.util.Map;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.lang.NonNull;
 import org.tctalent.server.exception.NoSuchObjectException;
 import org.tctalent.server.repository.db.read.dto.CandidateReadDto;
@@ -37,16 +39,27 @@ import org.tctalent.server.repository.db.read.dto.CandidateReadDto;
 public interface CandidateDtoService {
 
     /**
-     * Loads Candidate DTOs into a Map of ids to CandidateReadDto objects 
+     * Fetches a page of Candidate DTOs from the database by executing the given SQL queries.
+     * @param fetchIdsSql Sql which just returns the ids (and possible ranks) of the candidates
+     *                    to be fetched
+     * @param countSql Sql which returns the total number of candidates matching the query
+     * @param pageRequest Page request specifying the page number and page size and sort (if any).
+     * @return Page of Candidate DTOs
+     */
+    Page<CandidateReadDto> doFetchCandidateDtos(
+        String fetchIdsSql, String countSql, @NonNull PageRequest pageRequest);
+
+    /**
+     * Loads Candidate DTOs into a Map of ids to CandidateReadDto objects
      * for the given candidate IDs.
-     *  
+     *
      * @param ids Ids of candidates to be fetched
      * @return Map of candidate ids to CandidateDTOs
      * @throws JsonProcessingException if JSON cannot be processed
      * @throws NoSuchObjectException if any of the ids are bad - ie do not correspond a candidate.
      */
     @NonNull
-    Map<Long, CandidateReadDto> loadByIds(Collection<Long> ids) 
+    Map<Long, CandidateReadDto> loadByIds(Collection<Long> ids)
         throws NoSuchObjectException, JsonProcessingException;
 
 }

--- a/server/src/main/java/org/tctalent/server/service/db/CandidateSavedListService.java
+++ b/server/src/main/java/org/tctalent/server/service/db/CandidateSavedListService.java
@@ -16,12 +16,16 @@
 
 package org.tctalent.server.service.db;
 
+import java.util.Map;
+import java.util.Set;
+import org.springframework.lang.NonNull;
 import org.tctalent.server.exception.EntityExistsException;
 import org.tctalent.server.exception.InvalidRequestException;
 import org.tctalent.server.exception.NoSuchObjectException;
 import org.tctalent.server.exception.UnauthorisedActionException;
 import org.tctalent.server.model.db.Candidate;
 import org.tctalent.server.model.db.CandidateAttachment;
+import org.tctalent.server.model.db.CandidateSavedList;
 import org.tctalent.server.model.db.SavedList;
 import org.tctalent.server.request.candidate.IHasSetOfSavedLists;
 import org.tctalent.server.request.candidate.UpdateCandidateContextNoteRequest;
@@ -122,6 +126,21 @@ public interface CandidateSavedListService {
      * @throws InvalidRequestException if not authorized to delete this list.
      */
     boolean deleteSavedList(long savedListId) throws InvalidRequestException;
+
+    /**
+     * Finds all CandidateSavedList records for the given candidate ids in the give saved list.
+     * <p>
+     *     Every candidate in a saved list has a CandidateSavedList record.
+     *     If a candidate id is not in the given list, it will not be returned in the results.
+     *     So, effectively this method returns an entry in the map for every candidate id that is in
+     *     the list.
+     * </p>
+     * @param ids Candidate ids that we are looking for in the list.
+     * @param savedListId Id of a saved list
+     * @return Map of candidate id to CandidateSavedList record.
+     */
+    @NonNull
+    Map<Long, CandidateSavedList> findByCandidateIds(Set<Long> ids, long savedListId);
 
     /**
      * Merge the saved lists indicated in the request into the given candidate's

--- a/server/src/main/java/org/tctalent/server/service/db/CandidateSavedListService.java
+++ b/server/src/main/java/org/tctalent/server/service/db/CandidateSavedListService.java
@@ -31,10 +31,13 @@ import org.tctalent.server.request.list.UpdateExplicitSavedListContentsRequest;
 
 /**
  * Handle anything to do with deletion of candidate savedList relationships.
- * <p/>
+ * <p>
  * Relying on Cascading from SavedList or Candidate candidateSavedList
  * collections doesn't work.
+ * </p>
+ * <p>
  * See doc on SavedList and Candidate where candidateSavedList is declared
+ * </p>
  */
 public interface CandidateSavedListService {
 

--- a/server/src/main/java/org/tctalent/server/service/db/CandidateService.java
+++ b/server/src/main/java/org/tctalent/server/service/db/CandidateService.java
@@ -159,14 +159,6 @@ public interface CandidateService {
 
     Candidate getCandidate(long id) throws NoSuchObjectException;
 
-    /**
-     * Sets the transient answer field on Question Task Assignments, these come from various places either the candidate
-     * property table (stored as task name and answer values) or it's stored in a field on the candidate object.
-     * This method allows us to pass in the page of candidates from a search/list of candidates and then populate the fields.
-     * @param candidates: page of candidates from a search paged method (saved search or saved list)
-     */
-    void populateCandidatesTransientTaskAssignments(Page<Candidate> candidates);
-
     Candidate updateCandidateAdditionalInfo(long id, UpdateCandidateAdditionalInfoRequest request);
 
     Candidate updateShareableNotes(long id, UpdateCandidateShareableNotesRequest request);

--- a/server/src/main/java/org/tctalent/server/service/db/CandidateService.java
+++ b/server/src/main/java/org/tctalent/server/service/db/CandidateService.java
@@ -49,6 +49,7 @@ import org.tctalent.server.model.db.SavedList;
 import org.tctalent.server.model.db.partner.Partner;
 import org.tctalent.server.model.db.task.QuestionTaskAssignment;
 import org.tctalent.server.repository.db.CandidateRepository;
+import org.tctalent.server.repository.db.read.dto.CandidateReadDto;
 import org.tctalent.server.request.LoginRequest;
 import org.tctalent.server.request.RegisterCandidateByPartnerRequest;
 import org.tctalent.server.request.candidate.CandidateEmailPhoneOrWhatsappSearchRequest;
@@ -154,6 +155,8 @@ public interface CandidateService {
     Set<Long> searchCandidatesUsingSql(String sql) throws PersistenceException;
 
     Page<Candidate> getSavedListCandidates(SavedList savedList, SavedListGetRequest request);
+    
+    Page<CandidateReadDto> getSavedListCandidateDtos(SavedList savedList, SavedListGetRequest request);
 
     List<Candidate> getSavedListCandidatesUnpaged(SavedList savedList, SavedListGetRequest request);
 

--- a/server/src/main/java/org/tctalent/server/service/db/CandidateService.java
+++ b/server/src/main/java/org/tctalent/server/service/db/CandidateService.java
@@ -49,7 +49,6 @@ import org.tctalent.server.model.db.SavedList;
 import org.tctalent.server.model.db.partner.Partner;
 import org.tctalent.server.model.db.task.QuestionTaskAssignment;
 import org.tctalent.server.repository.db.CandidateRepository;
-import org.tctalent.server.repository.db.read.dto.CandidateReadDto;
 import org.tctalent.server.request.LoginRequest;
 import org.tctalent.server.request.RegisterCandidateByPartnerRequest;
 import org.tctalent.server.request.candidate.CandidateEmailPhoneOrWhatsappSearchRequest;
@@ -155,8 +154,6 @@ public interface CandidateService {
     Set<Long> searchCandidatesUsingSql(String sql) throws PersistenceException;
 
     Page<Candidate> getSavedListCandidates(SavedList savedList, SavedListGetRequest request);
-    
-    Page<CandidateReadDto> getSavedListCandidateDtos(SavedList savedList, SavedListGetRequest request);
 
     List<Candidate> getSavedListCandidatesUnpaged(SavedList savedList, SavedListGetRequest request);
 

--- a/server/src/main/java/org/tctalent/server/service/db/SavedListService.java
+++ b/server/src/main/java/org/tctalent/server/service/db/SavedListService.java
@@ -386,11 +386,6 @@ public interface SavedListService {
      */
     void setCandidateContext(long savedListId, Iterable<Candidate> candidates);
 
-    /**
-     * Candidate dto version of {@link #setCandidateContext(long, Iterable)}.
-     */
-    void setCandidateDtoContext(long savedListId, Iterable<CandidateReadDto> candidates);
-
     void setPublicIds(List<SavedList> savedLists);
 
     /**

--- a/server/src/main/java/org/tctalent/server/service/db/SavedListService.java
+++ b/server/src/main/java/org/tctalent/server/service/db/SavedListService.java
@@ -369,8 +369,9 @@ public interface SavedListService {
      * list will be returned through {@link Candidate#getContextNote()}
      * @param savedListId ID of saved list
      * @param candidates Candidate objects to be marked with the list context. Note that this
-     *                   is a transient property only found on the given objects (ie it is not
-     *                   stored in the database).
+     *                   is a transient property on the candidate objects because it depends on
+     *                   the list context. It does not come from the Candidate table, it comes
+     *                   from the CandidateSavedList table, depending on the particular list. 
      */
     void setCandidateContext(long savedListId, Iterable<Candidate> candidates);
 

--- a/server/src/main/java/org/tctalent/server/service/db/SavedListService.java
+++ b/server/src/main/java/org/tctalent/server/service/db/SavedListService.java
@@ -290,7 +290,12 @@ public interface SavedListService {
     @Nullable
     SavedList get(@NonNull User user, String listName);
 
-    //TODO JC Doc
+    /**
+     * Fetches candidate dtos from the given list according the given request.
+     * @param savedList Saved List whose candidates are to be fetched
+     * @param request Defines which candidates to fetch (if not all)
+     * @return Candidate dtos.
+     */
     Page<CandidateReadDto> getSavedListCandidateDtos(
         @NonNull SavedList savedList, SavedListGetRequest request);
 
@@ -381,7 +386,9 @@ public interface SavedListService {
      */
     void setCandidateContext(long savedListId, Iterable<Candidate> candidates);
 
-    //TODO JC Doc
+    /**
+     * Candidate dto version of {@link #setCandidateContext(long, Iterable)}.
+     */
     void setCandidateDtoContext(long savedListId, Iterable<CandidateReadDto> candidates);
 
     void setPublicIds(List<SavedList> savedLists);

--- a/server/src/main/java/org/tctalent/server/service/db/SavedListService.java
+++ b/server/src/main/java/org/tctalent/server/service/db/SavedListService.java
@@ -34,9 +34,11 @@ import org.tctalent.server.model.db.SalesforceJobOpp;
 import org.tctalent.server.model.db.SavedList;
 import org.tctalent.server.model.db.TaskImpl;
 import org.tctalent.server.model.db.User;
+import org.tctalent.server.repository.db.read.dto.CandidateReadDto;
 import org.tctalent.server.request.IdsRequest;
 import org.tctalent.server.request.candidate.PublishListRequest;
 import org.tctalent.server.request.candidate.PublishedDocImportReport;
+import org.tctalent.server.request.candidate.SavedListGetRequest;
 import org.tctalent.server.request.candidate.UpdateCandidateListOppsRequest;
 import org.tctalent.server.request.candidate.UpdateDisplayedFieldPathsRequest;
 import org.tctalent.server.request.candidate.source.UpdateCandidateSourceDescriptionRequest;
@@ -288,6 +290,10 @@ public interface SavedListService {
     @Nullable
     SavedList get(@NonNull User user, String listName);
 
+    //TODO JC Doc
+    Page<CandidateReadDto> getSavedListCandidateDtos(
+        @NonNull SavedList savedList, SavedListGetRequest request);
+
     /**
      * Returns true if there are no candidates in the list
      * @param id ID of list
@@ -371,9 +377,12 @@ public interface SavedListService {
      * @param candidates Candidate objects to be marked with the list context. Note that this
      *                   is a transient property on the candidate objects because it depends on
      *                   the list context. It does not come from the Candidate table, it comes
-     *                   from the CandidateSavedList table, depending on the particular list. 
+     *                   from the CandidateSavedList table, depending on the particular list.
      */
     void setCandidateContext(long savedListId, Iterable<Candidate> candidates);
+
+    //TODO JC Doc
+    void setCandidateDtoContext(long savedListId, Iterable<CandidateReadDto> candidates);
 
     void setPublicIds(List<SavedList> savedLists);
 

--- a/server/src/main/java/org/tctalent/server/service/db/SavedSearchService.java
+++ b/server/src/main/java/org/tctalent/server/service/db/SavedSearchService.java
@@ -114,6 +114,16 @@ public interface SavedSearchService {
         throws NoSuchObjectException;
 
     /**
+     * Returns the requested page of candidates of the given saved search.
+     * @param savedSearchId ID of saved search
+     * @param request Request specifying which page of candidates to return
+     * @return Page of candidates
+     * @throws NoSuchObjectException if no saved search exists with given id.
+     */
+    Page<CandidateReadDto> searchCandidateDtos(
+        long savedSearchId, SavedSearchGetRequest request) throws NoSuchObjectException;
+
+    /**
      * Returns a set of the ids of all candidates matching the given saved search.
      * <p/>
      * WARNING: This method clears the JPA persistence context by calling entityManager.clear().
@@ -131,7 +141,7 @@ public interface SavedSearchService {
 
     SearchCandidateRequest loadSavedSearch(long id);
 
-    SavedSearch getSavedSearch(long id);
+    SavedSearch getSavedSearch(long id) throws NoSuchObjectException;
 
     /**
      * Clears the given user's selections for the given saved search.

--- a/server/src/main/java/org/tctalent/server/service/db/TaskAssignmentService.java
+++ b/server/src/main/java/org/tctalent/server/service/db/TaskAssignmentService.java
@@ -16,22 +16,21 @@
 
 package org.tctalent.server.service.db;
 
+import java.io.IOException;
+import java.time.LocalDate;
+import java.util.List;
 import org.springframework.lang.NonNull;
 import org.springframework.lang.Nullable;
 import org.springframework.web.multipart.MultipartFile;
 import org.tctalent.server.exception.NoSuchObjectException;
-import org.tctalent.server.model.db.Status;
-import org.tctalent.server.model.db.task.TaskAssignment;
-import org.tctalent.server.request.task.TaskListRequest;
-
-import java.io.IOException;
-import java.time.LocalDate;
-import java.util.List;
 import org.tctalent.server.model.db.Candidate;
 import org.tctalent.server.model.db.SavedList;
+import org.tctalent.server.model.db.Status;
 import org.tctalent.server.model.db.TaskAssignmentImpl;
 import org.tctalent.server.model.db.TaskImpl;
 import org.tctalent.server.model.db.User;
+import org.tctalent.server.model.db.task.TaskAssignment;
+import org.tctalent.server.request.task.TaskListRequest;
 
 /**
  * Service for managing {@link TaskAssignment}s.
@@ -165,4 +164,11 @@ public interface TaskAssignmentService {
      */
     List<TaskAssignmentImpl> findByTaskIdAndCandidateIdAndStatus(Long taskId, Long candidateId, Status status);
 
+    /**
+     * Sets the transient answer field on Question Task Assignments, these come from various places
+     * either the candidate property table (stored as task name and answer values)
+     * or it's stored in a field on the candidate object.
+     * @param taskAssignments task assignment whose transients we want to populate
+     */
+    void populateTransientTaskAssignmentFields(List<TaskAssignmentImpl> taskAssignments);
 }

--- a/server/src/main/java/org/tctalent/server/service/db/impl/CandidateDtoFetchServiceImpl.java
+++ b/server/src/main/java/org/tctalent/server/service/db/impl/CandidateDtoFetchServiceImpl.java
@@ -41,7 +41,7 @@ import org.tctalent.server.repository.db.read.cache.CandidateRedisCache;
 import org.tctalent.server.repository.db.read.cache.CandidateVersionDao;
 import org.tctalent.server.repository.db.read.dto.CandidateReadDto;
 import org.tctalent.server.repository.db.read.sql.CandidateJsonDao;
-import org.tctalent.server.service.db.CandidateDtoService;
+import org.tctalent.server.service.db.CandidateDtoFetchService;
 import org.tctalent.server.util.CandidateSearchUtils;
 import org.tctalent.server.util.textExtract.IdAndRank;
 
@@ -67,7 +67,7 @@ import org.tctalent.server.util.textExtract.IdAndRank;
 @Service
 @RequiredArgsConstructor
 @Slf4j
-public class CandidateDtoServiceImpl implements CandidateDtoService {
+public class CandidateDtoFetchServiceImpl implements CandidateDtoFetchService {
     @PersistenceContext
     private EntityManager entityManager;
     private final CandidateJsonDao jsonDao;
@@ -77,7 +77,7 @@ public class CandidateDtoServiceImpl implements CandidateDtoService {
     private final CandidateVersionDao versionDao;
 
     @Override
-    public Page<CandidateReadDto> doFetchCandidateDtos(
+    public Page<CandidateReadDto> fetchPage(
         String fetchIdsSql, String countSql, @NonNull PageRequest pageRequest) {
         //Create and execute the query to return the candidate ids
         Query query = entityManager.createNativeQuery(fetchIdsSql);
@@ -114,7 +114,7 @@ public class CandidateDtoServiceImpl implements CandidateDtoService {
 
         Map<Long, CandidateReadDto> candidatesByIdUnsorted;
         try {
-            candidatesByIdUnsorted = loadByIds(ids);
+            candidatesByIdUnsorted = fetchByIds(ids);
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
         }
@@ -165,7 +165,7 @@ public class CandidateDtoServiceImpl implements CandidateDtoService {
 
     @Override
     @NonNull
-    public Map<Long, CandidateReadDto> loadByIds(Collection<Long> ids)
+    public Map<Long, CandidateReadDto> fetchByIds(Collection<Long> ids)
         throws NoSuchObjectException, JsonProcessingException {
 
         if (ids == null || ids.isEmpty()) {

--- a/server/src/main/java/org/tctalent/server/service/db/impl/CandidateDtoFetchServiceImpl.java
+++ b/server/src/main/java/org/tctalent/server/service/db/impl/CandidateDtoFetchServiceImpl.java
@@ -113,11 +113,7 @@ public class CandidateDtoFetchServiceImpl implements CandidateDtoFetchService {
         start = end;
 
         Map<Long, CandidateReadDto> candidatesByIdUnsorted;
-        try {
-            candidatesByIdUnsorted = fetchByIds(ids);
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
-        }
+        candidatesByIdUnsorted = fetchByIds(ids);
 
         end = System.currentTimeMillis();
         long fetchDtosTime = end - start;
@@ -166,7 +162,7 @@ public class CandidateDtoFetchServiceImpl implements CandidateDtoFetchService {
     @Override
     @NonNull
     public Map<Long, CandidateReadDto> fetchByIds(Collection<Long> ids)
-        throws NoSuchObjectException, JsonProcessingException {
+        throws NoSuchObjectException {
 
         if (ids == null || ids.isEmpty()) {
             return Map.of();
@@ -321,7 +317,11 @@ public class CandidateDtoFetchServiceImpl implements CandidateDtoFetchService {
 
         Map<Long, CandidateReadDto> out = new HashMap<>(jsonById.size());
         for (Map.Entry<Long, String> e : jsonById.entrySet()) {
-            out.put(e.getKey(), deserialize(e.getValue()));
+            try {
+                out.put(e.getKey(), deserialize(e.getValue()));
+            } catch (JsonProcessingException ex) {
+                throw new RuntimeException(ex);
+            }
         }
         return out;
     }

--- a/server/src/main/java/org/tctalent/server/service/db/impl/CandidateDtoServiceImpl.java
+++ b/server/src/main/java/org/tctalent/server/service/db/impl/CandidateDtoServiceImpl.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2026 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.service.db.impl;
+
+import static org.tctalent.server.configuration.SystemAdminConfiguration.PENDING_TERMS_ACCEPTANCE_LIST_ID;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Service;
+import org.tctalent.server.model.db.CandidateAttachment;
+import org.tctalent.server.model.db.CandidateSavedList;
+import org.tctalent.server.model.db.mapper.CandidateAttachmentMapper;
+import org.tctalent.server.repository.db.read.dto.CandidateAttachmentReadDto;
+import org.tctalent.server.repository.db.read.dto.CandidateDependantReadDto;
+import org.tctalent.server.repository.db.read.dto.CandidateReadDto;
+import org.tctalent.server.service.db.CandidateDtoService;
+import org.tctalent.server.service.db.CandidateSavedListService;
+import org.tctalent.server.service.db.SavedListService;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CandidateDtoServiceImpl implements CandidateDtoService {
+    private final CandidateSavedListService candidateSavedListService;
+    private final SavedListService savedListService;
+    private final CandidateAttachmentMapper attachmentMapper;
+
+    public void populateComputedFields(
+        Iterable<CandidateReadDto> candidates, @Nullable Long savedListId) {
+
+        //Get all CandidateSavedList objects in a single db access.
+        Set<Long> ids = new HashSet<>();
+        for (CandidateReadDto candidate : candidates) {
+            ids.add(candidate.getId());
+        }
+        Map<Long, CandidateSavedList> listContexts = savedListId == null ? Map.of() :
+            candidateSavedListService.findByCandidateIds(ids, savedListId);
+
+        //Load all candidates in the pending terms list
+        Set<Long> pendingTermsIds = savedListService.fetchCandidateIds(PENDING_TERMS_ACCEPTANCE_LIST_ID);
+
+        //Populate the computed fields
+        for (CandidateReadDto candidate : candidates) {
+            //Retrieve list context for this candidate
+            CandidateSavedList listContext = listContexts.get(candidate.getId());
+
+            //If the candidate is in the list then we need to retrieve the list dependant context.
+            if (listContext != null) {
+                //Set any context note
+                candidate.setContextNote(listContext.getContextNote());
+
+                //Need to retrieve the list dependent attachments if they exist
+                candidate.setListShareableCv(createDto(listContext.getShareableCv()));
+                candidate.setListShareableDoc(createDto(listContext.getShareableDoc()));
+            }
+
+            //Check whether the candidate is in the pending terms list
+            candidate.setPendingTerms(pendingTermsIds.contains(candidate.getId()));
+
+            //Compute the number of dependants
+            final List<CandidateDependantReadDto> dependants = candidate.getCandidateDependants();
+            candidate.setNumberDependants(dependants == null ? 0 : dependants.size());
+        }
+    }
+
+    @Nullable
+    private CandidateAttachmentReadDto createDto(@Nullable CandidateAttachment attachment) {
+        //TODO JC Will this copy the createdBy user?
+        return attachment == null ? null : attachmentMapper.toDto(attachment);
+    }
+}

--- a/server/src/main/java/org/tctalent/server/service/db/impl/CandidateDtoServiceImpl.java
+++ b/server/src/main/java/org/tctalent/server/service/db/impl/CandidateDtoServiceImpl.java
@@ -18,6 +18,9 @@ package org.tctalent.server.service.db.impl;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.Query;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -25,6 +28,9 @@ import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Service;
 import org.tctalent.server.exception.NoSuchObjectException;
@@ -36,12 +42,14 @@ import org.tctalent.server.repository.db.read.cache.CandidateVersionDao;
 import org.tctalent.server.repository.db.read.dto.CandidateReadDto;
 import org.tctalent.server.repository.db.read.sql.CandidateJsonDao;
 import org.tctalent.server.service.db.CandidateDtoService;
+import org.tctalent.server.util.CandidateSearchUtils;
+import org.tctalent.server.util.textExtract.IdAndRank;
 
 /**
  * Strict read service for CandidateReadDto.
  * <p>
  * Architecture:
- *   L1: Redis (shared, versioned keys)  //Todo 
+ *   L1: Redis (shared, versioned keys)
  *   L2: Postgres JSON cache (candidate_json_cache)
  *   L3: Postgres recomputation (SqlJsonQueryBuilder)
  * </p>
@@ -60,15 +68,104 @@ import org.tctalent.server.service.db.CandidateDtoService;
 @RequiredArgsConstructor
 @Slf4j
 public class CandidateDtoServiceImpl implements CandidateDtoService {
-    private final CandidateRedisCache redisCache;
-    private final CandidateVersionDao versionDao;
-    private final CandidateJsonCacheDao pgCacheDao;
+    @PersistenceContext
+    private EntityManager entityManager;
     private final CandidateJsonDao jsonDao;
     private final ObjectMapper objectMapper;
+    private final CandidateJsonCacheDao pgCacheDao;
+    private final CandidateRedisCache redisCache;
+    private final CandidateVersionDao versionDao;
+
+    @Override
+    public Page<CandidateReadDto> doFetchCandidateDtos(
+        String fetchIdsSql, String countSql, @NonNull PageRequest pageRequest) {
+        //Create and execute the query to return the candidate ids
+        Query query = entityManager.createNativeQuery(fetchIdsSql);
+        query.setFirstResult((int) pageRequest.getOffset());
+        query.setMaxResults(pageRequest.getPageSize());
+
+        LogBuilder.builder(log).action("findCandidates")
+            .message("Query: " + fetchIdsSql).logInfo();
+        long start = System.currentTimeMillis();
+        long end;
+
+        //Get results
+        final List<?> results = query.getResultList();
+
+        end = System.currentTimeMillis();
+        long fetchIdsTime = end - start;
+
+        start = end;
+
+        //Process the results
+        List<IdAndRank> idAndRanks =
+            CandidateSearchUtils.processIdRankSearchResults(results, pageRequest.getSort());
+
+        end = System.currentTimeMillis();
+        long convertTime = end - start;
+        start = end;
+
+        //Get ids of sorted candidates
+        List<Long> ids = idAndRanks.stream().map(IdAndRank::id).toList();
+
+        end = System.currentTimeMillis();
+        long fetchEntitiesTime = end - start;
+        start = end;
+
+        Map<Long, CandidateReadDto> candidatesByIdUnsorted;
+        try {
+            candidatesByIdUnsorted = loadByIds(ids);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+
+        end = System.currentTimeMillis();
+        long fetchDtosTime = end - start;
+        start = end;
+
+        //Candidates need to be sorted the same as the ids.
+
+        //Construct a sorted list of the candidates in the same order as the returned ids.
+        List<CandidateReadDto> candidatesSorted = new ArrayList<>();
+        for (IdAndRank idAndRank : idAndRanks) {
+            final CandidateReadDto candidate = candidatesByIdUnsorted.get(idAndRank.id());
+
+            //Optionally update candidate data with any ranking values.
+            final Number rank = idAndRank.rank();
+            //Rank is a transient field so no need to set to null
+            if (rank != null) {
+                candidate.setRank(rank);
+            }
+            candidatesSorted.add(candidate);
+        }
+
+        end = System.currentTimeMillis();
+        long sortTime = end - start;
+
+        LogBuilder.builder(log).action("countCandidates")
+            .message("Query: " + countSql).logInfo();
+        start = end;
+        //Compute count
+        long total =  ((Number) entityManager.createNativeQuery(countSql).getSingleResult()).longValue();
+
+        end = System.currentTimeMillis();
+        long countTime = end - start;
+
+        LogBuilder.builder(log).action("findCandidates")
+            .message("Timings: fetchIds: " + fetchIdsTime
+                + " convert: " + convertTime
+                + " fetchEntities: " + fetchEntitiesTime
+                + " fetchDtos: " + fetchDtosTime
+                + " sort: " + sortTime
+                + " count: " + countTime
+            ).logInfo();
+
+        return new PageImpl<>(candidatesSorted, pageRequest, total);
+    }
 
     @Override
     @NonNull
-    public Map<Long, CandidateReadDto> loadByIds(Collection<Long> ids) 
+    public Map<Long, CandidateReadDto> loadByIds(Collection<Long> ids)
         throws NoSuchObjectException, JsonProcessingException {
 
         if (ids == null || ids.isEmpty()) {
@@ -90,7 +187,7 @@ public class CandidateDtoServiceImpl implements CandidateDtoService {
         if (!badIds.isEmpty()) {
             LogBuilder.builder(log)
                 .action("CandidateDtoService.loadByIds")
-                .message("Requested candidate IDs not found in candidate table. " 
+                .message("Requested candidate IDs not found in candidate table. "
                     + "requestedIds=" + ids + ", missingIds=" + badIds)
                 .logError();
             throw new NoSuchObjectException(
@@ -104,7 +201,7 @@ public class CandidateDtoServiceImpl implements CandidateDtoService {
 
         Map<Long, String> jsonById =
             new HashMap<>(redisCache.multiGet(versions));
-        
+
         // ------------------------------------------------------------
         // Step 2: L2 Postgres JSON cache lookup (for Redis misses)
         // ------------------------------------------------------------
@@ -209,8 +306,8 @@ public class CandidateDtoServiceImpl implements CandidateDtoService {
         if (!unprocessedIds.isEmpty()) {
             LogBuilder.builder(log)
                 .action("CandidateDtoService.loadByIds")
-                .message("Candidate JSON missing after Redis + Postgres cache + recompute. " 
-                    + "requestedIds=" + ids + ", unprocessedIds=" + unprocessedIds 
+                .message("Candidate JSON missing after Redis + Postgres cache + recompute. "
+                    + "requestedIds=" + ids + ", unprocessedIds=" + unprocessedIds
                     + ", versions=" + versions)
                 .logError();
             throw new NoSuchObjectException(

--- a/server/src/main/java/org/tctalent/server/service/db/impl/CandidateSavedListServiceImpl.java
+++ b/server/src/main/java/org/tctalent/server/service/db/impl/CandidateSavedListServiceImpl.java
@@ -258,7 +258,7 @@ public class CandidateSavedListServiceImpl implements CandidateSavedListService 
         final List<CandidateSavedList> csls =
             candidateSavedListRepository.findBySavedList_Id(savedListId);
 
-        //Now load the csls into a map by candidate is for easy access.
+        //Now load the csls into a map by candidate id for easy access.
         Map<Long, CandidateSavedList> result = new HashMap<>();
         for (CandidateSavedList csl : csls) {
             result.put(csl.getCandidate().getId(), csl);

--- a/server/src/main/java/org/tctalent/server/service/db/impl/CandidateSavedListServiceImpl.java
+++ b/server/src/main/java/org/tctalent/server/service/db/impl/CandidateSavedListServiceImpl.java
@@ -17,10 +17,13 @@
 package org.tctalent.server.service.db.impl;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
-import jakarta.validation.constraints.NotNull;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.lang.NonNull;
 import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -52,7 +55,6 @@ import org.tctalent.server.security.AuthService;
 import org.tctalent.server.service.db.CandidateSavedListService;
 import org.tctalent.server.service.db.CandidateService;
 import org.tctalent.server.service.db.FileSystemService;
-import org.tctalent.server.service.db.SalesforceJobOppService;
 import org.tctalent.server.service.db.SavedListService;
 import org.tctalent.server.service.db.UserService;
 import org.tctalent.server.util.filesystem.GoogleFileSystemFile;
@@ -63,7 +65,6 @@ public class CandidateSavedListServiceImpl implements CandidateSavedListService 
     private final AuthService authService;
     private final CandidateService candidateService;
     private final FileSystemService fileSystemService;
-    private final SalesforceJobOppService salesforceJobOppService;
     private final SavedListService savedListService;
     private final SavedListRepository savedListRepository;
     private final UserService userService;
@@ -73,7 +74,7 @@ public class CandidateSavedListServiceImpl implements CandidateSavedListService 
     public CandidateSavedListServiceImpl(
         AuthService authService, CandidateService candidateService,
         FileSystemService fileSystemService,
-        SalesforceJobOppService salesforceJobOppService, SavedListService savedListService,
+        SavedListService savedListService,
         SavedListRepository savedListRepository,
         UserService userService,
         CandidateAttachmentRepository candidateAttachmentRepository,
@@ -81,7 +82,6 @@ public class CandidateSavedListServiceImpl implements CandidateSavedListService 
         this.authService = authService;
         this.candidateService = candidateService;
         this.fileSystemService = fileSystemService;
-        this.salesforceJobOppService = salesforceJobOppService;
         this.savedListService = savedListService;
         this.savedListRepository = savedListRepository;
         this.userService = userService;
@@ -248,6 +248,25 @@ public class CandidateSavedListServiceImpl implements CandidateSavedListService 
     }
 
     @Override
+    @NonNull
+    public Map<Long, CandidateSavedList> findByCandidateIds(Set<Long> ids, long savedListId) {
+
+        //Uses Spring Data query JPA repo method definition logic which supports nested properties.
+        //See
+        //https://docs.spring.io/spring-data/jpa/reference/repositories/query-methods-details.html#repositories.query-methods.query-property-expressions
+        //Hence: findBySavedList_Id
+        final List<CandidateSavedList> csls =
+            candidateSavedListRepository.findBySavedList_Id(savedListId);
+
+        //Now load the csls into a map by candidate is for easy access.
+        Map<Long, CandidateSavedList> result = new HashMap<>();
+        for (CandidateSavedList csl : csls) {
+            result.put(csl.getCandidate().getId(), csl);
+        }
+        return result;
+    }
+
+    @Override
     public boolean mergeCandidateSavedLists(long candidateId, IHasSetOfSavedLists request) {
         Candidate candidate = candidateService.findByIdLoadSavedLists(candidateId);
 
@@ -296,7 +315,7 @@ public class CandidateSavedListServiceImpl implements CandidateSavedListService 
         return done;
     }
 
-    private @NotNull Set<SavedList> fetchSavedLists(IHasSetOfSavedLists request)
+    private @NonNull Set<SavedList> fetchSavedLists(IHasSetOfSavedLists request)
         throws NoSuchObjectException {
 
         Set<SavedList> savedLists = new HashSet<>();

--- a/server/src/main/java/org/tctalent/server/service/db/impl/CandidateServiceImpl.java
+++ b/server/src/main/java/org/tctalent/server/service/db/impl/CandidateServiceImpl.java
@@ -75,6 +75,7 @@ import org.tctalent.server.exception.ExportFailedException;
 import org.tctalent.server.exception.InvalidRequestException;
 import org.tctalent.server.exception.InvalidSessionException;
 import org.tctalent.server.exception.NoSuchObjectException;
+import org.tctalent.server.exception.NotImplementedException;
 import org.tctalent.server.exception.PasswordMatchException;
 import org.tctalent.server.exception.SalesforceException;
 import org.tctalent.server.exception.UsernameTakenException;
@@ -129,6 +130,7 @@ import org.tctalent.server.repository.db.OccupationRepository;
 import org.tctalent.server.repository.db.SurveyTypeRepository;
 import org.tctalent.server.repository.db.TaskAssignmentRepository;
 import org.tctalent.server.repository.db.UserRepository;
+import org.tctalent.server.repository.db.read.dto.CandidateReadDto;
 import org.tctalent.server.repository.es.CandidateEsRepository;
 import org.tctalent.server.request.LoginRequest;
 import org.tctalent.server.request.PagedSearchRequest;
@@ -392,6 +394,15 @@ public class CandidateServiceImpl implements CandidateService {
             .logInfo();
 
         return candidatesPage;
+    }
+
+    @Override
+    public Page<CandidateReadDto> getSavedListCandidateDtos(
+        SavedList savedList, SavedListGetRequest request) {
+        //TODO JC Fetch the ids using sql query to get ids from list filtering by request 
+        //TODO JC Fetch the dtos
+        //TODO JC getSavedListCandidateDtos not implemented in CandidateServiceImpl
+        throw new NotImplementedException("CandidateServiceImpl", "getSavedListCandidateDtos");
     }
 
     @Override

--- a/server/src/main/java/org/tctalent/server/service/db/impl/CandidateServiceImpl.java
+++ b/server/src/main/java/org/tctalent/server/service/db/impl/CandidateServiceImpl.java
@@ -181,7 +181,6 @@ import org.tctalent.server.service.db.SalesforceService;
 import org.tctalent.server.service.db.SavedListService;
 import org.tctalent.server.service.db.SavedSearchService;
 import org.tctalent.server.service.db.SystemNotificationService;
-import org.tctalent.server.service.db.TaskAssignmentService;
 import org.tctalent.server.service.db.UserService;
 import org.tctalent.server.service.db.email.EmailHelper;
 import org.tctalent.server.service.db.util.PdfHelper;
@@ -266,7 +265,6 @@ public class CandidateServiceImpl implements CandidateService {
     private final PublicIDService publicIDService;
     private final RootRequestService rootRequestService;
     private final TaskAssignmentRepository taskAssignmentRepository;
-    private final TaskAssignmentService taskAssignmentService;
     private final EmailHelper emailHelper;
     private final PdfHelper pdfHelper;
     private final TextExtracter textExtracter;
@@ -607,7 +605,8 @@ public class CandidateServiceImpl implements CandidateService {
         final Candidate candidate = candidateRepository.findById(id)
             .orElseThrow(() -> new NoSuchObjectException(Candidate.class, id));
 
-        taskAssignmentService.populateTransientTaskAssignmentFields(candidate.getTaskAssignments());
+        //TODO JC Review how this is done. Commented out for now. See issue 2989
+//        taskAssignmentService.populateTransientTaskAssignmentFields(candidate.getTaskAssignments());
 
         return candidate;
     }
@@ -1867,7 +1866,9 @@ public class CandidateServiceImpl implements CandidateService {
             return Optional.empty();
         }
         Candidate candidate = candidateRepository.findByUserId(user.getId());
-        taskAssignmentService.populateTransientTaskAssignmentFields(candidate.getTaskAssignments());
+
+        //TODO JC Review how this is done. Commented out for now. See issue 2989
+//        taskAssignmentService.populateTransientTaskAssignmentFields(candidate.getTaskAssignments());
 
         return Optional.of(candidate);
     }
@@ -1898,7 +1899,9 @@ public class CandidateServiceImpl implements CandidateService {
         Set<Country> sourceCountries = userService.getDefaultSourceCountries(loggedInUser);
         Candidate candidate = candidateRepository.findByCandidateNumberRestricted(candidateNumber, sourceCountries)
                 .orElseThrow(() -> new CountryRestrictionException("You don't have access to this candidate."));
-        taskAssignmentService.populateTransientTaskAssignmentFields(candidate.getTaskAssignments());
+
+        //TODO JC Review how this is done. Commented out for now. See issue 2989
+//        taskAssignmentService.populateTransientTaskAssignmentFields(candidate.getTaskAssignments());
         return candidate;
     }
 

--- a/server/src/main/java/org/tctalent/server/service/db/impl/CandidateServiceImpl.java
+++ b/server/src/main/java/org/tctalent/server/service/db/impl/CandidateServiceImpl.java
@@ -99,7 +99,6 @@ import org.tctalent.server.model.db.HasTcQueryParameters;
 import org.tctalent.server.model.db.LanguageLevel;
 import org.tctalent.server.model.db.Occupation;
 import org.tctalent.server.model.db.PartnerImpl;
-import org.tctalent.server.model.db.QuestionTaskAssignmentImpl;
 import org.tctalent.server.model.db.Role;
 import org.tctalent.server.model.db.RootRequest;
 import org.tctalent.server.model.db.SavedList;
@@ -116,7 +115,6 @@ import org.tctalent.server.model.db.partner.Partner;
 import org.tctalent.server.model.db.task.QuestionTask;
 import org.tctalent.server.model.db.task.QuestionTaskAssignment;
 import org.tctalent.server.model.db.task.Task;
-import org.tctalent.server.model.db.task.TaskAssignment;
 import org.tctalent.server.model.es.CandidateEs;
 import org.tctalent.server.model.sf.Contact;
 import org.tctalent.server.repository.db.CandidateExamRepository;
@@ -183,7 +181,7 @@ import org.tctalent.server.service.db.SalesforceService;
 import org.tctalent.server.service.db.SavedListService;
 import org.tctalent.server.service.db.SavedSearchService;
 import org.tctalent.server.service.db.SystemNotificationService;
-import org.tctalent.server.service.db.TaskService;
+import org.tctalent.server.service.db.TaskAssignmentService;
 import org.tctalent.server.service.db.UserService;
 import org.tctalent.server.service.db.email.EmailHelper;
 import org.tctalent.server.service.db.util.PdfHelper;
@@ -268,7 +266,7 @@ public class CandidateServiceImpl implements CandidateService {
     private final PublicIDService publicIDService;
     private final RootRequestService rootRequestService;
     private final TaskAssignmentRepository taskAssignmentRepository;
-    private final TaskService taskService;
+    private final TaskAssignmentService taskAssignmentService;
     private final EmailHelper emailHelper;
     private final PdfHelper pdfHelper;
     private final TextExtracter textExtracter;
@@ -609,42 +607,9 @@ public class CandidateServiceImpl implements CandidateService {
         final Candidate candidate = candidateRepository.findById(id)
             .orElseThrow(() -> new NoSuchObjectException(Candidate.class, id));
 
-        populateTransientTaskAssignmentFields(candidate.getTaskAssignments());
+        taskAssignmentService.populateTransientTaskAssignmentFields(candidate.getTaskAssignments());
 
         return candidate;
-    }
-
-    @Override
-    public void populateCandidatesTransientTaskAssignments(Page<Candidate> candidates) {
-        for (Candidate candidate : candidates) {
-            populateTransientTaskAssignmentFields(candidate.getTaskAssignments());
-        }
-    }
-
-    /**
-     * Sets transient fields on the given task assignments.
-     * @param taskAssignments Task assignments
-     */
-    private void populateTransientTaskAssignmentFields(List<TaskAssignmentImpl> taskAssignments) {
-        for (TaskAssignmentImpl taskAssignment : taskAssignments) {
-            populateTransientTaskAssignmentFields(taskAssignment);
-        }
-    }
-
-    private void populateTransientTaskAssignmentFields(TaskAssignment taskAssignment) {
-
-        taskService.populateTransientFields(taskAssignment.getTask());
-
-        //If task is completed, see if there is any transient data to be populated - eg the
-        //answer on a question task
-        if (taskAssignment.getCompletedDate() != null) {
-            if (taskAssignment instanceof QuestionTaskAssignmentImpl) {
-                QuestionTaskAssignment qta = (QuestionTaskAssignmentImpl) taskAssignment;
-                String answer = fetchCandidateTaskAnswer(qta);
-                qta.setAnswer(answer);
-            }
-        }
-
     }
 
     /**
@@ -1902,8 +1867,7 @@ public class CandidateServiceImpl implements CandidateService {
             return Optional.empty();
         }
         Candidate candidate = candidateRepository.findByUserId(user.getId());
-
-        populateTransientTaskAssignmentFields(candidate.getTaskAssignments());
+        taskAssignmentService.populateTransientTaskAssignmentFields(candidate.getTaskAssignments());
 
         return Optional.of(candidate);
     }
@@ -1934,7 +1898,7 @@ public class CandidateServiceImpl implements CandidateService {
         Set<Country> sourceCountries = userService.getDefaultSourceCountries(loggedInUser);
         Candidate candidate = candidateRepository.findByCandidateNumberRestricted(candidateNumber, sourceCountries)
                 .orElseThrow(() -> new CountryRestrictionException("You don't have access to this candidate."));
-        populateTransientTaskAssignmentFields(candidate.getTaskAssignments());
+        taskAssignmentService.populateTransientTaskAssignmentFields(candidate.getTaskAssignments());
         return candidate;
     }
 

--- a/server/src/main/java/org/tctalent/server/service/db/impl/CandidateServiceImpl.java
+++ b/server/src/main/java/org/tctalent/server/service/db/impl/CandidateServiceImpl.java
@@ -75,7 +75,6 @@ import org.tctalent.server.exception.ExportFailedException;
 import org.tctalent.server.exception.InvalidRequestException;
 import org.tctalent.server.exception.InvalidSessionException;
 import org.tctalent.server.exception.NoSuchObjectException;
-import org.tctalent.server.exception.NotImplementedException;
 import org.tctalent.server.exception.PasswordMatchException;
 import org.tctalent.server.exception.SalesforceException;
 import org.tctalent.server.exception.UsernameTakenException;
@@ -130,7 +129,6 @@ import org.tctalent.server.repository.db.OccupationRepository;
 import org.tctalent.server.repository.db.SurveyTypeRepository;
 import org.tctalent.server.repository.db.TaskAssignmentRepository;
 import org.tctalent.server.repository.db.UserRepository;
-import org.tctalent.server.repository.db.read.dto.CandidateReadDto;
 import org.tctalent.server.repository.es.CandidateEsRepository;
 import org.tctalent.server.request.LoginRequest;
 import org.tctalent.server.request.PagedSearchRequest;
@@ -394,15 +392,6 @@ public class CandidateServiceImpl implements CandidateService {
             .logInfo();
 
         return candidatesPage;
-    }
-
-    @Override
-    public Page<CandidateReadDto> getSavedListCandidateDtos(
-        SavedList savedList, SavedListGetRequest request) {
-        //TODO JC Fetch the ids using sql query to get ids from list filtering by request 
-        //TODO JC Fetch the dtos
-        //TODO JC getSavedListCandidateDtos not implemented in CandidateServiceImpl
-        throw new NotImplementedException("CandidateServiceImpl", "getSavedListCandidateDtos");
     }
 
     @Override

--- a/server/src/main/java/org/tctalent/server/service/db/impl/SavedListServiceImpl.java
+++ b/server/src/main/java/org/tctalent/server/service/db/impl/SavedListServiceImpl.java
@@ -814,8 +814,7 @@ public class SavedListServiceImpl implements SavedListService {
     @Override
     public void setCandidateDtoContext(long savedListId, Iterable<CandidateReadDto> candidates) {
         for (CandidateReadDto candidate : candidates) {
-            //TODO JC dto needs to support this transient field
-//            candidate.setContextSavedListId(savedListId);
+            candidate.setContextSavedListId(savedListId);
         }
     }
 

--- a/server/src/main/java/org/tctalent/server/service/db/impl/SavedListServiceImpl.java
+++ b/server/src/main/java/org/tctalent/server/service/db/impl/SavedListServiceImpl.java
@@ -92,7 +92,7 @@ import org.tctalent.server.request.list.UpdateExplicitSavedListContentsRequest;
 import org.tctalent.server.request.list.UpdateSavedListContentsRequest;
 import org.tctalent.server.request.list.UpdateSavedListInfoRequest;
 import org.tctalent.server.request.search.UpdateSharingRequest;
-import org.tctalent.server.service.db.CandidateDtoService;
+import org.tctalent.server.service.db.CandidateDtoFetchService;
 import org.tctalent.server.service.db.CandidateOpportunityService;
 import org.tctalent.server.service.db.DocPublisherService;
 import org.tctalent.server.service.db.ExportColumnsService;
@@ -121,7 +121,7 @@ public class SavedListServiceImpl implements SavedListService {
     private final static String REGISTERED_NAME_SUFFIX = "*";
     private final static String EXCLUSION_LIST_SUFFIX = "Exclude";
     private final CandidateRepository candidateRepository;
-    private final CandidateDtoService candidateDtoService;
+    private final CandidateDtoFetchService candidateDtoFetchService;
     private final CandidateSavedListRepository candidateSavedListRepository;
     private final CandidateOpportunityService candidateOpportunityService;
     private final ExportColumnsService exportColumnsService;
@@ -141,7 +141,7 @@ public class SavedListServiceImpl implements SavedListService {
     @Autowired
     public SavedListServiceImpl(
         CandidateRepository candidateRepository,
-        CandidateDtoService candidateDtoService,
+        CandidateDtoFetchService candidateDtoFetchService,
         CandidateSavedListRepository candidateSavedListRepository,
         CandidateOpportunityService candidateOpportunityService, ExportColumnsService exportColumnsService,
         SavedListRepository savedListRepository,
@@ -153,7 +153,7 @@ public class SavedListServiceImpl implements SavedListService {
         UserRepository userRepository,
         UserService userService) {
         this.candidateRepository = candidateRepository;
-        this.candidateDtoService = candidateDtoService;
+        this.candidateDtoFetchService = candidateDtoFetchService;
         this.candidateSavedListRepository = candidateSavedListRepository;
         this.candidateOpportunityService = candidateOpportunityService;
         this.exportColumnsService = exportColumnsService;
@@ -567,7 +567,7 @@ public class SavedListServiceImpl implements SavedListService {
         String sql = extractFetchSQL(savedList, request, true);
         String countSql = extractCountSQL(savedList, request);
 
-        return candidateDtoService.doFetchCandidateDtos(sql, countSql, pageRequest);
+        return candidateDtoFetchService.fetchPage(sql, countSql, pageRequest);
     }
 
     private String extractCountSQL(SavedList savedList, SavedListGetRequest request) {

--- a/server/src/main/java/org/tctalent/server/service/db/impl/SavedListServiceImpl.java
+++ b/server/src/main/java/org/tctalent/server/service/db/impl/SavedListServiceImpl.java
@@ -45,6 +45,7 @@ import org.springframework.lang.NonNull;
 import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 import org.springframework.web.reactive.function.client.WebClientException;
 import org.tctalent.server.configuration.GoogleDriveConfig;
 import org.tctalent.server.exception.EntityExistsException;
@@ -561,18 +562,16 @@ public class SavedListServiceImpl implements SavedListService {
     @Override
     public Page<CandidateReadDto> getSavedListCandidateDtos(
         @NonNull SavedList savedList, SavedListGetRequest request) {
-        User user = userService.getLoggedInUser();
         final PageRequest pageRequest = request.getPageRequest();
 
-        long savedListId = savedList.getId();
-        String sql = extractFetchSQL(savedListId, request, user, true);
-        String countSql = extractCountSQL(savedListId, request, user);
+        String sql = extractFetchSQL(savedList, request, true);
+        String countSql = extractCountSQL(savedList, request);
 
         return candidateDtoService.doFetchCandidateDtos(sql, countSql, pageRequest);
     }
 
-    private String extractCountSQL(long savedListId, SavedListGetRequest request, User user) {
-        String joinAndWhereSql = extractJoinAndWhereSQL(savedListId, request, user,false);
+    private String extractCountSQL(SavedList savedList, SavedListGetRequest request) {
+        String joinAndWhereSql = extractJoinAndWhereSQL(savedList, request, false);
         String selectSql = extractCountSelectSql();
         return selectSql + joinAndWhereSql;
     }
@@ -582,8 +581,8 @@ public class SavedListServiceImpl implements SavedListService {
     }
 
     private String extractFetchSQL(
-        long savedListId, SavedListGetRequest request, User user, boolean ordered) {
-        String joinAndWhereSql = extractJoinAndWhereSQL(savedListId, request, user, ordered);
+        SavedList savedList, SavedListGetRequest request, boolean ordered) {
+        String joinAndWhereSql = extractJoinAndWhereSQL(savedList, request, ordered);
 
         String selectSql = extractFetchSelectSql(request, ordered);
 
@@ -616,19 +615,36 @@ public class SavedListServiceImpl implements SavedListService {
         return sql;
     }
 
-    private String extractJoinAndWhereSQL(long savedListId, SavedListGetRequest request, User user, boolean ordered) {
+    private String extractJoinAndWhereSQL(
+        @NonNull SavedList savedList, SavedListGetRequest request, boolean ordered) {
+        long savedListId = savedList.getId();
+        Long jobOppId = savedList.getSfJobOpp() == null ? null : savedList.getSfJobOpp().getId();
+
         //Uses a LinkedHashSet so that ordering is predictable - which helps unit testing
         Set<String> joins = new LinkedHashSet<>();
         List<String> ands = new ArrayList<>();
 
-        //TODO JC in list filtering
+        //Candidates must be in list
         joins.add("candidate_saved_list");
         ands.add(
             "candidate.id in (select candidate_id from candidate_saved_list where saved_list_id = "
                 + savedListId + ")");
 
-        //TODO JC keyword filtering
-        //TODO JC show closed opps filtering
+        //Filter on key word (matching candidate number or name)
+        if (StringUtils.hasText(request.getKeyword())) {
+            joins.add("users");
+            String keyword = request.getKeyword().toLowerCase();
+            ands.add("(lower(candidate_number) like '%" + keyword + "%'"
+                + " or lower(concat(users.first_name, ' ', users.last_name)) like '%" + keyword + "%')" );
+        }
+
+        //Filter only if this list has an associated jobOpp and the request is NOT to show closed
+        //opportunities.
+        //The exception is that we do want to see "won" opportunities even though won is a closed state.
+        if (jobOppId != null && request.getShowClosedOpps() != null && !request.getShowClosedOpps()) {
+            ands.add("candidate.id in (select candidate_id from candidate_opportunity where job_opp_id ="
+                + jobOppId + " and closed = false or won = true)");
+        }
 
         if (ordered) {
             List<String> tableSet = CandidateSearchUtils.buildNonCandidateTableList(request.getSort());

--- a/server/src/main/java/org/tctalent/server/service/db/impl/SavedListServiceImpl.java
+++ b/server/src/main/java/org/tctalent/server/service/db/impl/SavedListServiceImpl.java
@@ -31,6 +31,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -69,6 +70,7 @@ import org.tctalent.server.repository.db.GetCandidateSavedListsQuery;
 import org.tctalent.server.repository.db.GetSavedListsQuery;
 import org.tctalent.server.repository.db.SavedListRepository;
 import org.tctalent.server.repository.db.UserRepository;
+import org.tctalent.server.repository.db.read.dto.CandidateReadDto;
 import org.tctalent.server.request.IdsRequest;
 import org.tctalent.server.request.candidate.EmployerCandidateDecision;
 import org.tctalent.server.request.candidate.EmployerCandidateFeedbackData;
@@ -77,6 +79,7 @@ import org.tctalent.server.request.candidate.PublishedDocColumnDef;
 import org.tctalent.server.request.candidate.PublishedDocColumnSetUp;
 import org.tctalent.server.request.candidate.PublishedDocColumnType;
 import org.tctalent.server.request.candidate.PublishedDocImportReport;
+import org.tctalent.server.request.candidate.SavedListGetRequest;
 import org.tctalent.server.request.candidate.UpdateCandidateListOppsRequest;
 import org.tctalent.server.request.candidate.UpdateDisplayedFieldPathsRequest;
 import org.tctalent.server.request.candidate.source.UpdateCandidateSourceDescriptionRequest;
@@ -88,6 +91,7 @@ import org.tctalent.server.request.list.UpdateExplicitSavedListContentsRequest;
 import org.tctalent.server.request.list.UpdateSavedListContentsRequest;
 import org.tctalent.server.request.list.UpdateSavedListInfoRequest;
 import org.tctalent.server.request.search.UpdateSharingRequest;
+import org.tctalent.server.service.db.CandidateDtoService;
 import org.tctalent.server.service.db.CandidateOpportunityService;
 import org.tctalent.server.service.db.DocPublisherService;
 import org.tctalent.server.service.db.ExportColumnsService;
@@ -98,6 +102,7 @@ import org.tctalent.server.service.db.SalesforceService;
 import org.tctalent.server.service.db.SavedListService;
 import org.tctalent.server.service.db.TaskAssignmentService;
 import org.tctalent.server.service.db.UserService;
+import org.tctalent.server.util.CandidateSearchUtils;
 import org.tctalent.server.util.filesystem.GoogleFileSystemDrive;
 import org.tctalent.server.util.filesystem.GoogleFileSystemFile;
 import org.tctalent.server.util.filesystem.GoogleFileSystemFolder;
@@ -115,6 +120,7 @@ public class SavedListServiceImpl implements SavedListService {
     private final static String REGISTERED_NAME_SUFFIX = "*";
     private final static String EXCLUSION_LIST_SUFFIX = "Exclude";
     private final CandidateRepository candidateRepository;
+    private final CandidateDtoService candidateDtoService;
     private final CandidateSavedListRepository candidateSavedListRepository;
     private final CandidateOpportunityService candidateOpportunityService;
     private final ExportColumnsService exportColumnsService;
@@ -134,6 +140,7 @@ public class SavedListServiceImpl implements SavedListService {
     @Autowired
     public SavedListServiceImpl(
         CandidateRepository candidateRepository,
+        CandidateDtoService candidateDtoService,
         CandidateSavedListRepository candidateSavedListRepository,
         CandidateOpportunityService candidateOpportunityService, ExportColumnsService exportColumnsService,
         SavedListRepository savedListRepository,
@@ -145,6 +152,7 @@ public class SavedListServiceImpl implements SavedListService {
         UserRepository userRepository,
         UserService userService) {
         this.candidateRepository = candidateRepository;
+        this.candidateDtoService = candidateDtoService;
         this.candidateSavedListRepository = candidateSavedListRepository;
         this.candidateOpportunityService = candidateOpportunityService;
         this.exportColumnsService = exportColumnsService;
@@ -551,6 +559,102 @@ public class SavedListServiceImpl implements SavedListService {
     }
 
     @Override
+    public Page<CandidateReadDto> getSavedListCandidateDtos(
+        @NonNull SavedList savedList, SavedListGetRequest request) {
+        User user = userService.getLoggedInUser();
+        final PageRequest pageRequest = request.getPageRequest();
+
+        long savedListId = savedList.getId();
+        String sql = extractFetchSQL(savedListId, request, user, true);
+        String countSql = extractCountSQL(savedListId, request, user);
+
+        return candidateDtoService.doFetchCandidateDtos(sql, countSql, pageRequest);
+    }
+
+    private String extractCountSQL(long savedListId, SavedListGetRequest request, User user) {
+        String joinAndWhereSql = extractJoinAndWhereSQL(savedListId, request, user,false);
+        String selectSql = extractCountSelectSql();
+        return selectSql + joinAndWhereSql;
+    }
+
+    private String extractCountSelectSql() {
+        return "select count(distinct candidate.id) from candidate";
+    }
+
+    private String extractFetchSQL(
+        long savedListId, SavedListGetRequest request, User user, boolean ordered) {
+        String joinAndWhereSql = extractJoinAndWhereSQL(savedListId, request, user, ordered);
+
+        String selectSql = extractFetchSelectSql(request, ordered);
+
+        String sql = selectSql + joinAndWhereSql;
+
+        if (ordered) {
+            Sort sort = request.getSort();
+            String orderBySql = CandidateSearchUtils.buildOrderByClause(sort);
+            sql += orderBySql;
+        }
+
+        return sql;
+    }
+
+    private String extractFetchSelectSql(SavedListGetRequest request, boolean ordered) {
+        String sql;
+        if (!ordered) {
+            sql = "select distinct candidate.id from candidate";
+        } else {
+            Sort sort = request.getSort();
+
+            sql = "select distinct candidate.id";
+            String nonIdSortFields =
+                CandidateSearchUtils.buildNonIdFieldList(sort, null);
+            if (!nonIdSortFields.isEmpty()) {
+                sql += "," + nonIdSortFields;
+            }
+            sql += " from candidate";
+        }
+        return sql;
+    }
+
+    private String extractJoinAndWhereSQL(long savedListId, SavedListGetRequest request, User user, boolean ordered) {
+        //Uses a LinkedHashSet so that ordering is predictable - which helps unit testing
+        Set<String> joins = new LinkedHashSet<>();
+        List<String> ands = new ArrayList<>();
+
+        //TODO JC in list filtering
+        joins.add("candidate_saved_list");
+        ands.add(
+            "candidate.id in (select candidate_id from candidate_saved_list where saved_list_id = "
+                + savedListId + ")");
+
+        //TODO JC keyword filtering
+        //TODO JC show closed opps filtering
+
+        if (ordered) {
+            List<String> tableSet = CandidateSearchUtils.buildNonCandidateTableList(request.getSort());
+            if (!tableSet.isEmpty()) {
+                joins.addAll(tableSet);
+            }
+        }
+
+        String joinClause = joins.stream()
+            .map(CandidateSearchUtils::getTableJoin)
+            .collect(Collectors.joining(" left join "));
+
+        String whereClause = String.join(" and ", ands);
+
+        String query = "";
+        if (!joinClause.isEmpty()) {
+            query += " left join " + joinClause;
+        }
+        if (!whereClause.isEmpty()) {
+            query += " where " + whereClause;
+        }
+
+        return query;
+    }
+
+    @Override
     public boolean isEmpty(long id) throws NoSuchObjectException {
         SavedList savedList = get(id);
         return savedList.getCandidates().isEmpty();
@@ -688,6 +792,14 @@ public class SavedListServiceImpl implements SavedListService {
     public void setCandidateContext(long savedListId, Iterable<Candidate> candidates) {
         for (Candidate candidate : candidates) {
             candidate.setContextSavedListId(savedListId);
+        }
+    }
+
+    @Override
+    public void setCandidateDtoContext(long savedListId, Iterable<CandidateReadDto> candidates) {
+        for (CandidateReadDto candidate : candidates) {
+            //TODO JC dto needs to support this transient field
+//            candidate.setContextSavedListId(savedListId);
         }
     }
 

--- a/server/src/main/java/org/tctalent/server/service/db/impl/SavedListServiceImpl.java
+++ b/server/src/main/java/org/tctalent/server/service/db/impl/SavedListServiceImpl.java
@@ -811,13 +811,6 @@ public class SavedListServiceImpl implements SavedListService {
         }
     }
 
-    @Override
-    public void setCandidateDtoContext(long savedListId, Iterable<CandidateReadDto> candidates) {
-        for (CandidateReadDto candidate : candidates) {
-            candidate.setContextSavedListId(savedListId);
-        }
-    }
-
     @Transactional
     @Override
     public void setPublicIds(List<SavedList> savedLists) {

--- a/server/src/main/java/org/tctalent/server/service/db/impl/SavedSearchServiceImpl.java
+++ b/server/src/main/java/org/tctalent/server/service/db/impl/SavedSearchServiceImpl.java
@@ -318,6 +318,32 @@ public class SavedSearchServiceImpl implements SavedSearchService {
         return candidates;
     }
 
+    @Override
+    public Page<CandidateReadDto> searchCandidateDtos(long savedSearchId,
+        SavedSearchGetRequest request) throws NoSuchObjectException {
+        SearchCandidateRequest searchRequest =
+            loadSavedSearch(savedSearchId);
+
+        //Merge the SavedSearchGetRequest - notably the page request - in to
+        //the standard saved search request.
+        searchRequest.merge(request);
+
+        //If user filters on unverified statuses we bypass performing a full search
+        //Simply return candidates that the user has already reviewed as verified and/or rejected
+        if (request.getReviewStatusFilter() != null &&
+            request.getReviewStatusFilter().contains(ReviewStatus.unverified)) {
+            return reviewedCandidateDtos(searchRequest);
+        }
+
+        //Do the search
+        final Page<CandidateReadDto> candidates = doSearchCandidateDtos(searchRequest);
+
+        //Add in any selections
+        markUserSelectedCandidateDtos(savedSearchId, candidates);
+
+        return candidates;
+    }
+
     private Page<Candidate> reviewedCandidates(SearchCandidateRequest request) {
         Page<Candidate> candidates = candidateRepository.findReviewedCandidatesBySavedSearchId(
             request.getSavedSearchId(),
@@ -325,6 +351,21 @@ public class SavedSearchServiceImpl implements SavedSearchService {
             request.getPageRequestWithoutSort());
 
         return candidates;
+    }
+
+    private Page<CandidateReadDto> reviewedCandidateDtos(SearchCandidateRequest request) {
+        Page<Candidate> candidates = reviewedCandidates(request);
+
+        List<Long> ids = candidates.stream().map(Candidate::getId).collect(Collectors.toList());
+        final Map<Long, CandidateReadDto> dtos = candidateDtoFetchService.fetchByIds(ids);
+
+        //Construct a sortedlist of DTOs in the same order as the ids.
+        List<CandidateReadDto> candidateDtos = new ArrayList<>();
+        for (Long id : ids) {
+            candidateDtos.add(dtos.get(id));
+        }
+
+        return new PageImpl<>(candidateDtos, request.getPageRequest(), candidates.getTotalElements());
     }
 
     @Override

--- a/server/src/main/java/org/tctalent/server/service/db/impl/SavedSearchServiceImpl.java
+++ b/server/src/main/java/org/tctalent/server/service/db/impl/SavedSearchServiceImpl.java
@@ -26,7 +26,6 @@ import static org.tctalent.server.util.StringHelper.getStringListFromString;
 import static org.tctalent.server.util.locale.LocaleHelper.getOffsetDateTime;
 
 import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.opencsv.CSVWriter;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
@@ -2152,89 +2151,9 @@ public class SavedSearchServiceImpl implements SavedSearchService {
         final PageRequest pageRequest = request.getPageRequest();
 
         String sql = extractFetchSQL(request, user, excludedCandidates, true);
-        LogBuilder.builder(log).action("findCandidates")
-            .message("Query: " + sql).logInfo();
-
-        //Create and execute the query to return the candidate ids
-        Query query = entityManager.createNativeQuery(sql);
-        query.setFirstResult((int) pageRequest.getOffset());
-        query.setMaxResults(pageRequest.getPageSize());
-
-        long start = System.currentTimeMillis();
-        long end;
-
-        //Get results
-        final List<?> results = query.getResultList();
-
-        end = System.currentTimeMillis();
-        long fetchIdsTime = end - start;
-        start = end;
-
-        //Process the results
-        List<IdAndRank> idAndRanks =
-            CandidateSearchUtils.processIdRankSearchResults(results, request.getSort());
-
-        end = System.currentTimeMillis();
-        long convertTime = end - start;
-        start = end;
-
-        //Get ids of sorted candidates
-        List<Long> ids = idAndRanks.stream().map(IdAndRank::id).toList();
-
-        end = System.currentTimeMillis();
-        long fetchEntitiesTime = end - start;
-        start = end;
-
-        Map<Long, CandidateReadDto> candidatesByIdUnsorted;
-        try {
-            candidatesByIdUnsorted = candidateDtoService.loadByIds(ids);
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
-        }
-
-        end = System.currentTimeMillis();
-        long fetchDtosTime = end - start;
-        start = end;
-
-        //Candidates need to be sorted the same as the ids.
-
-        //Construct a sorted list of the candidates in the same order as the returned ids.
-        List<CandidateReadDto> candidatesSorted = new ArrayList<>();
-        for (IdAndRank idAndRank : idAndRanks) {
-            final CandidateReadDto candidate = candidatesByIdUnsorted.get(idAndRank.id());
-
-            //Optionally update candidate data with any ranking values.
-            final Number rank = idAndRank.rank();
-            //Rank is a transient field so no need to set to null
-            if (rank != null) {
-                candidate.setRank(rank);
-            }
-            candidatesSorted.add(candidate);
-        }
-
-        end = System.currentTimeMillis();
-        long sortTime = end - start;
-        start = end;
-
-        //Compute count
         String countSql = extractCountSQL(request, user, excludedCandidates);
-        LogBuilder.builder(log).action("countCandidates")
-            .message("Query: " + countSql).logInfo();
-        long total =  ((Number) entityManager.createNativeQuery(countSql).getSingleResult()).longValue();
 
-        end = System.currentTimeMillis();
-        long countTime = end - start;
-
-        LogBuilder.builder(log).action("findCandidates")
-            .message("Timings: fetchIds: " + fetchIdsTime
-                + " convert: " + convertTime
-                + " fetchEntities: " + fetchEntitiesTime
-                + " fetchDtos: " + fetchDtosTime
-                + " sort: " + sortTime
-                + " count: " + countTime
-            ).logInfo();
-
-        return new PageImpl<>(candidatesSorted, pageRequest, total);
+        return candidateDtoService.doFetchCandidateDtos(sql, countSql, pageRequest);
     }
 
 

--- a/server/src/main/java/org/tctalent/server/service/db/impl/SavedSearchServiceImpl.java
+++ b/server/src/main/java/org/tctalent/server/service/db/impl/SavedSearchServiceImpl.java
@@ -134,7 +134,7 @@ import org.tctalent.server.request.search.UpdateSavedSearchRequest;
 import org.tctalent.server.request.search.UpdateSharingRequest;
 import org.tctalent.server.request.search.UpdateWatchingRequest;
 import org.tctalent.server.security.AuthService;
-import org.tctalent.server.service.db.CandidateDtoService;
+import org.tctalent.server.service.db.CandidateDtoFetchService;
 import org.tctalent.server.service.db.CandidateSavedListService;
 import org.tctalent.server.service.db.CandidateService;
 import org.tctalent.server.service.db.CountryService;
@@ -166,7 +166,7 @@ public class SavedSearchServiceImpl implements SavedSearchService {
 
     private final CandidateRepository candidateRepository;
     private final CandidateService candidateService;
-    private final CandidateDtoService candidateDtoService;
+    private final CandidateDtoFetchService candidateDtoFetchService;
     private final CandidateReviewStatusRepository candidateReviewStatusRepository;
     private final CandidateSavedListService candidateSavedListService;
     private final CountryService countryService;
@@ -2153,7 +2153,7 @@ public class SavedSearchServiceImpl implements SavedSearchService {
         String sql = extractFetchSQL(request, user, excludedCandidates, true);
         String countSql = extractCountSQL(request, user, excludedCandidates);
 
-        return candidateDtoService.doFetchCandidateDtos(sql, countSql, pageRequest);
+        return candidateDtoFetchService.fetchPage(sql, countSql, pageRequest);
     }
 
 

--- a/server/src/main/java/org/tctalent/server/service/db/impl/TaskAssigmentServiceImpl.java
+++ b/server/src/main/java/org/tctalent/server/service/db/impl/TaskAssigmentServiceImpl.java
@@ -17,16 +17,23 @@
 package org.tctalent.server.service.db.impl;
 
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Optional;
+import org.apache.commons.beanutils.PropertyUtils;
 import org.springframework.lang.NonNull;
 import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
+import org.tctalent.server.exception.InvalidRequestException;
 import org.tctalent.server.exception.InvalidSessionException;
 import org.tctalent.server.exception.NoSuchObjectException;
 import org.tctalent.server.model.db.Candidate;
+import org.tctalent.server.model.db.CandidateExam;
+import org.tctalent.server.model.db.CandidateProperty;
+import org.tctalent.server.model.db.Exam;
 import org.tctalent.server.model.db.QuestionTaskAssignmentImpl;
 import org.tctalent.server.model.db.SavedList;
 import org.tctalent.server.model.db.Status;
@@ -34,6 +41,8 @@ import org.tctalent.server.model.db.TaskAssignmentImpl;
 import org.tctalent.server.model.db.TaskImpl;
 import org.tctalent.server.model.db.UploadTaskAssignmentImpl;
 import org.tctalent.server.model.db.User;
+import org.tctalent.server.model.db.task.QuestionTask;
+import org.tctalent.server.model.db.task.QuestionTaskAssignment;
 import org.tctalent.server.model.db.task.Task;
 import org.tctalent.server.model.db.task.TaskAssignment;
 import org.tctalent.server.model.db.task.TaskType;
@@ -43,6 +52,7 @@ import org.tctalent.server.repository.db.TaskAssignmentRepository;
 import org.tctalent.server.request.task.TaskListRequest;
 import org.tctalent.server.security.AuthService;
 import org.tctalent.server.service.db.CandidateAttachmentService;
+import org.tctalent.server.service.db.CandidatePropertyService;
 import org.tctalent.server.service.db.TaskAssignmentService;
 import org.tctalent.server.service.db.TaskService;
 
@@ -54,16 +64,19 @@ import org.tctalent.server.service.db.TaskService;
 @Service
 public class TaskAssigmentServiceImpl implements TaskAssignmentService {
     private final CandidateAttachmentService candidateAttachmentService;
+    private final CandidatePropertyService candidatePropertyService;
     private final TaskAssignmentRepository taskAssignmentRepository;
     private final TaskService taskService;
     private final AuthService authService;
 
     public TaskAssigmentServiceImpl(
         CandidateAttachmentService candidateAttachmentService,
+        CandidatePropertyService candidatePropertyService,
         TaskAssignmentRepository taskAssignmentRepository,
         AuthService authService,
         TaskService taskService) {
         this.candidateAttachmentService = candidateAttachmentService;
+        this.candidatePropertyService = candidatePropertyService;
         this.taskAssignmentRepository = taskAssignmentRepository;
         this.authService = authService;
         this.taskService = taskService;
@@ -239,4 +252,94 @@ public class TaskAssigmentServiceImpl implements TaskAssignmentService {
             .orElseThrow(() -> new InvalidSessionException("Not logged in"));
         return user;
     }
+
+    @Override
+    public void populateTransientTaskAssignmentFields(List<TaskAssignmentImpl> taskAssignments) {
+        for (TaskAssignment taskAssignment : taskAssignments) {
+            taskService.populateTransientFields(taskAssignment.getTask());
+
+            //If task is completed, see if there is any transient data to be populated - eg the
+            //answer on a question task
+            if (taskAssignment.getCompletedDate() != null) {
+                if (taskAssignment instanceof QuestionTaskAssignmentImpl) {
+                    QuestionTaskAssignment qta = (QuestionTaskAssignmentImpl) taskAssignment;
+                    String answer = fetchCandidateTaskAnswer(qta);
+                    qta.setAnswer(answer);
+                }
+            }
+        }
+    }
+
+    /**
+     * Retrieves the answer, if any, of the give question task assignment.
+     * @param questionTaskAssignment Question task assignment
+     * @return Candidate's answer to the question
+     * @throws NoSuchObjectException if the answer could not be retrieved because the answer has
+     * been specified as being located in a non existent candidate field or property.
+     */
+    @Nullable
+    private String fetchCandidateTaskAnswer(QuestionTaskAssignment questionTaskAssignment)
+        throws NoSuchObjectException {
+        String answer;
+        Task task = questionTaskAssignment.getTask();
+        if (task instanceof QuestionTask) {
+            String answerField = ((QuestionTask) task).getCandidateAnswerField();
+            Candidate candidate = questionTaskAssignment.getCandidate();
+            if (answerField == null) {
+                //Get answer from candidate property
+                String propertyName = task.getName();
+                final CandidateProperty property =
+                    candidatePropertyService.findProperty(candidate, propertyName);
+                answer = property != null ? property.getValue() : null;
+            } else {
+                //Get answer from candidate field
+
+                //TODO JC This is a bit of a hack - we need a better way of processing things like candidateExams
+                String candidateExamsFieldName = "candidateExams";
+                if (answerField.startsWith(candidateExamsFieldName + ".")) {
+                    //Special code for candidate exams
+                    //Extract the exam name from the answerField
+                    String examName = answerField.substring(candidateExamsFieldName.length() + 1);
+                    Exam examType = Exam.valueOf(examName);
+
+                    //See if we already have an entry for this exam
+                    Optional<CandidateExam> examO = Optional.empty();
+                    final List<CandidateExam> candidateExams = candidate.getCandidateExams();
+                    if (candidateExams != null) {
+                        examO = candidateExams.stream().filter(
+                            e -> e.getExam().equals(examType)).findFirst();
+                    }
+
+                    //Fetch the answer
+                    CandidateExam exam;
+                    if (examO.isPresent()) {
+                        exam = examO.get();
+                        answer = exam.getScore();
+                    } else {
+                        answer = null;
+                    }
+                } else {
+                    try {
+                        Object value = PropertyUtils.getProperty(candidate, answerField);
+                        answer = value != null ? value.toString() : null;
+                    } catch (IllegalAccessException e) {
+                        throw new InvalidRequestException("Unable to access '" + answerField
+                            + "' field of candidate");
+                    } catch (InvocationTargetException e) {
+                        throw new InvalidRequestException("Error while accessing '" + answerField
+                            + "' field of candidate");
+                    } catch (NoSuchMethodException e) {
+                        throw new NoSuchObjectException(
+                            "Answer not found to " + task.getDisplayName()
+                                + ". No such candidate field: " + answerField);
+                    }
+                }
+            }
+        } else {
+            throw new InvalidRequestException("Task is not a QuestionTask: " + task.getName());
+        }
+
+        return answer;
+    }
+
 }

--- a/server/src/main/java/org/tctalent/server/service/db/impl/TaskServiceImpl.java
+++ b/server/src/main/java/org/tctalent/server/service/db/impl/TaskServiceImpl.java
@@ -123,6 +123,8 @@ public class TaskServiceImpl implements TaskService {
         }
     }
 
+    //TODO JC Perhaps these allowed answers should be stored in DB - not transient. Changes
+    //triggered by change to candidateAnswerField
     private void populateTransientQuestionFields(QuestionTask qt) {
         final String field = qt.getCandidateAnswerField();
 
@@ -162,11 +164,14 @@ public class TaskServiceImpl implements TaskService {
             }
         } else if (field == null && qt.getExplicitAllowedAnswers() != null){
             //TODO JC This needs a review - can some logic go into the getAnswer method of QuestionTaskImpl?
-            
+
             //TODO JC I don't really understand what this is doing - create an issue for fixing this?
+            //It is saying that for properties, with explicit allowed answers,
+            // we need to set the allowed answers. Why? Why can't you just use the explicit allowed answers?
+
             // There is no answer field associated with question (it should be stored as a property)
             // but there are explicit allowed answers provided.
-            // We need to then set the allowed answers for to these explicit answers, 
+            // We need to then set the allowed answers for to these explicit answers,
             // so that they can be displayed in the front end.
             List<AllowedQuestionTaskAnswer> allowedAnswers = new ArrayList<>();
             for (String answer : qt.getExplicitAllowedAnswers()) {

--- a/server/src/main/java/org/tctalent/server/service/db/impl/TaskServiceImpl.java
+++ b/server/src/main/java/org/tctalent/server/service/db/impl/TaskServiceImpl.java
@@ -161,8 +161,13 @@ public class TaskServiceImpl implements TaskService {
                 qt.setAllowedAnswers(allowedAnswers);
             }
         } else if (field == null && qt.getExplicitAllowedAnswers() != null){
-            // There is no answer field associated with question (it should be stored as a property) but there are explicit allowed answers provided.
-            // We need to then set the allowed answers for to these explicit answers, so that they can be displayed in the front end.
+            //TODO JC This needs a review - can some logic go into the getAnswer method of QuestionTaskImpl?
+            
+            //TODO JC I don't really understand what this is doing - create an issue for fixing this?
+            // There is no answer field associated with question (it should be stored as a property)
+            // but there are explicit allowed answers provided.
+            // We need to then set the allowed answers for to these explicit answers, 
+            // so that they can be displayed in the front end.
             List<AllowedQuestionTaskAnswer> allowedAnswers = new ArrayList<>();
             for (String answer : qt.getExplicitAllowedAnswers()) {
                 allowedAnswers.add(new AllowedQuestionTaskAnswer(

--- a/server/src/main/java/org/tctalent/server/util/CandidateSearchUtils.java
+++ b/server/src/main/java/org/tctalent/server/util/CandidateSearchUtils.java
@@ -45,6 +45,8 @@ public abstract class CandidateSearchUtils {
             "candidate_job_experience on candidate.id = candidate_job_experience.candidate_id");
         tableJoins.put("candidate_language",
             "candidate_language on candidate.id = candidate_language.candidate_id");
+        tableJoins.put("candidate_saved_list",
+            "candidate_saved_list on candidate.id = candidate_saved_list.candidate_id");
         tableJoins.put("candidate_occupation",
             "candidate_occupation on candidate.id = candidate_occupation.candidate_id");
         tableJoins.put("country",

--- a/server/src/main/resources/db/migration/V1_400__make_attachment_location_always_a_url.sql
+++ b/server/src/main/resources/db/migration/V1_400__make_attachment_location_always_a_url.sql
@@ -1,0 +1,10 @@
+update candidate_attachment
+set location = concat('https://s3.us-east-1.amazonaws.com/files.tbbtalent.org/candidate/',
+      CASE WHEN migrated = true THEN
+               'migrated' ELSE
+               (select candidate_number from candidate where id = candidate_attachment.candidate_id)
+          END,
+      '/',
+      location
+   )
+where location not like 'https:%';

--- a/server/src/main/resources/db/migration/V1_400__make_attachment_location_always_a_url.sql
+++ b/server/src/main/resources/db/migration/V1_400__make_attachment_location_always_a_url.sql
@@ -7,4 +7,4 @@ set location = concat('https://s3.us-east-1.amazonaws.com/files.tbbtalent.org/ca
       '/',
       location
    )
-where location not like 'https:%';
+where type = 'file' and location not like 'https:%';

--- a/server/src/main/resources/db/migration/V1_401__add_candidate_review_item_version_trigger.sql
+++ b/server/src/main/resources/db/migration/V1_401__add_candidate_review_item_version_trigger.sql
@@ -21,3 +21,9 @@ drop trigger if exists candidate_review_item_bump_version on candidate_review_it
 create trigger candidate_review_item_bump_version
     after insert or update or delete on candidate_review_item
     for each row execute function bump_candidate_ref_version();
+
+-- Candidate review item
+drop trigger if exists task_assignment_bump_version on task_assignment;
+create trigger task_assignment_bump_version
+    after insert or update or delete on task_assignment
+    for each row execute function bump_candidate_ref_version();

--- a/server/src/main/resources/db/migration/V1_401__add_candidate_review_item_version_trigger.sql
+++ b/server/src/main/resources/db/migration/V1_401__add_candidate_review_item_version_trigger.sql
@@ -1,0 +1,23 @@
+-- Candidate coupon code
+drop trigger if exists candidate_coupon_code_bump_version on candidate_coupon_code;
+create trigger candidate_coupon_code_bump_version
+    after insert or update or delete on candidate_coupon_code
+    for each row execute function bump_candidate_ref_version();
+
+-- Candidate exam
+drop trigger if exists candidate_exam_bump_version on candidate_exam;
+create trigger candidate_exam_bump_version
+    after insert or update or delete on candidate_exam
+    for each row execute function bump_candidate_ref_version();
+
+-- Candidate property
+drop trigger if exists candidate_property_bump_version on candidate_property;
+create trigger candidate_property_bump_version
+    after insert or update or delete on candidate_property
+    for each row execute function bump_candidate_ref_version();
+
+-- Candidate review item
+drop trigger if exists candidate_review_item_bump_version on candidate_review_item;
+create trigger candidate_review_item_bump_version
+    after insert or update or delete on candidate_review_item
+    for each row execute function bump_candidate_ref_version();

--- a/server/src/test/java/org/tctalent/server/api/admin/CandidateAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/CandidateAdminApiTest.java
@@ -36,6 +36,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.tctalent.server.data.CandidateTestData.getCandidate;
+import static org.tctalent.server.data.CandidateTestData.getListOfCandidateDtos;
 import static org.tctalent.server.data.CandidateTestData.getListOfCandidates;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -66,6 +67,7 @@ import org.tctalent.server.model.db.CandidateDestination;
 import org.tctalent.server.model.db.CandidateVisaCheck;
 import org.tctalent.server.model.db.Country;
 import org.tctalent.server.model.db.Status;
+import org.tctalent.server.repository.db.read.dto.CandidateReadDto;
 import org.tctalent.server.request.candidate.CandidateEmailPhoneOrWhatsappSearchRequest;
 import org.tctalent.server.request.candidate.CandidateEmailSearchRequest;
 import org.tctalent.server.request.candidate.CandidateExternalIdSearchRequest;
@@ -138,6 +140,13 @@ class CandidateAdminApiTest extends ApiTestBase {
                     getListOfCandidates().size()
             );
 
+    private final Page<CandidateReadDto> candidateDtos =
+            new PageImpl<>(
+                    getListOfCandidateDtos(),
+                    PageRequest.of(0,10, Sort.unsorted()),
+                    getListOfCandidates().size()
+            );
+
     private final Candidate candidate = getCandidate();
 
     @MockBean
@@ -201,11 +210,11 @@ class CandidateAdminApiTest extends ApiTestBase {
         SearchCandidateRequest request = new SearchCandidateRequest();
 
         given(savedSearchService
-                .searchCandidates(any(SearchCandidateRequest.class)))
-                .willReturn(candidates);
+                .searchCandidateDtos(any(SearchCandidateRequest.class)))
+                .willReturn(candidateDtos);
 
         postSearchRequestAndVerifyResponse(SEARCH_PATH, objectMapper.writeValueAsString(request));
-        verify(savedSearchService).searchCandidates(any(SearchCandidateRequest.class));
+        verify(savedSearchService).searchCandidateDtos(any(SearchCandidateRequest.class));
     }
 
     @Test

--- a/server/src/test/java/org/tctalent/server/api/admin/SavedListCandidateAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/SavedListCandidateAdminApiTest.java
@@ -5,12 +5,12 @@
  * the terms of the GNU Affero General Public License as published by the Free
  * Software Foundation, either version 3 of the License, or any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT 
+ * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
  * for more details.
  *
- * You should have received a copy of the GNU Affero General Public License 
+ * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
@@ -66,10 +66,13 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.tctalent.server.api.dto.CandidateBuilderSelector;
 import org.tctalent.server.api.dto.DtoType;
 import org.tctalent.server.api.dto.SavedListBuilderSelector;
+import org.tctalent.server.data.CandidateTestData;
 import org.tctalent.server.model.db.Candidate;
 import org.tctalent.server.model.db.SavedList;
+import org.tctalent.server.repository.db.read.dto.CandidateReadDto;
 import org.tctalent.server.request.candidate.SavedListGetRequest;
 import org.tctalent.server.request.list.UpdateExplicitSavedListContentsRequest;
+import org.tctalent.server.service.db.CandidateDtoService;
 import org.tctalent.server.service.db.CandidateSavedListService;
 import org.tctalent.server.service.db.CandidateService;
 import org.tctalent.server.service.db.SavedListService;
@@ -105,6 +108,14 @@ class SavedListCandidateAdminApiTest extends ApiTestBase {
             1
         );
 
+    private static final List<CandidateReadDto> savedListCandidateDtos = CandidateTestData.getListOfCandidateDtos();
+    private static final Page<CandidateReadDto> savedListCandidateDtosPage =
+        new PageImpl<>(
+            savedListCandidateDtos,
+            PageRequest.of(0,10, Sort.unsorted()),
+            1
+        );
+
     @Autowired
     MockMvc mockMvc;
     @Autowired
@@ -120,6 +131,8 @@ class SavedListCandidateAdminApiTest extends ApiTestBase {
     CandidateSavedListService candidateSavedListService;
     @MockBean
     CandidateService candidateService;
+    @MockBean
+    CandidateDtoService candidateDtoService;
     @MockBean
     CandidateBuilderSelector candidateBuilderSelector;
     @MockBean
@@ -312,9 +325,9 @@ class SavedListCandidateAdminApiTest extends ApiTestBase {
 
         given(savedListService.get(anyLong()))
             .willReturn(savedList);
-        given(candidateService.getSavedListCandidates(any(SavedList.class), any(
+        given(savedListService.getSavedListCandidateDtos(any(SavedList.class), any(
             SavedListGetRequest.class)))
-            .willReturn(savedListCandidatesPage);
+            .willReturn(savedListCandidateDtosPage);
 
         mockMvc.perform(
                 post(BASE_PATH + "/123" + SEARCH_PAGED_PATH)
@@ -337,7 +350,7 @@ class SavedListCandidateAdminApiTest extends ApiTestBase {
         ;
 
         verify(savedListService).get(anyLong());
-        verify(candidateService).getSavedListCandidates(any(SavedList.class),
+        verify(savedListService).getSavedListCandidateDtos(any(SavedList.class),
             any(SavedListGetRequest.class));
     }
 

--- a/server/src/test/java/org/tctalent/server/api/admin/SavedSearchCandidateAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/SavedSearchCandidateAdminApiTest.java
@@ -5,12 +5,12 @@
  * the terms of the GNU Affero General Public License as published by the Free
  * Software Foundation, either version 3 of the License, or any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT 
+ * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
  * for more details.
  *
- * You should have received a copy of the GNU Affero General Public License 
+ * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
@@ -30,6 +30,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.tctalent.server.data.CandidateTestData.getListOfCandidateDtos;
 import static org.tctalent.server.data.CandidateTestData.getListOfCandidates;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -48,8 +49,11 @@ import org.springframework.data.domain.Sort;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.tctalent.server.api.dto.CandidateBuilderSelector;
+import org.tctalent.server.data.SavedListTestData;
 import org.tctalent.server.model.db.Candidate;
+import org.tctalent.server.repository.db.read.dto.CandidateReadDto;
 import org.tctalent.server.request.candidate.SavedSearchGetRequest;
+import org.tctalent.server.service.db.CandidateDtoService;
 import org.tctalent.server.service.db.CandidateService;
 import org.tctalent.server.service.db.SavedSearchService;
 import org.tctalent.server.util.dto.DtoBuilder;
@@ -76,10 +80,19 @@ class SavedSearchCandidateAdminApiTest extends ApiTestBase {
           1
       );
 
+  private final Page<CandidateReadDto> candidateReadDtoPage =
+      new PageImpl<>(
+          getListOfCandidateDtos(),
+          PageRequest.of(0, 10, Sort.unsorted()),
+          1
+      );
+
   @MockBean
   SavedSearchService savedSearchService;
   @MockBean
   CandidateService candidateService;
+  @MockBean
+  CandidateDtoService candidateDtoService;
   @MockBean
   CandidateBuilderSelector candidateBuilderSelector;
 
@@ -109,8 +122,12 @@ class SavedSearchCandidateAdminApiTest extends ApiTestBase {
     SavedSearchGetRequest request = new SavedSearchGetRequest();
 
     given(savedSearchService
-        .searchCandidates(anyLong(), any(SavedSearchGetRequest.class)))
-        .willReturn(candidatePage);
+        .searchCandidateDtos(anyLong(), any(SavedSearchGetRequest.class)))
+        .willReturn(candidateReadDtoPage);
+
+    given(savedSearchService
+        .getSelectionListForLoggedInUser(anyLong()))
+        .willReturn(SavedListTestData.getSavedList());
 
     mockMvc.perform(post(BASE_PATH + SEARCH_PAGED_PATH.replace("{id}", Long.toString(SAVED_SEARCH_ID)))
             .with(csrf())
@@ -129,10 +146,11 @@ class SavedSearchCandidateAdminApiTest extends ApiTestBase {
         .andExpect(jsonPath("$.hasNext", is(false)))
         .andExpect(jsonPath("$.content", notNullValue()))
         .andExpect(jsonPath("$.content[0].selected", is(false)))
-        .andExpect(jsonPath("$.content[0].status", is("draft")));
+        .andExpect(jsonPath("$.content[0].status", is("draft")))
+    ;
 
-  verify(savedSearchService).searchCandidates(anyLong(), any(SavedSearchGetRequest.class));
-  verify(savedSearchService).setCandidateContext(anyLong(), any(Page.class));
+  verify(savedSearchService).searchCandidateDtos(anyLong(), any(SavedSearchGetRequest.class));
+  verify(candidateDtoService).populateComputedFields(any(), any());
   }
 
   @Test

--- a/server/src/test/java/org/tctalent/server/data/CandidateTestData.java
+++ b/server/src/test/java/org/tctalent/server/data/CandidateTestData.java
@@ -73,6 +73,8 @@ import org.tctalent.server.model.db.User;
 import org.tctalent.server.model.db.VisaEligibility;
 import org.tctalent.server.model.db.YesNo;
 import org.tctalent.server.model.db.YesNoUnsure;
+import org.tctalent.server.repository.db.read.dto.CandidateReadDto;
+import org.tctalent.server.repository.db.read.dto.UserReadDto;
 
 public class CandidateTestData {
 
@@ -83,6 +85,14 @@ public class CandidateTestData {
             "test.candidate1@some.thing",
             Role.user);
 
+    private static final UserReadDto candidate1userdto =
+        UserReadDto.builder()
+            .username("candidate1")
+            .firstName("test")
+            .lastName("candidate1")
+            .email("test.candidate1@some.thing")
+            .build();
+
     private static final User candidate2user =
         new User("candidate2",
             "test",
@@ -90,12 +100,28 @@ public class CandidateTestData {
             "test.candidate2@some.thing",
             Role.user);
 
+    private static final UserReadDto candidate2userdto =
+        UserReadDto.builder()
+            .username("candidate2")
+            .firstName("test")
+            .lastName("candidate2")
+            .email("test.candidate2@some.thing")
+            .build();
+
     private static final User candidate3user =
         new User("candidate3",
             "test",
             "candidate3",
             "test.candidate3@some.thing",
             Role.user);
+
+    private static final UserReadDto candidate3userdto =
+        UserReadDto.builder()
+            .username("candidate3")
+            .firstName("test")
+            .lastName("candidate3")
+            .email("test.candidate3@some.thing")
+            .build();
 
     public static Candidate getCandidate() {
         Candidate candidate = new Candidate(
@@ -132,6 +158,17 @@ public class CandidateTestData {
             new Candidate(candidate1user, "+123-456-789", "+123-456-789", getAuditUser()),
             new Candidate(candidate2user, "+234-567-890", "+123-456-789", getAuditUser()),
             new Candidate(candidate3user, "+345-678-901", "+345-678-901", getAuditUser())
+        );
+    }
+
+    public static List<CandidateReadDto> getListOfCandidateDtos() {
+        return List.of(
+            CandidateReadDto.builder()
+                .user(candidate1userdto).phone("+123-456-789").whatsapp("+123-456-789").build(),
+            CandidateReadDto.builder()
+                .user(candidate2userdto).phone("+234-567-890").whatsapp("+123-456-789").build(),
+            CandidateReadDto.builder()
+                .user(candidate3userdto).phone("+345-678-901").whatsapp("+345-678-901").build()
         );
     }
 

--- a/server/src/test/java/org/tctalent/server/data/CandidateTestData.java
+++ b/server/src/test/java/org/tctalent/server/data/CandidateTestData.java
@@ -165,13 +165,13 @@ public class CandidateTestData {
         return List.of(
             CandidateReadDto.builder()
                 .user(candidate1userdto).phone("+123-456-789").whatsapp("+123-456-789")
-                .nationality(CountryTestData.PAKISTAN_DTO).build(),
+                .status(CandidateStatus.draft).nationality(CountryTestData.PAKISTAN_DTO).build(),
             CandidateReadDto.builder()
                 .user(candidate2userdto).phone("+234-567-890").whatsapp("+123-456-789")
-                .nationality(CountryTestData.PAKISTAN_DTO).build(),
+                .status(CandidateStatus.draft).nationality(CountryTestData.PAKISTAN_DTO).build(),
             CandidateReadDto.builder()
                 .user(candidate3userdto).phone("+345-678-901").whatsapp("+345-678-901")
-                .nationality(CountryTestData.PAKISTAN_DTO).build()
+                .status(CandidateStatus.draft).nationality(CountryTestData.PAKISTAN_DTO).build()
         );
     }
 

--- a/server/src/test/java/org/tctalent/server/data/CandidateTestData.java
+++ b/server/src/test/java/org/tctalent/server/data/CandidateTestData.java
@@ -164,11 +164,14 @@ public class CandidateTestData {
     public static List<CandidateReadDto> getListOfCandidateDtos() {
         return List.of(
             CandidateReadDto.builder()
-                .user(candidate1userdto).phone("+123-456-789").whatsapp("+123-456-789").build(),
+                .user(candidate1userdto).phone("+123-456-789").whatsapp("+123-456-789")
+                .nationality(CountryTestData.PAKISTAN_DTO).build(),
             CandidateReadDto.builder()
-                .user(candidate2userdto).phone("+234-567-890").whatsapp("+123-456-789").build(),
+                .user(candidate2userdto).phone("+234-567-890").whatsapp("+123-456-789")
+                .nationality(CountryTestData.PAKISTAN_DTO).build(),
             CandidateReadDto.builder()
-                .user(candidate3userdto).phone("+345-678-901").whatsapp("+345-678-901").build()
+                .user(candidate3userdto).phone("+345-678-901").whatsapp("+345-678-901")
+                .nationality(CountryTestData.PAKISTAN_DTO).build()
         );
     }
 

--- a/server/src/test/java/org/tctalent/server/data/CountryTestData.java
+++ b/server/src/test/java/org/tctalent/server/data/CountryTestData.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Set;
 import org.tctalent.server.model.db.Country;
 import org.tctalent.server.model.db.Status;
+import org.tctalent.server.repository.db.read.dto.CountryReadDto;
 
 public class CountryTestData {
 
@@ -30,6 +31,13 @@ public class CountryTestData {
     public static final Country JORDAN = new Country("Jordan", Status.active);
     public static final Country PAKISTAN = new Country("Pakistan", Status.active);
     public static final Country COSTA_RICA = new Country("Costa Rica", Status.active);
+
+    public static final CountryReadDto LEBANON_DTO = CountryReadDto.builder()
+        .name("Lebanon").status(Status.active).build();
+    public static final CountryReadDto JORDAN_DTO = CountryReadDto.builder()
+        .name("Jordan").status(Status.active).build();
+    public static final CountryReadDto PAKISTAN_DTO = CountryReadDto.builder()
+        .name("Pakistan").status(Status.active).build();
 
     public static List<Country> getSourceCountryList() {
         return new ArrayList<>(List.of(LEBANON, JORDAN));

--- a/server/src/test/java/org/tctalent/server/repository/db/read/sql/SqlJsonQueryBuilderTest.java
+++ b/server/src/test/java/org/tctalent/server/repository/db/read/sql/SqlJsonQueryBuilderTest.java
@@ -17,15 +17,33 @@
 package org.tctalent.server.repository.db.read.sql;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.tctalent.server.repository.db.read.annotation.SqlColumn;
+import org.tctalent.server.repository.db.read.annotation.SqlDefaults;
+import org.tctalent.server.repository.db.read.annotation.SqlTable;
 import org.tctalent.server.repository.db.read.dto.CandidateReadDto;
 
 class SqlJsonQueryBuilderTest {
 
+    @Getter
+    @Setter
+    @SqlTable(name="candidate", alias = "c")
+    @SqlDefaults(mapUnannotatedColumns = true)
+    static class SampleDto {
+        @SqlColumn(transform = "to_jsonb(string_to_array(%s, ','))")
+        private List<String> names;
+        private String somethingElse;
+    }
+
+
     SqlJsonQueryBuilder sqlJsonQueryBuilder;
-    
+
     @BeforeEach
     void setUp() {
         sqlJsonQueryBuilder = new SqlJsonQueryBuilder();
@@ -35,6 +53,18 @@ class SqlJsonQueryBuilderTest {
     void buildByIdsQuery() {
         final String sql = sqlJsonQueryBuilder.buildByIdsQuery(CandidateReadDto.class, "ids");
         System.out.println(sql);
+    }
+
+    @Test
+    void SqlColumnTransforms_are_applied() {
+        final String sql = sqlJsonQueryBuilder.buildByIdsQuery(SampleDto.class, "ids");
+        String expected = """
+            select
+              c.id,
+              jsonb_build_object('names', to_jsonb(string_to_array(c.names, ',')), 'somethingElse', c.something_else) as json
+            from candidate c
+            where c.id in (:ids)""";
+        assertEquals(expected, sql);
     }
 
     @Test

--- a/ui/admin-portal/src/app/components/candidates/show/candidate-source-base.ts
+++ b/ui/admin-portal/src/app/components/candidates/show/candidate-source-base.ts
@@ -57,8 +57,9 @@ export class CandidateSourceBaseComponent {
   @Input() candidateSource: CandidateSource;
   //Temporary - todo to be removed when we no longer use Elasticsearch or CandidateSpecifications
   @Input() useOldSearch: boolean;
-  //Temporary - todo to be removed when we always use fast search.
-  @Input() useFastSearch: boolean;
+
+  //Temporary - todo to be removed when we no longer use old fetching
+  useOldFetch: boolean = false;
 
   selectedFields: CandidateFieldInfo[] = [];
 
@@ -166,11 +167,8 @@ export class CandidateSourceBaseComponent {
     const request = this.createSearchRequest(keyword, showClosedOpps);
     request.dtoType = dtoType;
 
-    //todo jc This is where we could flag fast retrieval for both lists and searches
-    request.useCachedDtos = this.useFastSearch;
-
     // Return the observable so the caller can subscribe to it
-    return this.candidateSourceCandidateService.searchPaged(this.candidateSource, request).pipe(
+    return this.candidateSourceCandidateService.searchPaged(this.candidateSource, request, this.useOldFetch).pipe(
       tap(results => {
         this.results = results;
         this.cacheResults();

--- a/ui/admin-portal/src/app/components/candidates/show/candidate-source-base.ts
+++ b/ui/admin-portal/src/app/components/candidates/show/candidate-source-base.ts
@@ -166,6 +166,9 @@ export class CandidateSourceBaseComponent {
     const request = this.createSearchRequest(keyword, showClosedOpps);
     request.dtoType = dtoType;
 
+    //todo jc This is where we could flag fast retrieval for both lists and searches
+    request.useCachedDtos = this.useFastSearch;
+
     // Return the observable so the caller can subscribe to it
     return this.candidateSourceCandidateService.searchPaged(this.candidateSource, request).pipe(
       tap(results => {

--- a/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.html
+++ b/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.html
@@ -234,6 +234,10 @@
 
   <div class="results-area">
 
+    <div class="col text-center">
+      <input type="checkbox" [checked]="useOldFetch"
+             (change)="toggleFetch()"> Old fetch
+    </div>
 
     <!-- Review status -->
     <div *ngIf="isReviewable()" class="mt-3">

--- a/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.ts
+++ b/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.ts
@@ -433,8 +433,6 @@ export class ShowCandidatesComponent extends CandidateSourceBaseComponent implem
     this.searching = true;
     const request = this.searchRequest;
 
-    //todo jc Display a text sort toggle if there is a query string
-
     console.log("applying search request: Old = " + request.useOldSearch);
 
     //Guard against the case where we have a text sort where there is no query string.
@@ -459,7 +457,7 @@ export class ShowCandidatesComponent extends CandidateSourceBaseComponent implem
     request.sortDirection = this.sortDirection;
     request.dtoType = this.searchDetail;
 
-    this.subscription = this.candidateService.search(request).subscribe(
+    this.subscription = this.candidateService.search(request, this.useOldFetch).subscribe(
       results => {
         this.results = results;
         this.cacheResults();

--- a/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.ts
+++ b/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.ts
@@ -374,11 +374,8 @@ export class ShowCandidatesComponent extends CandidateSourceBaseComponent implem
     }
 
     //Redo existing search if the type of search changes
-    if (changes.useOldSearch || changes.useFastSearch) {
+    if (changes.useOldSearch) {
       if (this.searchRequest) {
-        if (changes.useFastSearch) {
-          this.searchRequest.useFastSearch = changes.useFastSearch.currentValue ;
-        }
         if (changes.useOldSearch) {
           this.searchRequest.useOldSearch = changes.useOldSearch.currentValue ;
         }
@@ -438,7 +435,7 @@ export class ShowCandidatesComponent extends CandidateSourceBaseComponent implem
 
     //todo jc Display a text sort toggle if there is a query string
 
-    console.log("applying search request: Fast = " + request.useFastSearch + ", Old = " + request.useOldSearch);
+    console.log("applying search request: Old = " + request.useOldSearch);
 
     //Guard against the case where we have a text sort where there is no query string.
     let queryString = request.simpleQueryString;
@@ -551,6 +548,11 @@ export class ShowCandidatesComponent extends CandidateSourceBaseComponent implem
   }
 
   onReviewStatusChange() {
+    this.doSearch(true);
+  }
+
+  toggleFetch() {
+    this.useOldFetch = !this.useOldFetch;
     this.doSearch(true);
   }
 

--- a/ui/admin-portal/src/app/components/candidates/view/tab/candidate-visa-tab/job/candidate-visa-job.component.ts
+++ b/ui/admin-portal/src/app/components/candidates/view/tab/candidate-visa-tab/job/candidate-visa-job.component.ts
@@ -192,7 +192,7 @@ export class CandidateVisaJobComponent implements OnInit {
   fetchCandidateOppIdForJob(jobId: number): number {
     if (this.hasJobOpps) {
       return this.candidate.candidateOpportunities.find(
-        co => co.jobOpp.id === jobId).id;
+        co => co.jobOpp?.id === jobId)?.id;
     }
   }
 

--- a/ui/admin-portal/src/app/components/search/define-search/define-search.component.html
+++ b/ui/admin-portal/src/app/components/search/define-search/define-search.component.html
@@ -908,10 +908,6 @@
               <input type="checkbox" [checked]="useOldSearch" [disabled]="!searchRequest"
                      (change)="useOldSearch = !useOldSearch"> Use old way of searching
             </div>
-            <div class="col text-center">
-              <input type="checkbox" [checked]="useFastSearch" [disabled]="!searchRequest"
-                     (change)="useFastSearch = !useFastSearch"> Use fast way of searching
-            </div>
           </div>
         </div>
 
@@ -923,7 +919,6 @@
 
   <app-show-candidates *ngIf="!error && !loading"
                        [useOldSearch]="useOldSearch"
-                       [useFastSearch]="useFastSearch"
                        [isKeywordSearch]="!isEmptySearchTerms()"
                        [candidateSource]="savedSearch"
                        [pageNumber]="pageNumber"

--- a/ui/admin-portal/src/app/components/search/define-search/define-search.component.ts
+++ b/ui/admin-portal/src/app/components/search/define-search/define-search.component.ts
@@ -127,7 +127,6 @@ export class DefineSearchComponent implements OnInit, OnChanges, AfterViewInit {
   error: any;
   loading: boolean;
   useOldSearch: boolean;
-  useFastSearch: boolean;
   searchForm: UntypedFormGroup;
   showSearchRequest: boolean = false;
   results: SearchResults<Candidate>;
@@ -423,7 +422,6 @@ export class DefineSearchComponent implements OnInit, OnChanges, AfterViewInit {
     request.sortDirection = this.sortDirection;
 
     request.useOldSearch = this.useOldSearch;
-    request.useFastSearch = this.useFastSearch;
 
     //Note that just changing searchRequest triggers the display of the results
     //See the html of this component, for which app-show-candidates takes

--- a/ui/admin-portal/src/app/model/opportunity.ts
+++ b/ui/admin-portal/src/app/model/opportunity.ts
@@ -65,6 +65,10 @@ export function getOpportunityStageName(opp: Opportunity): string {
 export function getStageBadgeColor(opp: Opportunity): BadgeColor {
   //Need to select the appropriate stage's badge color - depending on whether opp is a candidate or
   // job opportunity.
+  //Handle bad data.
+  if (!opp) {
+    return "gray";
+  }
   if (isCandidateOpportunity(opp)) {
     return getCandidateOppStageBadgeColor(opp);
   }

--- a/ui/admin-portal/src/app/model/search-candidate-request.ts
+++ b/ui/admin-portal/src/app/model/search-candidate-request.ts
@@ -18,7 +18,6 @@ import {SavedSearchJoin} from './saved-search';
 
 export interface SearchCandidateRequest {
   useOldSearch?: boolean;
-  useFastSearch?: boolean;
   simpleQueryString?: string;
   keyword?: string;
   gender?: string;

--- a/ui/admin-portal/src/app/services/candidate-source-candidate.service.spec.ts
+++ b/ui/admin-portal/src/app/services/candidate-source-candidate.service.spec.ts
@@ -111,7 +111,7 @@ describe('CandidateSourceCandidateService', () => {
 
       (service as any).isSavedSearch.and.returnValue(false);
 
-      service.searchPaged(source, request).subscribe(response => {
+      service.searchPaged(source, request, false).subscribe(response => {
         expect(response).toEqual(mockResponse);
       });
 

--- a/ui/admin-portal/src/app/services/candidate-source-candidate.service.ts
+++ b/ui/admin-portal/src/app/services/candidate-source-candidate.service.ts
@@ -51,14 +51,13 @@ export class CandidateSourceCandidateService {
       `${apiUrl}/${source.id}/search`, request)
   }
 
-  searchPaged(source: CandidateSource, request: SearchCandidateSourcesRequest):
+  searchPaged(source: CandidateSource, request: SearchCandidateSourcesRequest, useOldFetch: boolean):
     Observable<SearchResults<Candidate>> {
 
     const apiUrl = isSavedSearch(source) ?
       this.savedSearchApiUrl : this.savedListApiUrl;
-    //todo hack the fast search for lists.
     let suffix = "search-paged";
-    if (!isSavedSearch(source)) suffix = 'search-paged-fast'
+    if (useOldFetch) suffix = 'search-paged-old-fetch'
     return this.http.post<SearchResults<Candidate>>(
       `${apiUrl}/${source.id}/${suffix}`, request)
   }

--- a/ui/admin-portal/src/app/services/candidate-source-candidate.service.ts
+++ b/ui/admin-portal/src/app/services/candidate-source-candidate.service.ts
@@ -56,8 +56,11 @@ export class CandidateSourceCandidateService {
 
     const apiUrl = isSavedSearch(source) ?
       this.savedSearchApiUrl : this.savedListApiUrl;
+    //todo hack the fast search for lists.
+    let suffix = "search-paged";
+    if (!isSavedSearch(source)) suffix = 'search-paged-fast'
     return this.http.post<SearchResults<Candidate>>(
-      `${apiUrl}/${source.id}/search-paged`, request)
+      `${apiUrl}/${source.id}/${suffix}`, request)
   }
 
   export(source: CandidateSource, request: PagedSearchRequest) {

--- a/ui/admin-portal/src/app/services/candidate.service.spec.ts
+++ b/ui/admin-portal/src/app/services/candidate.service.spec.ts
@@ -55,7 +55,7 @@ describe('CandidateService', () => {
     const dummyRequest = {};
     const dummyResponse: SearchResults<Candidate> = { content: [], totalElements: 0 } as SearchResults<Candidate>;
 
-    service.search(dummyRequest).subscribe(response => {
+    service.search(dummyRequest, false).subscribe(response => {
       expect(response).toEqual(dummyResponse);
     });
 

--- a/ui/admin-portal/src/app/services/candidate.service.ts
+++ b/ui/admin-portal/src/app/services/candidate.service.ts
@@ -57,10 +57,10 @@ export class CandidateService implements IntakeService {
 
   constructor(private http: HttpClient) {}
 
-  search(request): Observable<SearchResults<Candidate>> {
+  search(request, useOldFetch: boolean): Observable<SearchResults<Candidate>> {
     let suffix = "search";
-    if (request.useFastSearch) {
-      suffix += "-fast";
+    if (useOldFetch) {
+      suffix += "-old-fetch";
     }
     return this.http.post<SearchResults<Candidate>>(`${this.apiUrl}/${suffix}`, request);
   }


### PR DESCRIPTION
This introduces separate API end points and associated service methods which duplicate the standard Search and List end points with copies which use the cached candidate json to fetch dtos directly, rather than entities.

On the Angular side there is a useOldFetch flag which allows the user to switch back and forward between using the new (faster) api end points and the standard endpoints which use entities.

The default is to use the fast fetching.

Getting this going involved fixing some other issues around constructing the new Json objects from the new "ReadDto"s.

There are a lot of changes - but essentially that is what is going on.
