### PR TITLE
3118 Next button does not always activate even when cursor is in button 

### DIFF
--- a/ui/candidate-portal/src/app/components/chatbot/chatbot.component.scss
+++ b/ui/candidate-portal/src/app/components/chatbot/chatbot.component.scss
@@ -71,10 +71,12 @@
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   z-index: 999;
   overflow: hidden;
+  visibility: hidden;
 
   &.open {
     transform: translateY(0) scale(1);
     opacity: 1;
+    visibility: visible;
   }
 }
 


### PR DESCRIPTION
The `.chatbot-panel` was using `opacity: 0` and `transform` to appear hidden when closed, but the element remained fully interactive in the DOM. This caused it to intercept mouse events over the registration step footer, making the Next button unclickable in the overlapping area. 

Added `visibility: hidden` to the closed state of `.chatbot-panel`, with `visibility: visible` restored in the `.open` state.