### PR TITLE
3160 migrate staging services to opc accounts

### DIFF
--- a/infra/aws/terraform/computing.tf
+++ b/infra/aws/terraform/computing.tf
@@ -240,8 +240,8 @@ resource "aws_ecs_task_definition" "web-app" {
   requires_compatibilities = ["FARGATE"]
   network_mode             = "awsvpc"
   execution_role_arn       = aws_iam_role.ecs_task_execution_role.arn
-  cpu                      = 256
-  memory                   = 2048
+  cpu                      = var.fargate_cpu
+  memory                   = var.fargate_memory
   container_definitions = jsonencode([
     {
       name                   = "${var.app}-${var.env}"

--- a/infra/aws/terraform/ecr.tf
+++ b/infra/aws/terraform/ecr.tf
@@ -29,7 +29,7 @@ resource "aws_ecr_lifecycle_policy" "app" {
         description  = "Keep last 10 tagged images"
         selection = {
           tagStatus     = "tagged"
-          tagPrefixList = ["v", "release", "tc-plus"]
+          tagPrefixList = ["v", "release", "tc-server"]
           countType     = "imageCountMoreThan"
           countNumber   = 10
         }

--- a/infra/aws/terraform/opc-prod/README.md
+++ b/infra/aws/terraform/opc-prod/README.md
@@ -1,6 +1,6 @@
-# TC-Plus OPC Production Environment
+# TC-Server OPC Production Environment
 
-Deploy the TC-Plus infrastructure to the OPC AWS production account (`289896345557`, `eu-west-2`).
+Deploy the TC-Server infrastructure to the OPC AWS production account (`289896345557`, `eu-west-2`).
 
 ## Prerequisites
 

--- a/infra/aws/terraform/opc-prod/main.tf
+++ b/infra/aws/terraform/opc-prod/main.tf
@@ -204,6 +204,8 @@ module "tc-plus-prod" {
   container_image = "289896345557.dkr.ecr.eu-west-2.amazonaws.com/tc-core:tc-plus-prod"
   container_port  = 8080
   ecs_tasks_count = 2
+  fargate_cpu     = 1024
+  fargate_memory  = 2048
 
   # Database configuration
   # RDS creates a local database (tcplus), but the service currently connects to the legacy TBB

--- a/infra/aws/terraform/opc-prod/main.tf
+++ b/infra/aws/terraform/opc-prod/main.tf
@@ -162,7 +162,7 @@ variable "translation_password" {
 }
 
 variable "tc_boot_admin_password" {
-  description = "Boot admin password for TC-Plus"
+  description = "Boot admin password for TC server"
   type        = string
   sensitive   = true
   default     = ""
@@ -185,23 +185,23 @@ provider "aws" {
 locals {
   common_tags = {
     Project     = "OPC"
-    Application = "TC-Plus"
+    Application = "TC-Server"
     Environment = "prod"
     ManagedBy   = "terraform"
   }
 }
 
-# TC-Plus infrastructure for OPC AWS production account
-module "tc-plus-prod" {
+# TC-Server infrastructure for OPC AWS production account
+module "tc-server-prod" {
   source = "../"
 
   common_tags = local.common_tags
 
   # ECS configuration
-  app             = "tc-plus"
+  app             = "tc-server"
   env             = "opc-prod"
   site_domain     = "plus.tctalent.org"
-  container_image = "289896345557.dkr.ecr.eu-west-2.amazonaws.com/tc-core:tc-plus-prod"
+  container_image = "289896345557.dkr.ecr.eu-west-2.amazonaws.com/tc-core:tc-server-prod"
   container_port  = 8080
   ecs_tasks_count = 2
   fargate_cpu     = 1024

--- a/infra/aws/terraform/opc-staging/README.md
+++ b/infra/aws/terraform/opc-staging/README.md
@@ -1,6 +1,6 @@
-# TC-Plus OPC Staging Environment
+# TC-Server OPC Staging Environment
 
-Deploy the TC-Plus infrastructure to the OPC AWS staging account (`164804461258`, `eu-west-2`).
+Deploy the TC-Server infrastructure to the OPC AWS staging account (`164804461258`, `eu-west-2`).
 
 ## Prerequisites
 

--- a/infra/aws/terraform/opc-staging/main.tf
+++ b/infra/aws/terraform/opc-staging/main.tf
@@ -185,23 +185,23 @@ provider "aws" {
 locals {
   common_tags = {
     Project     = "OPC"
-    Application = "TC-Plus"
+    Application = "TC-Server"
     Environment = "staging"
     ManagedBy   = "terraform"
   }
 }
 
-# TC-Plus infrastructure for OPC AWS staging account
-module "tc-plus-staging" {
+# TC-Server infrastructure for OPC AWS staging account
+module "tc-server-staging" {
   source = "../"
 
   common_tags = local.common_tags
 
   # ECS configuration
-  app             = "tc-plus"
+  app             = "tc-server"
   env             = "opc-staging"
   site_domain     = "tctalent-test.org"
-  container_image = "164804461258.dkr.ecr.eu-west-2.amazonaws.com/tc-core:tc-plus-staging"
+  container_image = "164804461258.dkr.ecr.eu-west-2.amazonaws.com/tc-core:tc-server-staging"
   container_port  = 8080
   ecs_tasks_count = 1
   fargate_cpu     = 512

--- a/infra/aws/terraform/opc-staging/main.tf
+++ b/infra/aws/terraform/opc-staging/main.tf
@@ -200,7 +200,7 @@ module "tc-plus-staging" {
   # ECS configuration
   app             = "tc-plus"
   env             = "opc-staging"
-  site_domain     = "test.plus.tctalent.org"
+  site_domain     = "tctalent-test.org"
   container_image = "164804461258.dkr.ecr.eu-west-2.amazonaws.com/tc-core:tc-plus-staging"
   container_port  = 8080
   ecs_tasks_count = 1
@@ -244,7 +244,7 @@ module "tc-plus-staging" {
   m2                                     = "/usr/local/apache-maven/bin"
   m2_home                                = "/usr/local/apache-maven"
   server_port                            = "8080"
-  server_url                             = "https://test.plus.tctalent.org/"
+  server_url                             = "https://tctalent-test.org/"
   sf_base_classic_url                    = "https://talentbeyondboundaries--sfstaging.sandbox.my.salesforce.com/"  # todo: either create for OPC or decouple TC+ from SF
   sf_base_lightning_url                  = "https://talentbeyondboundaries--sfstaging.sandbox.lightning.force.com"  # todo: either create for OPC or decouple TC+ from SF
   sf_base_login_url                      = "https://test.salesforce.com/"  # todo: either create for OPC or decouple TC+ from SF
@@ -256,12 +256,12 @@ module "tc-plus-staging" {
   spring_servlet_max_file_size           = "10MB"
   spring_servlet_max_request_size        = "10MB"
   tc_api_url                             = "https://test.api.tctalent.org"  # todo: set TC API URL
-  tc_cors_urls                           = "https://test.plus.tctalent.org,https://*.d2jx6ziu0w8kq9.amplifyapp.com,https://*.d1bt868vpd541m.amplifyapp.com"
+  tc_cors_urls                           = "https://tctalent-test.org,https://*.d2jx6ziu0w8kq9.amplifyapp.com,https://*.d1bt868vpd541m.amplifyapp.com"
   tc_db_copy_config                      = "data.sharing/tcCopies.xml" # todo: can this be retired?
   tc_destinations                        = "Australia,Canada,New Zealand,United Kingdom"  # todo: set TC destinations
-  tc_skills_extraction_api_url           = "https://test.skills.plus.tctalent.org"
-  web_admin                              = "https://test.plus.tctalent.org/admin-portal"
-  web_portal                             = "https://test.plus.tctalent.org/candidate-portal"
+  tc_skills_extraction_api_url           = "https://test.skills.tctalent.org"
+  web_admin                              = "https://tctalent-test.org/admin-portal"
+  web_portal                             = "https://tctalent-test.org/candidate-portal"
   tc_instance_type                       = "TBB"
 
   # Secrets: loaded from secrets.auto.tfvars

--- a/infra/aws/terraform/opc-staging/main.tf
+++ b/infra/aws/terraform/opc-staging/main.tf
@@ -204,6 +204,8 @@ module "tc-plus-staging" {
   container_image = "164804461258.dkr.ecr.eu-west-2.amazonaws.com/tc-core:tc-plus-staging"
   container_port  = 8080
   ecs_tasks_count = 1
+  fargate_cpu     = 512
+  fargate_memory  = 2048
 
   # Database configuration
   # RDS creates a local database (tcplus), but the service currently connects to the legacy TBB

--- a/infra/aws/terraform/opc-staging/main.tf
+++ b/infra/aws/terraform/opc-staging/main.tf
@@ -247,9 +247,9 @@ module "tc-plus-staging" {
   m2_home                                = "/usr/local/apache-maven"
   server_port                            = "8080"
   server_url                             = "https://tctalent-test.org/"
-  sf_base_classic_url                    = "https://talentbeyondboundaries--sfstaging.sandbox.my.salesforce.com/"  # todo: either create for OPC or decouple TC+ from SF
-  sf_base_lightning_url                  = "https://talentbeyondboundaries--sfstaging.sandbox.lightning.force.com"  # todo: either create for OPC or decouple TC+ from SF
-  sf_base_login_url                      = "https://test.salesforce.com/"  # todo: either create for OPC or decouple TC+ from SF
+  sf_base_classic_url                    = "https://talentbeyondboundaries--sfstaging.sandbox.my.salesforce.com/"
+  sf_base_lightning_url                  = "https://talentbeyondboundaries--sfstaging.sandbox.lightning.force.com"
+  sf_base_login_url                      = "https://test.salesforce.com/"
   spring_client_url                      = "-" # todo: confirm if used/needed
   spring_datasource_url                  = "jdbc:postgresql://tbbtalent-prod.cy7icd7y1lyr.us-east-1.rds.amazonaws.com:5432/tctalent" # legacy TBB DB -- in parallel to local RDS
   spring_datasource_username             = "tctalent"
@@ -257,7 +257,7 @@ module "tc-plus-staging" {
   spring_db_pool_min                     = "20"
   spring_servlet_max_file_size           = "10MB"
   spring_servlet_max_request_size        = "10MB"
-  tc_api_url                             = "https://test.api.tctalent.org"  # todo: set TC API URL
+  tc_api_url                             = "https://test.api.tctalent.org"
   tc_cors_urls                           = "https://tctalent-test.org,https://*.d2jx6ziu0w8kq9.amplifyapp.com,https://*.d1bt868vpd541m.amplifyapp.com"
   tc_db_copy_config                      = "data.sharing/tcCopies.xml" # todo: can this be retired?
   tc_destinations                        = "Australia,Canada,New Zealand,United Kingdom"  # todo: set TC destinations

--- a/infra/aws/terraform/variables.tf
+++ b/infra/aws/terraform/variables.tf
@@ -45,6 +45,18 @@ variable "ecs_tasks_count" {
   default     = 1
 }
 
+variable "fargate_cpu" {
+  type        = number
+  description = "Fargate task CPU units (1024 = 1 vCPU)"
+  default     = 256
+}
+
+variable "fargate_memory" {
+  type        = number
+  description = "Fargate task memory in MiB"
+  default     = 2048
+}
+
 ### Database configuration variables:
 
 variable "db_public_access" {

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -200,9 +200,9 @@ jib {
         } else if (project.hasProperty("prod-tc-system")) {
             image = "968457613372.dkr.ecr.us-east-1.amazonaws.com/talent-catalog"
         } else if (project.hasProperty("opc-staging")) {
-            image = "164804461258.dkr.ecr.eu-west-2.amazonaws.com/tc-core:tc-plus-staging"
+            image = "164804461258.dkr.ecr.eu-west-2.amazonaws.com/tc-core:tc-server-staging"
         } else if (project.hasProperty("opc-prod")) {
-            image = "289896345557.dkr.ecr.eu-west-2.amazonaws.com/tc-core:tc-plus-prod"
+            image = "289896345557.dkr.ecr.eu-west-2.amazonaws.com/tc-core:tc-server-prod"
         }
         credHelper = 'ecr-login'
     }


### PR DESCRIPTION
This PR -

Includes the terraform configuration changes to migrate the TC staging services to OPC AWS.

These changes have already been applied via terraform and the service migration is done.

- migrates the OPC staging service from test.plus.tctalent.org to tctalent-test.org
- adds configurable fargate cpu and memory levels (mirroring the tc-api and tc-skills configuration)

These changes have been changed in configuration but cannot yet be applied via terraform (see Note below)

- renames all relevant parameter values from tc-plus to tc-server
- updates the gradle jib deploy to promote images named tc-server (not tc-plus)

Important Note: 

- once this PR is approved and merged a new service image will need to be deployed (with the new image name "tc-server")
- after the image is deployed: run plan and apply the terraform changes to rename all services from tc-plus to tc-server -- which will pick up the deployed tc-server image 