### PR TITLE
3075 post service deployment testing and extra params check

### DIFF
--- a/infra/aws/terraform/network.tf
+++ b/infra/aws/terraform/network.tf
@@ -12,7 +12,7 @@ module "vpc" {
 
   create_database_subnet_group           = true
   create_database_subnet_route_table     = true
-  create_database_internet_gateway_route = true
+  create_database_internet_gateway_route = false
 
   enable_nat_gateway = false
   enable_vpn_gateway = false

--- a/infra/aws/terraform/opc-prod/main.tf
+++ b/infra/aws/terraform/opc-prod/main.tf
@@ -194,10 +194,8 @@ module "tc-plus-prod" {
   ecs_tasks_count = 2
 
   # Database configuration
-  # RDS creates a local database (tcplus), but the service currently connects to the
-  # legacy TBB database via spring_datasource_url below. When ready to cut over to the
-  # local RDS instance, remove spring_datasource_url and the auto-populate logic will
-  # use the RDS endpoint instead.
+  # RDS creates a local database (tcplus), but the service currently connects to the legacy TBB
+  # database via spring_datasource_url below. It does not currently connect  to the OPC RDS instance.
   db_enable              = true
   db_public_access       = false
   db_multi_az            = true

--- a/infra/aws/terraform/opc-prod/main.tf
+++ b/infra/aws/terraform/opc-prod/main.tf
@@ -194,6 +194,10 @@ module "tc-plus-prod" {
   ecs_tasks_count = 2
 
   # Database configuration
+  # RDS creates a local database (tcplus), but the service currently connects to the
+  # legacy TBB database via spring_datasource_url below. When ready to cut over to the
+  # local RDS instance, remove spring_datasource_url and the auto-populate logic will
+  # use the RDS endpoint instead.
   db_enable              = true
   db_public_access       = false
   db_multi_az            = true
@@ -235,6 +239,7 @@ module "tc-plus-prod" {
   sf_base_lightning_url                  = "https://talentbeyondboundaries.lightning.force.com"  # todo: either create for OPC or decouple TC+ from SF
   sf_base_login_url                      = "https://login.salesforce.com/"  # todo: either create for OPC or decouple TC+ from SF
   spring_client_url                      = "-" # todo: confirm if used/needed
+  spring_datasource_url                  = "jdbc:postgresql://prod-tbb.cskpt7osayvj.us-east-1.rds.amazonaws.com:5432/tctalent" # legacy TBB DB -- remove when cutting over to local RDS
   spring_datasource_username             = "tctalent"
   spring_db_pool_max                     = "50"
   spring_db_pool_min                     = "20"

--- a/infra/aws/terraform/opc-prod/main.tf
+++ b/infra/aws/terraform/opc-prod/main.tf
@@ -219,7 +219,7 @@ module "tc-plus-prod" {
 
   # SSM-backed application parameters (stored in SSM, injected into ECS task)
   # Non-secrets: provided directly here
-  s3_bucket                              = "opc-talentcatalog-prod" # todo: confirm bucket name
+  s3_bucket                              = "files.tbbtalent.org" # todo: confirm bucket name
   environment                            = "opc-prod"
   email_default                          = ""  # todo: confirm if used/needed
   email_test_override                    = "-"  # todo: set prod value

--- a/infra/aws/terraform/opc-prod/main.tf
+++ b/infra/aws/terraform/opc-prod/main.tf
@@ -245,7 +245,7 @@ module "tc-plus-prod" {
   spring_db_pool_min                     = "20"
   spring_servlet_max_file_size           = "10MB"
   spring_servlet_max_request_size        = "10MB"
-  tc_api_url                             = "https://api.tctalent.org"  # todo: set TC API URL
+  tc_api_url                             = "https://api.plus.tctalent.org"  # todo: set TC API URL
   tc_cors_urls                           = "https://tctalent.org"  # todo: set prod CORS URLs
   tc_db_copy_config                      = "data.sharing/tcCopies.xml" # todo: can this be retired?
   tc_destinations                        = "Australia,Canada,New Zealand,United Kingdom"  # todo: set TC destinations

--- a/infra/aws/terraform/opc-staging/main.tf
+++ b/infra/aws/terraform/opc-staging/main.tf
@@ -194,6 +194,10 @@ module "tc-plus-staging" {
   ecs_tasks_count = 2
 
   # Database configuration
+  # RDS creates a local database (tcplus), but the service currently connects to the
+  # legacy TBB database via spring_datasource_url below. When ready to cut over to the
+  # local RDS instance, remove spring_datasource_url and the auto-populate logic will
+  # use the RDS endpoint instead.
   db_enable              = true
   db_public_access       = false
   db_multi_az            = false
@@ -235,6 +239,7 @@ module "tc-plus-staging" {
   sf_base_lightning_url                  = "https://talentbeyondboundaries--sfstaging.sandbox.lightning.force.com"  # todo: either create for OPC or decouple TC+ from SF
   sf_base_login_url                      = "https://test.salesforce.com/"  # todo: either create for OPC or decouple TC+ from SF
   spring_client_url                      = "-" # todo: confirm if used/needed
+  spring_datasource_url                  = "jdbc:postgresql://tbbtalent-prod.cy7icd7y1lyr.us-east-1.rds.amazonaws.com:5432/tctalent" # legacy TBB DB -- in parallel to local RDS
   spring_datasource_username             = "tctalent"
   spring_db_pool_max                     = "50"
   spring_db_pool_min                     = "20"

--- a/infra/aws/terraform/opc-staging/main.tf
+++ b/infra/aws/terraform/opc-staging/main.tf
@@ -191,7 +191,7 @@ module "tc-plus-staging" {
   site_domain     = "test.plus.tctalent.org"
   container_image = "164804461258.dkr.ecr.eu-west-2.amazonaws.com/tc-core:tc-plus-staging"
   container_port  = 8080
-  ecs_tasks_count = 2
+  ecs_tasks_count = 1
 
   # Database configuration
   # RDS creates a local database (tcplus), but the service currently connects to the

--- a/infra/aws/terraform/opc-staging/main.tf
+++ b/infra/aws/terraform/opc-staging/main.tf
@@ -249,7 +249,7 @@ module "tc-plus-staging" {
   tc_cors_urls                           = "https://test.plus.tctalent.org,https://*.d2jx6ziu0w8kq9.amplifyapp.com,https://*.d1bt868vpd541m.amplifyapp.com"
   tc_db_copy_config                      = "data.sharing/tcCopies.xml" # todo: can this be retired?
   tc_destinations                        = "Australia,Canada,New Zealand,United Kingdom"  # todo: set TC destinations
-  tc_skills_extraction_api_url           = "https://skills.plus.tctalent.org"
+  tc_skills_extraction_api_url           = "https://test.skills.plus.tctalent.org"
   web_admin                              = "https://test.plus.tctalent.org/admin-portal"
   web_portal                             = "https://test.plus.tctalent.org/candidate-portal"
 

--- a/infra/aws/terraform/opc-staging/main.tf
+++ b/infra/aws/terraform/opc-staging/main.tf
@@ -219,7 +219,7 @@ module "tc-plus-staging" {
 
   # SSM-backed application parameters (stored in SSM, injected into ECS task)
   # Non-secrets: provided directly here
-  s3_bucket                              = "opc-talentcatalog-staging" # todo: confirm bucket name
+  s3_bucket                              = "files.tbbtalent.org" # todo: confirm bucket name
   environment                            = "opc-staging"
   email_default                          = "UPDATE_DEFAULT_EMAIL_HERE"  # todo: confirm if used/needed
   email_test_override                    = "john@cameronfoundation.org" # todo: change to shared address

--- a/infra/aws/terraform/opc-staging/main.tf
+++ b/infra/aws/terraform/opc-staging/main.tf
@@ -194,10 +194,8 @@ module "tc-plus-staging" {
   ecs_tasks_count = 1
 
   # Database configuration
-  # RDS creates a local database (tcplus), but the service currently connects to the
-  # legacy TBB database via spring_datasource_url below. When ready to cut over to the
-  # local RDS instance, remove spring_datasource_url and the auto-populate logic will
-  # use the RDS endpoint instead.
+  # RDS creates a local database (tcplus), but the service currently connects to the legacy TBB
+  # database via spring_datasource_url below. It does not currently connect  to the OPC RDS instance.
   db_enable              = true
   db_public_access       = false
   db_multi_az            = false

--- a/infra/aws/terraform/parameters.tf
+++ b/infra/aws/terraform/parameters.tf
@@ -257,7 +257,9 @@ resource "aws_ssm_parameter" "spring_datasource_password" {
 resource "aws_ssm_parameter" "spring_datasource_url" {
   name  = "/${var.app}/${var.env}/SPRING_DATASOURCE_URL"
   type  = "String"
-  value = var.db_enable ? "jdbc:postgresql://${module.database[0].db_instance_endpoint}/tbbtalent" : var.spring_datasource_url
+  # Explicit spring_datasource_url takes precedence (e.g. connecting to legacy external TC DB).
+  # Falls back to auto-populated RDS endpoint when db_enable=true and no explicit URL is provided.
+  value = var.spring_datasource_url != "" ? var.spring_datasource_url : (var.db_enable ? "jdbc:postgresql://${module.database[0].db_instance_endpoint}/${var.db_name}" : "")
 }
 
 resource "aws_ssm_parameter" "spring_datasource_username" {

--- a/infra/aws/terraform/variables.tf
+++ b/infra/aws/terraform/variables.tf
@@ -88,7 +88,7 @@ variable "db_major_engine_version" {
 variable "db_name" {
   type        = string
   description = "The name of the database to create (alphanumeric only)"
-  default     = "tbbtalent"
+  default     = "tctalent"
 }
 
 variable "db_backup_retention_days" {

--- a/ui/admin-portal/src/app/services/env.service.ts
+++ b/ui/admin-portal/src/app/services/env.service.ts
@@ -79,7 +79,19 @@ export class EnvService {
       this._allCandidatesDashboardId = '86f9d8cb-44a9-48fc-b516-eab1f87fc097';
       this._presetWorkspaceId = '987e2e02';
 
+    } else if ((/^test.plus.tctalent.org/.test(hostname))) {
+      this._env = Environment.Staging;
+      this._sfLightningUrl = 'https://talentbeyondboundaries--sfstaging.sandbox.lightning.force.com/';
+      this._allCandidatesDashboardId = '86f9d8cb-44a9-48fc-b516-eab1f87fc097';
+      this._presetWorkspaceId = '987e2e02';
+
     } else if ((/^tctalent.org/.test(hostname))) {
+      this._env = Environment.Prod;
+      this._sfLightningUrl = 'https://talentbeyondboundaries.lightning.force.com/';
+      this._allCandidatesDashboardId = '3d577f48-a4db-4e7d-95ed-6590d76829cc';
+      this._presetWorkspaceId = 'effaaec0';
+
+    } else if ((/^plus.tctalent.org/.test(hostname))) {
       this._env = Environment.Prod;
       this._sfLightningUrl = 'https://talentbeyondboundaries.lightning.force.com/';
       this._allCandidatesDashboardId = '3d577f48-a4db-4e7d-95ed-6590d76829cc';

--- a/ui/admin-portal/src/app/services/env.service.ts
+++ b/ui/admin-portal/src/app/services/env.service.ts
@@ -73,25 +73,25 @@ export class EnvService {
       this._allCandidatesDashboardId =  '86f9d8cb-44a9-48fc-b516-eab1f87fc097';
       this._presetWorkspaceId = '987e2e02';
 
-    } else if ((/^tctalent-test.org/.test(hostname))) {
+    } else if ((/^tctalent-test\.org/.test(hostname))) {
       this._env = Environment.Staging;
       this._sfLightningUrl = 'https://talentbeyondboundaries--sfstaging.sandbox.lightning.force.com/';
       this._allCandidatesDashboardId = '86f9d8cb-44a9-48fc-b516-eab1f87fc097';
       this._presetWorkspaceId = '987e2e02';
 
-    } else if ((/^test.plus.tctalent.org/.test(hostname))) {
+    } else if ((/^test\.plus\.tctalent\.org/.test(hostname))) {
       this._env = Environment.Staging;
       this._sfLightningUrl = 'https://talentbeyondboundaries--sfstaging.sandbox.lightning.force.com/';
       this._allCandidatesDashboardId = '86f9d8cb-44a9-48fc-b516-eab1f87fc097';
       this._presetWorkspaceId = '987e2e02';
 
-    } else if ((/^tctalent.org/.test(hostname))) {
+    } else if ((/^tctalent\.org/.test(hostname))) {
       this._env = Environment.Prod;
       this._sfLightningUrl = 'https://talentbeyondboundaries.lightning.force.com/';
       this._allCandidatesDashboardId = '3d577f48-a4db-4e7d-95ed-6590d76829cc';
       this._presetWorkspaceId = 'effaaec0';
 
-    } else if ((/^plus.tctalent.org/.test(hostname))) {
+    } else if ((/^plus\.tctalent\.org/.test(hostname))) {
       this._env = Environment.Prod;
       this._sfLightningUrl = 'https://talentbeyondboundaries.lightning.force.com/';
       this._allCandidatesDashboardId = '3d577f48-a4db-4e7d-95ed-6590d76829cc';


### PR DESCRIPTION
This PR - 

- updates terraform configuration to resolve several issues from integration testing the opc-staging services
- adds the temporary opc service hostnames to env.service.ts - this is required for Preset and SF integration testing

