### PR TITLE
3007 Prevent candidate detail panel opening on icon click

### DIFF
--- a/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.html
+++ b/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.html
@@ -584,7 +584,7 @@
                 </tc-icon>
               </div>
             </td>
-            <td>
+            <td (click)="$event.stopPropagation()">
               <div class="d-flex align-items-center gap-1">
                 <a [routerLink]="['/candidate',candidate.candidateNumber]">{{candidate.candidateNumber}}</a>
                 <a target="_blank" [routerLink]="['/candidate',candidate.candidateNumber]">


### PR DESCRIPTION
Added click event propagation prevention to the candidate number/icons cell so links and icons no longer trigger row selection, while clicks elsewhere on the row still open the candidate detail card