### PR TITLE
3008 Add won/closed to candidate opportunity DTOs for admin portal

### DIFF
--- a/server/src/main/java/org/tctalent/server/api/admin/CandidateOpportunityAdminApi.java
+++ b/server/src/main/java/org/tctalent/server/api/admin/CandidateOpportunityAdminApi.java
@@ -118,6 +118,7 @@ public class CandidateOpportunityAdminApi implements ITableApi<SearchCandidateOp
             .add("sfId")
             .add("candidate", shortCandidateDto())
             .add("closed")
+            .add("won")
             .add("closingComments")
             .add("closingCommentsForCandidate")
             .add("employerFeedback")

--- a/server/src/main/java/org/tctalent/server/api/dto/CandidateBuilderSelector.java
+++ b/server/src/main/java/org/tctalent/server/api/dto/CandidateBuilderSelector.java
@@ -380,6 +380,8 @@ public class CandidateBuilderSelector {
             .add("candidate", shortCandidateDto())
             .add("name")
             .add("stage")
+            .add("closed")
+            .add("won")
             .add("nextStep")
             .add("nextStepDueDate")
             ;

--- a/server/src/main/java/org/tctalent/server/repository/db/read/dto/CandidateOpportunityReadDto.java
+++ b/server/src/main/java/org/tctalent/server/repository/db/read/dto/CandidateOpportunityReadDto.java
@@ -36,6 +36,7 @@ import org.tctalent.server.repository.db.read.annotation.SqlTable;
 public class CandidateOpportunityReadDto {
     @JsonOneToOne(joinColumn = "candidate_id")
     private ShortCandidateReadDto candidate;
+    private Boolean closed;
     private String closingComments;
     private String closingCommentsForCandidate;
     @JsonOneToOne(joinColumn = "created_by")
@@ -55,4 +56,5 @@ public class CandidateOpportunityReadDto {
     @JsonOneToOne(joinColumn = "updated_by")
     private UserReadDto updatedBy;
     private OffsetDateTime updatedDate;
+    private Boolean won;
 }


### PR DESCRIPTION
The Admin UI relies on the `won` and `closed` flags for badge color, filtering, and edit logic, but these fields were missing from the candidate opportunity DTOs returned by admin endpoints, causing them to be undefined in Angular.

I exposed `won` and `closed` in the server-side DTOs instead of computing them on the client, since they are already derived from stage on the server and stored in the DB, ensuring a single source of truth and keeping the UI simpler.

I added won/closed to the candidate opportunity DTO in `CandidateBuilderSelector.java`, added won to the admin candidate opportunity DTO in `CandidateOpportunityAdminApi.java` (as closed already existed), and added won/closed to `CandidateOpportunityReadDto` so the search DTO mapping works correctly.