### PR TITLE
3128 jwt reconnect loop with expired tokens

### DIFF
--- a/server/src/main/java/org/tctalent/server/configuration/WebSocketConfig2.java
+++ b/server/src/main/java/org/tctalent/server/configuration/WebSocketConfig2.java
@@ -95,6 +95,13 @@ public class WebSocketConfig2 implements WebSocketMessageBrokerConfigurer {
                 return message;
             }
 
+            /**
+             * Throws MessageDeliveryException rather than a plain RuntimeException so that
+             * Spring's channel infrastructure re-throws it as-is instead of wrapping it in a
+             * generic "Failed to send message to channel" MessageDeliveryException. This
+             * preserves our error message in the STOMP ERROR frame sent to the client, allowing
+             * the frontend to detect expired token errors and stop reconnecting.
+             */
             private void handleInvalidToken(Message<?> message) {
                 throw new MessageDeliveryException(message,
                     JwtTokenProvider.EXPIRED_OR_INVALID_TOKEN_MSG);

--- a/server/src/main/java/org/tctalent/server/configuration/WebSocketConfig2.java
+++ b/server/src/main/java/org/tctalent/server/configuration/WebSocketConfig2.java
@@ -35,7 +35,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.util.StringUtils;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
-import org.tctalent.server.exception.ExpiredTokenException;
+import org.springframework.messaging.MessageDeliveryException;
 import org.tctalent.server.security.JwtTokenProvider;
 import org.tctalent.server.security.TcUserDetailsService;
 
@@ -85,18 +85,19 @@ public class WebSocketConfig2 implements WebSocketMessageBrokerConfigurer {
                                 UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
                                 accessor.setUser(authentication);
                             } else {
-                                handleInvalidToken();
+                                handleInvalidToken(message);
                             }
                         } catch (JwtException | IllegalArgumentException e) {
-                            handleInvalidToken();
+                            handleInvalidToken(message);
                         }
                     }
                 }
                 return message;
             }
 
-            private void handleInvalidToken() {
-                throw new ExpiredTokenException(JwtTokenProvider.EXPIRED_OR_INVALID_TOKEN_MSG);
+            private void handleInvalidToken(Message<?> message) {
+                throw new MessageDeliveryException(message,
+                    JwtTokenProvider.EXPIRED_OR_INVALID_TOKEN_MSG);
             }
 
         });

--- a/ui/admin-portal/src/app/components/candidate-opp/view-candidate-opp-from-url/view-candidate-opp-from-url.component.spec.ts
+++ b/ui/admin-portal/src/app/components/candidate-opp/view-candidate-opp-from-url/view-candidate-opp-from-url.component.spec.ts
@@ -16,7 +16,7 @@
 
 import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
 import {ActivatedRoute, convertToParamMap} from '@angular/router';
-import {of, throwError} from 'rxjs';
+import {of, Subject, throwError} from 'rxjs';
 import {ViewCandidateOppFromUrlComponent} from './view-candidate-opp-from-url.component';
 import {CandidateOpportunityService} from '../../../services/candidate-opportunity.service';
 import {mockCandidateOpportunity} from "../../../MockData/MockCandidateOpportunity";
@@ -41,7 +41,7 @@ describe('ViewCandidateOppFromUrlComponent', () => {
   beforeEach(waitForAsync(() => {
     // Create a spy object for CandidateOpportunityService
     const spyOpportunityService = jasmine.createSpyObj('CandidateOpportunityService', ['get']);
-    mockAuthService = jasmine.createSpyObj('AuthenticationService', ['getLoggedInUser']);
+    mockAuthService = jasmine.createSpyObj('AuthenticationService', ['getLoggedInUser'], { loggedInUser$: new Subject<any>() });
     spyOpportunityService.get.and.callThrough();
 
     TestBed.configureTestingModule({

--- a/ui/admin-portal/src/app/components/candidates/view/view-candidate.component.spec.ts
+++ b/ui/admin-portal/src/app/components/candidates/view/view-candidate.component.spec.ts
@@ -20,7 +20,7 @@ import {CandidateService} from "../../../services/candidate.service";
 import {SavedListService} from "../../../services/saved-list.service";
 import {ViewCandidateComponent} from "./view-candidate.component";
 import {ComponentFixture, TestBed, waitForAsync} from "@angular/core/testing";
-import {of, throwError} from "rxjs";
+import {of, Subject, throwError} from "rxjs";
 import {ActivatedRoute, convertToParamMap} from "@angular/router";
 import {MockCandidate} from "../../../MockData/MockCandidate";
 import {HttpClientTestingModule} from "@angular/common/http/testing";
@@ -67,7 +67,7 @@ describe('ViewCandidateComponent', () => {
     mockSavedListService = jasmine.createSpyObj('SavedListService', ['search']);
     mockModalService = jasmine.createSpyObj('NgbModal', ['open']);
     mockLocalStorageService = jasmine.createSpyObj('LocalStorageService', ['get', 'set']);
-    mockAuthenticationService = jasmine.createSpyObj('AuthenticationService', ['getLoggedInUser']);
+    mockAuthenticationService = jasmine.createSpyObj('AuthenticationService', ['getLoggedInUser'], { loggedInUser$: new Subject<any>() });
     const authorizationSpy = jasmine.createSpyObj('AuthorizationService', [
       'isEditableCandidate',
       'canViewPrivateCandidateInfo',

--- a/ui/admin-portal/src/app/components/job/jobs-with-detail/jobs-with-detail.component.spec.ts
+++ b/ui/admin-portal/src/app/components/job/jobs-with-detail/jobs-with-detail.component.spec.ts
@@ -16,7 +16,7 @@
 
 import { ComponentFixture, TestBed, waitForAsync, fakeAsync, tick } from '@angular/core/testing';
 import { JobsWithDetailComponent } from './jobs-with-detail.component';
-import {  of, throwError } from 'rxjs';
+import {  of, Subject, throwError } from 'rxjs';
 import { Job } from '../../../model/job';
 import { JobService } from '../../../services/job.service';
 import { AuthenticationService } from '../../../services/authentication.service';
@@ -41,7 +41,7 @@ describe('JobsWithDetailComponent', () => {
   beforeEach(waitForAsync(() => {
     jobWithUser.starringUsers[0].id=1; //Set the first Starring User index to 1
     const jobServiceSpy = jasmine.createSpyObj('JobService', ['checkUnreadChats','updateStarred','searchPaged']);
-    const authServiceSpy = jasmine.createSpyObj('AuthenticationService', ['getLoggedInUser'], { currentUser: { id: 1 } });
+    const authServiceSpy = jasmine.createSpyObj('AuthenticationService', ['getLoggedInUser'], { currentUser: { id: 1 }, loggedInUser$: new Subject<any>() });
     TestBed.configureTestingModule({
       declarations: [SortedByComponent,ChatReadStatusComponent,JobsWithDetailComponent,JobsComponent],
       imports: [

--- a/ui/admin-portal/src/app/components/job/view/view-job/view-job.component.spec.ts
+++ b/ui/admin-portal/src/app/components/job/view/view-job/view-job.component.spec.ts
@@ -22,7 +22,7 @@ import {JobService} from '../../../../services/job.service';
 import {SlackService} from '../../../../services/slack.service';
 import {Router} from '@angular/router';
 import {CommonModule, Location} from '@angular/common';
-import {of} from 'rxjs';
+import {of, Subject} from 'rxjs';
 import {Job} from '../../../../model/job';
 import {HttpClientTestingModule} from "@angular/common/http/testing";
 import {MockUser} from "../../../../MockData/MockUser";
@@ -51,7 +51,7 @@ describe('ViewJobComponent', () => {
   let mockLocation: jasmine.SpyObj<Location>;
 
   beforeEach(async () => {
-    mockAuthService = jasmine.createSpyObj('AuthenticationService', ['getLoggedInUser']);
+    mockAuthService = jasmine.createSpyObj('AuthenticationService', ['getLoggedInUser'], { loggedInUser$: new Subject<any>() });
     mockJobService = jasmine.createSpyObj('JobService', ['updateStarred']);
     mockSlackService = jasmine.createSpyObj('SlackService', ['postJobFromId']);
     mockRouter = jasmine.createSpyObj('Router', ['navigate']);

--- a/ui/admin-portal/src/app/services/chat.service.spec.ts
+++ b/ui/admin-portal/src/app/services/chat.service.spec.ts
@@ -16,7 +16,7 @@
 
 import {TestBed} from '@angular/core/testing';
 import {HttpClientTestingModule, HttpTestingController} from '@angular/common/http/testing';
-import {of} from 'rxjs';
+import {of, Subject} from 'rxjs';
 import {ChatService} from './chat.service';
 import {RxStompService} from './rx-stomp.service';
 import {AuthenticationService} from './authentication.service';
@@ -33,7 +33,7 @@ describe('ChatService', () => {
 
   beforeEach(() => {
     const rxStompServiceSpy = jasmine.createSpyObj('RxStompService', ['watch', 'configure', 'activate', 'deactivate']);
-    const authenticationServiceSpy = jasmine.createSpyObj('AuthenticationService', ['getLoggedInUser', 'getToken', 'logout']);
+    const authenticationServiceSpy = jasmine.createSpyObj('AuthenticationService', ['getLoggedInUser', 'getToken', 'logout'], { loggedInUser$: new Subject<any>() });
 
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],

--- a/ui/admin-portal/src/app/services/chat.service.ts
+++ b/ui/admin-portal/src/app/services/chat.service.ts
@@ -76,7 +76,13 @@ export class ChatService implements OnDestroy {
     private authenticationService: AuthenticationService,
     private http: HttpClient,
     private rxStompService: RxStompService
-  ) {}
+  ) {
+    this.authenticationService.loggedInUser$.subscribe(user => {
+      if (user === null) {
+        this.cleanUp();
+      }
+    });
+  }
 
   ngOnDestroy(): void {
     //Note that there seems to be some doubt whether this is called when a service is destroyed.
@@ -97,6 +103,8 @@ export class ChatService implements OnDestroy {
     this.chatPosts$.clear();
     this.chatByRequest$.clear();
 
+    //Reinitialize so new takeUntil pipes work after re-login
+    this.destroyStompSubscriptions$ = new Subject<void>();
   }
 
   /**

--- a/ui/admin-portal/src/app/services/chat.service.ts
+++ b/ui/admin-portal/src/app/services/chat.service.ts
@@ -348,18 +348,6 @@ export class ChatService implements OnDestroy {
     this.authenticationService.logout();
   }
 
-  private isTokenExpired(token: string): boolean {
-    try {
-      const payload = JSON.parse(atob(token.split('.')[1]));
-      if (!payload.exp) {
-        return false;
-      }
-      return payload.exp * 1000 < Date.now();
-    } catch {
-      return true;
-    }
-  }
-
   /**
    * Returns an RxStompConfig, populated with the current Authorization header token in
    * currentHeaders.
@@ -385,18 +373,6 @@ export class ChatService implements OnDestroy {
       // Set to 0 to disable
       // Typical value 500 (500 milli seconds)
       reconnectDelay: 5000,
-
-      // Read a fresh token before each connection attempt (including reconnects).
-      // If the token is missing or expired, deactivate stomp and stop reconnecting.
-      beforeConnect: (rxStomp) => {
-        const token = this.authenticationService.getToken();
-        if (token && !this.isTokenExpired(token)) {
-          rxStomp.stompClient.connectHeaders = { Authorization: `Bearer ${token}` };
-        } else {
-          console.log('Auth token missing or expired - stopping STOMP reconnection');
-          rxStomp.deactivate();
-        }
-      },
 
       // Will log diagnostics on console
       // It can be quite verbose, not recommended in production

--- a/ui/admin-portal/src/app/services/chat.service.ts
+++ b/ui/admin-portal/src/app/services/chat.service.ts
@@ -348,6 +348,18 @@ export class ChatService implements OnDestroy {
     this.authenticationService.logout();
   }
 
+  private isTokenExpired(token: string): boolean {
+    try {
+      const payload = JSON.parse(atob(token.split('.')[1]));
+      if (!payload.exp) {
+        return false;
+      }
+      return payload.exp * 1000 < Date.now();
+    } catch {
+      return true;
+    }
+  }
+
   /**
    * Returns an RxStompConfig, populated with the current Authorization header token in
    * currentHeaders.
@@ -373,6 +385,18 @@ export class ChatService implements OnDestroy {
       // Set to 0 to disable
       // Typical value 500 (500 milli seconds)
       reconnectDelay: 5000,
+
+      // Read a fresh token before each connection attempt (including reconnects).
+      // If the token is missing or expired, trigger logout and stop reconnecting.
+      beforeConnect: (rxStomp) => {
+        const token = this.authenticationService.getToken();
+        if (token && !this.isTokenExpired(token)) {
+          rxStomp.stompClient.connectHeaders = { Authorization: `Bearer ${token}` };
+        } else {
+          console.log('Auth token missing or expired - stopping STOMP reconnection');
+          rxStomp.deactivate();
+        }
+      },
 
       // Will log diagnostics on console
       // It can be quite verbose, not recommended in production

--- a/ui/admin-portal/src/app/services/chat.service.ts
+++ b/ui/admin-portal/src/app/services/chat.service.ts
@@ -387,7 +387,7 @@ export class ChatService implements OnDestroy {
       reconnectDelay: 5000,
 
       // Read a fresh token before each connection attempt (including reconnects).
-      // If the token is missing or expired, trigger logout and stop reconnecting.
+      // If the token is missing or expired, deactivate stomp and stop reconnecting.
       beforeConnect: (rxStomp) => {
         const token = this.authenticationService.getToken();
         if (token && !this.isTokenExpired(token)) {


### PR DESCRIPTION
This PR:

- fixes repeating reconnect loop in the ChatService authentication handling
- correctly triggers websocket cleanup and prevents reconnections on expired or missing tokens