### PR TITLE
Upgrade upload-artifact action to version 4 in CI workflows

### DIFF
--- a/.github/workflows/tc-prod-build-deploy.yml
+++ b/.github/workflows/tc-prod-build-deploy.yml
@@ -46,7 +46,7 @@ jobs:
           SF_PRIVATE_KEY: ${{ secrets.SF_PRIVATE_KEY }}
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: server-build
           path: server/build/libs/*.jar

--- a/.github/workflows/tc-test-build-deploy.yml
+++ b/.github/workflows/tc-test-build-deploy.yml
@@ -46,7 +46,7 @@ jobs:
           SF_PRIVATE_KEY: ${{ secrets.SF_PRIVATE_KEY }}
       
       - name: Upload build artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: server-build
           path: server/build/libs/*.jar


### PR DESCRIPTION
This PR updates the GitHub Actions workflows to use a newer version of the artifact upload action. The previous version has benn deprecated by GitHub.

