### PR TITLE
3202 jobs tab performance issues

### DIFF
--- a/server/src/main/java/org/tctalent/server/api/admin/JobAdminApi.java
+++ b/server/src/main/java/org/tctalent/server/api/admin/JobAdminApi.java
@@ -124,8 +124,12 @@ public class JobAdminApi implements
     @PostMapping("search-paged")
     public @NotNull Map<String, Object> searchPaged(@Valid SearchJobRequest request) {
         Page<SalesforceJobOpp> jobs = jobService.searchJobs(request);
-        final DtoBuilder builder =
-            Boolean.TRUE.equals(request.getJobNameAndIdOnly()) ? jobNameAndIdDto() : jobDto();
+        final DtoBuilder builder;
+        if (Boolean.TRUE.equals(request.getJobNameAndIdOnly())) {
+            builder = jobNameAndIdDto();
+        } else {
+            builder = jobListDto();
+        }
         final Map<String, Object> objectMap = builder.buildPage(jobs);
         return objectMap;
     }
@@ -230,6 +234,28 @@ public class JobAdminApi implements
         return new DtoBuilder()
             .add("id")
             .add("name")
+            ;
+    }
+
+    private DtoBuilder jobListDto() {
+        return new DtoBuilder()
+            .add("id")
+            .add("name")
+            .add("country", countryService.selectBuilder())
+            .add("stage")
+            .add("closed")
+            .add("won")
+            .add("createdDate")
+            .add("submissionDueDate")
+            .add("contactUser", shortUserDto())
+            .add("submissionList", minimalSavedListDto())
+            .add("starringUsers", shortUserDto())
+            ;
+    }
+
+    private DtoBuilder minimalSavedListDto() {
+        return new DtoBuilder()
+            .add("id")
             ;
     }
 

--- a/server/src/main/java/org/tctalent/server/service/db/impl/JobServiceImpl.java
+++ b/server/src/main/java/org/tctalent/server/service/db/impl/JobServiceImpl.java
@@ -525,11 +525,9 @@ public class JobServiceImpl implements JobService {
     @Override
     public Page<SalesforceJobOpp> searchJobs(SearchJobRequest request) {
         User loggedInUser = userService.getLoggedInUser();
-        Page<SalesforceJobOpp> jobs = salesforceJobOppRepository.findAll(
+        return salesforceJobOppRepository.findAll(
             JobSpecification.buildSearchQuery(request, loggedInUser),
             request.getPageRequest());
-        checkEmployerEntities(jobs);
-        return jobs;
     }
 
     @NonNull

--- a/server/src/test/java/org/tctalent/server/api/admin/JobAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/JobAdminApiTest.java
@@ -441,8 +441,7 @@ class JobAdminApiTest extends ApiTestBase {
                 .andExpect(jsonPath("$.hasNext", is(false)))
                 .andExpect(jsonPath("$.hasPrevious", is(false)))
                 .andExpect(jsonPath("$.content", notNullValue()))
-                .andExpect(jsonPath("$.content.[0].id", is(99)))
-                .andExpect(jsonPath("$.content.[0].sfId", is("123456")));
+                .andExpect(jsonPath("$.content.[0].id", is(99)));
 
         verify(jobService).searchJobs(any(SearchJobRequest.class));
     }

--- a/ui/admin-portal/src/app/components/job/jobs-with-detail/jobs-with-detail.component.html
+++ b/ui/admin-portal/src/app/components/job/jobs-with-detail/jobs-with-detail.component.html
@@ -23,6 +23,7 @@
         [tabIsActive]="tabIsActive"
         [chatsRead$]="chatsRead$"
         (oppSelection)="onJobSelected($event)"
+        (refreshRequested)="onRefreshRequested()"
       >
       </app-jobs>
 

--- a/ui/admin-portal/src/app/components/job/jobs-with-detail/jobs-with-detail.component.html
+++ b/ui/admin-portal/src/app/components/job/jobs-with-detail/jobs-with-detail.component.html
@@ -36,6 +36,9 @@
               class="fas fa-arrow-{{sidePanelIsMax ? 'right' : 'left'}}"></i></button>
           </div>
 
+          <tc-loading [loading]="loading"></tc-loading>
+          <tc-alert type="danger" *ngIf="error">{{error}}</tc-alert>
+
           <div *ngIf="selectedJob">
             <app-view-job
               *ngIf="selectedJob"

--- a/ui/admin-portal/src/app/components/job/jobs-with-detail/jobs-with-detail.component.spec.ts
+++ b/ui/admin-portal/src/app/components/job/jobs-with-detail/jobs-with-detail.component.spec.ts
@@ -40,7 +40,7 @@ describe('JobsWithDetailComponent', () => {
   let mockedUser = new MockUser();
   beforeEach(waitForAsync(() => {
     jobWithUser.starringUsers[0].id=1; //Set the first Starring User index to 1
-    const jobServiceSpy = jasmine.createSpyObj('JobService', ['checkUnreadChats','updateStarred','searchPaged']);
+    const jobServiceSpy = jasmine.createSpyObj('JobService', ['checkUnreadChats','updateStarred','searchPaged','get']);
     const authServiceSpy = jasmine.createSpyObj('AuthenticationService', ['getLoggedInUser'], { currentUser: { id: 1 }, loggedInUser$: new Subject<any>() });
     TestBed.configureTestingModule({
       declarations: [SortedByComponent,ChatReadStatusComponent,JobsWithDetailComponent,JobsComponent],
@@ -64,8 +64,9 @@ describe('JobsWithDetailComponent', () => {
     // Mocking return values for the service methods
     jobService.checkUnreadChats.and.returnValue(of({ numberUnreadChats: 0 }));
     jobService.updateStarred.and.returnValue(throwError("error"));
+    jobService.get.and.returnValue(of(jobWithUser));
     jobServiceSpy.searchPaged.and.returnValue(of());
-   }));
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(JobsWithDetailComponent);
@@ -76,16 +77,19 @@ describe('JobsWithDetailComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
   it('Ensure that selectedJob, error, and loading properties are initialized correctly', () => {
     expect(component.selectedJob).toBeUndefined();
     expect(component.error).toBeUndefined();
     expect(component.loading).toBeFalsy();
   });
 
-  it('should select a job', () => {
+  it('should select a job', fakeAsync(() => {
     component.onJobSelected(jobWithUser);
+    tick();
     expect(component.selectedJob).toEqual(jobWithUser);
-  });
+  }));
+
   it('should refresh jobs component when job is updated', () => {
     const jobsComponentSpy = jasmine.createSpyObj('JobsComponent', ['search']);
     component.jobsComponent = jobsComponentSpy;
@@ -93,6 +97,7 @@ describe('JobsWithDetailComponent', () => {
     component.onJobUpdated({} as Job);
     expect(jobsComponentSpy.search).toHaveBeenCalled();
   });
+
   it('should correctly identify whether the authenticated user has starred the job', () => {
     // Mock the authentication service to return a mock user ID
     authService.getLoggedInUser.and.returnValue(mockedUser);
@@ -107,6 +112,7 @@ describe('JobsWithDetailComponent', () => {
     starred = component.isStarred();
     expect(starred).toBeFalsy();
   });
+
   it('should handle error when toggling starred status', fakeAsync(() => {
     const error = 'Error toggling starred status';
     jobService.updateStarred.and.returnValue(throwError(error));

--- a/ui/admin-portal/src/app/components/job/jobs-with-detail/jobs-with-detail.component.ts
+++ b/ui/admin-portal/src/app/components/job/jobs-with-detail/jobs-with-detail.component.ts
@@ -39,6 +39,8 @@ export class JobsWithDetailComponent extends MainSidePanelBase implements OnInit
   error: any;
   loading: boolean;
 
+  private readonly jobCache = new Map<number, Job>();
+
   @Input() searchBy: SearchOppsBy;
   @Input() tabIsActive: boolean;
 
@@ -69,10 +71,19 @@ export class JobsWithDetailComponent extends MainSidePanelBase implements OnInit
   }
 
   onJobSelected(job: Job) {
+    const cachedJob = this.jobCache.get(job.id);
+    if (cachedJob) {
+      this.selectedJob = cachedJob;
+      this.loading = false;
+      this.error = null;
+      return;
+    }
+
     this.loading = true;
     this.error = null;
     this.jobService.get(job.id).subscribe({
       next: (fullJob: Job) => {
+        this.jobCache.set(fullJob.id, fullJob);
         this.selectedJob = fullJob;
         this.loading = false;
       },
@@ -87,7 +98,11 @@ export class JobsWithDetailComponent extends MainSidePanelBase implements OnInit
     this.loading = true;
     this.error = null
     this.jobService.updateStarred(this.selectedJob.id, !this.isStarred()).subscribe(
-      (job: Job) => {this.selectedJob = job; this.loading = false},
+      (job: Job) => {
+        this.selectedJob = job;
+        this.jobCache.set(job.id, job);
+        this.loading = false
+      },
       (error) => {this.error = error; this.loading = false}
     )
   }
@@ -98,6 +113,8 @@ export class JobsWithDetailComponent extends MainSidePanelBase implements OnInit
 
   // Refresh the jobs component (list of jobs) so that the new updated details can be displayed.
   onJobUpdated(job: Job) {
+    this.selectedJob = job;
+    this.jobCache.set(job.id, job);
     this.jobsComponent.search();
   }
 }

--- a/ui/admin-portal/src/app/components/job/jobs-with-detail/jobs-with-detail.component.ts
+++ b/ui/admin-portal/src/app/components/job/jobs-with-detail/jobs-with-detail.component.ts
@@ -79,9 +79,23 @@ export class JobsWithDetailComponent extends MainSidePanelBase implements OnInit
       return;
     }
 
+    this.fetchFullJob(job.id);
+  }
+
+  onRefreshRequested() {
+    this.jobCache.clear();
+
+    if (!this.selectedJob) {
+      return;
+    }
+
+    this.fetchFullJob(this.selectedJob.id);
+  }
+
+  private fetchFullJob(jobId: number) {
     this.loading = true;
     this.error = null;
-    this.jobService.get(job.id).subscribe({
+    this.jobService.get(jobId).subscribe({
       next: (fullJob: Job) => {
         this.jobCache.set(fullJob.id, fullJob);
         this.selectedJob = fullJob;

--- a/ui/admin-portal/src/app/components/job/jobs-with-detail/jobs-with-detail.component.ts
+++ b/ui/admin-portal/src/app/components/job/jobs-with-detail/jobs-with-detail.component.ts
@@ -69,7 +69,18 @@ export class JobsWithDetailComponent extends MainSidePanelBase implements OnInit
   }
 
   onJobSelected(job: Job) {
-    this.selectedJob = job;
+    this.loading = true;
+    this.error = null;
+    this.jobService.get(job.id).subscribe({
+      next: (fullJob: Job) => {
+        this.selectedJob = fullJob;
+        this.loading = false;
+      },
+      error: (error) => {
+        this.error = error;
+        this.loading = false;
+      }
+    });
   }
 
   doToggleStarred() {

--- a/ui/admin-portal/src/app/components/util/opportunity/FilteredOppsComponentBase.ts
+++ b/ui/admin-portal/src/app/components/util/opportunity/FilteredOppsComponentBase.ts
@@ -81,6 +81,7 @@ export abstract class FilteredOppsComponentBase<T extends Opportunity> implement
   @Input() tabIsActive: boolean = true;
 
   @Output() oppSelection = new EventEmitter();
+  @Output() refreshRequested = new EventEmitter<void>();
 
   opps: T[];
 
@@ -302,6 +303,7 @@ export abstract class FilteredOppsComponentBase<T extends Opportunity> implement
 
   refresh(event: any): void {
     this.search();
+    this.refreshRequested.emit();
     event.preventDefault(); // Stops form from submitting and search being called twice on click
   }
 


### PR DESCRIPTION
This PR -

- introduces a minimal jobListDto() in JobAdminApi for job table view (instead of full jobDto() which is not needed)
- fetches full jobDto() for the currently selected job in JobsWithDetailComponent
- adds loading and error indicator on jobs-with-detail.component.html
- Removes the call to checkEmployerEntity for search-paged calls - this is safe to remove, see issue comments for analysis and thinking behind this decision
- caches full jobDto() after initial fetch for a faster UI response when users peruse the job list

In local testing this appears to be 4-5x faster.

Check in staging after deployment. 
For comparison -- the search-paged was taking >24s in staging to fetch 28 jobs for the jobs table.