### PR TITLE
Setup GRN staging infrastructure with Terraform and Jib

### DIFF
--- a/.github/workflows/tc-test-build-deploy.yml
+++ b/.github/workflows/tc-test-build-deploy.yml
@@ -74,3 +74,7 @@ jobs:
 
       - name: Deploy to OPC with Jib
         run: ./gradlew jib -Popc-staging -x test
+
+      # --- Deploy to GRN Staging (same OPC staging account, eu-west-2) ---
+      - name: Deploy to GRN Staging with Jib
+        run: ./gradlew jib -Pgrn-staging -x test

--- a/infra/aws/terraform/computing.tf
+++ b/infra/aws/terraform/computing.tf
@@ -104,13 +104,13 @@ module "alb" {
       health_check = {
         enabled             = true
         interval            = 65
-        path                = "/"
+        path                = "/actuator/health"
         port                = "traffic-port"
         healthy_threshold   = 2
         unhealthy_threshold = 5
         timeout             = 60
         protocol            = "HTTP"
-        matcher             = "200,302"
+        matcher             = "200"
       }
       targets = {}
     }

--- a/infra/aws/terraform/grn-staging/.terraform.lock.hcl
+++ b/infra/aws/terraform/grn-staging/.terraform.lock.hcl
@@ -1,0 +1,84 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.37.0"
+  constraints = ">= 3.67.0, >= 4.0.0, >= 4.6.0, >= 4.28.0, >= 6.28.0, >= 6.34.0"
+  hashes = [
+    "h1:OdQC/z+3ReUAPhlXCJIJYUZlSQ3b96TWfFK3lCT5zKU=",
+    "zh:0427fadb719ed5a32feb09f047539d2348e659056f3b8a8589d34d8f0a95be7a",
+    "zh:3891c670674aba2125a7ac6d4348cde43646b1b46ce6f829e6f4724091bc0dcd",
+    "zh:632cb24b7b5790b730b33bcbe9f1a7b75f2644fb52f9d6aaafb0249c9e7601d2",
+    "zh:6e96ed1f824c2efa9de5b7c22ab3715624ba34c28564a06e9a15e71bc3d3a30b",
+    "zh:7b8fd86907b659bc45f4a3f42c3c0ccc66925a74e265b01e9e66242c0b2cafef",
+    "zh:81f9a587deddef4dfcc2101c54ec28a3a554056837f68ebb920c83fe8327b16f",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a9a38a67cb98d690fec951ec3e133b6836279629db2ed3a0ebf97a5bea58674f",
+    "zh:b18f60d62e4bd4d466077e09c39259d1a85355f0f00b801fe8aedbc50193d357",
+    "zh:b7a51bc0faf60d17043b4df1d1b7bb55129eaa4bdeb65ff55f5b00b9b8fee9f7",
+    "zh:c28c42f91ca3a6b65b3fd3ed6e891fc0fc28d0cb5ab65dea65eda8eec5cea5f3",
+    "zh:d895ddc04280ed26b6ca64ca05b78caaa7b72c8e167af4093545efbc608d5482",
+    "zh:f4a56f5157009ef160fbd79105078fe675df479cb73c1b7e1fea2741403a0b67",
+    "zh:f547d6ca371b96fec97b972fc0c93bcfc23d58e34a9da215b94e9d2aa170fb77",
+    "zh:f7b0a3cd4adadd3f4b9609a54e651ed5eafa22c196ab229042fc1d0aa0ab8f3a",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version = "3.2.4"
+  hashes = [
+    "h1:L5V05xwp/Gto1leRryuesxjMfgZwjb7oool4WS1UEFQ=",
+    "zh:59f6b52ab4ff35739647f9509ee6d93d7c032985d9f8c6237d1f8a59471bbbe2",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:795c897119ff082133150121d39ff26cb5f89a730a2c8c26f3a9c1abf81a9c43",
+    "zh:7b9c7b16f118fbc2b05a983817b8ce2f86df125857966ad356353baf4bff5c0a",
+    "zh:85e33ab43e0e1726e5f97a874b8e24820b6565ff8076523cc2922ba671492991",
+    "zh:9d32ac3619cfc93eb3c4f423492a8e0f79db05fec58e449dee9b2d5873d5f69f",
+    "zh:9e15c3c9dd8e0d1e3731841d44c34571b6c97f5b95e8296a45318b94e5287a6e",
+    "zh:b4c2ab35d1b7696c30b64bf2c0f3a62329107bd1a9121ce70683dec58af19615",
+    "zh:c43723e8cc65bcdf5e0c92581dcbbdcbdcf18b8d2037406a5f2033b1e22de442",
+    "zh:ceb5495d9c31bfb299d246ab333f08c7fb0d67a4f82681fbf47f2a21c3e11ab5",
+    "zh:e171026b3659305c558d9804062762d168f50ba02b88b231d20ec99578a6233f",
+    "zh:ed0fe2acdb61330b01841fa790be00ec6beaac91d41f311fb8254f74eb6a711f",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.8.1"
+  constraints = ">= 3.1.0"
+  hashes = [
+    "h1:u8AKlWVDTH5r9YLSeswoVEjiY72Rt4/ch7U+61ZDkiQ=",
+    "zh:08dd03b918c7b55713026037c5400c48af5b9f468f483463321bd18e17b907b4",
+    "zh:0eee654a5542dc1d41920bbf2419032d6f0d5625b03bd81339e5b33394a3e0ae",
+    "zh:229665ddf060aa0ed315597908483eee5b818a17d09b6417a0f52fd9405c4f57",
+    "zh:2469d2e48f28076254a2a3fc327f184914566d9e40c5780b8d96ebf7205f8bc0",
+    "zh:37d7eb334d9561f335e748280f5535a384a88675af9a9eac439d4cfd663bcb66",
+    "zh:741101426a2f2c52dee37122f0f4a2f2d6af6d852cb1db634480a86398fa3511",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:a902473f08ef8df62cfe6116bd6c157070a93f66622384300de235a533e9d4a9",
+    "zh:b85c511a23e57a2147355932b3b6dce2a11e856b941165793a0c3d7578d94d05",
+    "zh:c5172226d18eaac95b1daac80172287b69d4ce32750c82ad77fa0768be4ea4b8",
+    "zh:dab4434dba34aad569b0bc243c2d3f3ff86dd7740def373f2a49816bd2ff819b",
+    "zh:f49fd62aa8c5525a5c17abd51e27ca5e213881d58882fd42fec4a545b53c9699",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/time" {
+  version     = "0.13.1"
+  constraints = ">= 0.13.0"
+  hashes = [
+    "h1:ZT5ppCNIModqk3iOkVt5my8b8yBHmDpl663JtXAIRqM=",
+    "zh:02cb9aab1002f0f2a94a4f85acec8893297dc75915f7404c165983f720a54b74",
+    "zh:04429b2b31a492d19e5ecf999b116d396dac0b24bba0d0fb19ecaefe193fdb8f",
+    "zh:26f8e51bb7c275c404ba6028c1b530312066009194db721a8427a7bc5cdbc83a",
+    "zh:772ff8dbdbef968651ab3ae76d04afd355c32f8a868d03244db3f8496e462690",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:898db5d2b6bd6ca5457dccb52eedbc7c5b1a71e4a4658381bcbb38cedbbda328",
+    "zh:8de913bf09a3fa7bedc29fec18c47c571d0c7a3d0644322c46f3aa648cf30cd8",
+    "zh:9402102c86a87bdfe7e501ffbb9c685c32bbcefcfcf897fd7d53df414c36877b",
+    "zh:b18b9bb1726bb8cfbefc0a29cf3657c82578001f514bcf4c079839b6776c47f0",
+    "zh:b9d31fdc4faecb909d7c5ce41d2479dd0536862a963df434be4b16e8e4edc94d",
+    "zh:c951e9f39cca3446c060bd63933ebb89cedde9523904813973fbc3d11863ba75",
+    "zh:e5b773c0d07e962291be0e9b413c7a22c044b8c7b58c76e8aa91d1659990dfb5",
+  ]
+}

--- a/infra/aws/terraform/grn-staging/README.md
+++ b/infra/aws/terraform/grn-staging/README.md
@@ -1,0 +1,69 @@
+# GRN Staging Environment (OPC AWS Account)
+
+Deploy the TC-Server infrastructure for **GRN (Global Refugee Network)** to the OPC AWS staging account (`164804461258`, `eu-west-2`). 
+This runs **alongside** the existing opc-staging deployment in the same account, with separate state, resources, and domain.
+
+- **Domain:** [test.globalrefugee.net](https://test.globalrefugee.net)
+- **Resource prefix:** `grn-staging` (VPC, ECS cluster, ALB, RDS, etc.)
+- **SSM parameter path:** `/grn/staging/`
+- **ECR repository:** `grn-core` (image tag e.g. `grn-staging`)
+
+## Prerequisites
+
+- AWS CLI configured with credentials that can assume `arn:aws:iam::164804461258:role/opc-staging-terraform-exec`
+- Terraform >= 1.3
+- The S3 backend bucket (`opc-shared-terraform-state`) and DynamoDB lock table (`opc-terraform-locks`) 
+  must already exist in the OPC account
+
+## 1. Initialise Terraform
+
+```bash
+cd infra/aws/terraform/grn-staging
+terraform init
+```
+
+## 2. Set secrets
+
+Create/edit `secrets.auto.tfvars` in this directory with the real secret values (same structure as 
+opc-staging). This file is git-ignored and auto-loaded by Terraform. **Do not commit it.**
+
+Include at least:
+
+- `aws_access_key`, `aws_secret_key`
+- `jwt_secret`, `spring_datasource_password`
+- `tc_api_key`, `translation_password`, `tc_boot_admin_password`
+- Other secrets as required by the application (see opc-staging README for the full list)
+
+## 3. Deploy infrastructure
+
+```bash
+terraform plan -out tfplan
+terraform apply tfplan
+```
+
+This creates a full stack for GRN staging (VPC, RDS, ECS, ALB, Route53, ACM, ElastiCache, ECR repo `grn-core`) 
+and populates SSM under `/grn/staging/`.
+
+## 4. DNS
+
+Point the domain **globalrefugee.net** (and www if desired) at the ALB output (e.g. via Route53). 
+Terraform will create the ACM certificate and ALB; you need to create the DNS records that point to 
+the ALB.
+
+## 5. Build and push container image
+
+Build and push the app image to the GRN ECR repo with tag `grn-staging`:
+
+```bash
+# From project root, after AWS auth and ECR login
+# Build and push to 164804461258.dkr.ecr.eu-west-2.amazonaws.com/grn-core:grn-staging
+```
+
+Use CI or the same pattern as opc-staging (e.g. a Gradle property or env for `grn-staging` that sets 
+the image target).
+
+## State and coexistence with opc-staging
+
+- **State key:** `staging/grn/terraform.tfstate` (opc-staging uses `staging/talentcatalog/terraform.tfstate`).
+- **Same account, same role:** Both use the OPC staging account and `opc-staging-terraform-exec` role.
+- **Separate resources:** All resources are prefixed `grn-staging`; no overlap with opc-staging.

--- a/infra/aws/terraform/grn-staging/main.tf
+++ b/infra/aws/terraform/grn-staging/main.tf
@@ -244,6 +244,8 @@ module "grn_staging" {
   sf_base_lightning_url                  = "https://talentbeyondboundaries--sfstaging.sandbox.lightning.force.com"
   sf_base_login_url                      = "https://test.salesforce.com/"
   spring_client_url                      = "-"
+  # Empty so SPRING_DATASOURCE_URL is auto-populated from the RDS created by this stack.
+  # The provided spring_datasource_username/password are used to create the RDS master user and are written to SSM for the app.
   spring_datasource_url                  = "" # use RDS created by this stack
   spring_datasource_username            = "tctalent"
   spring_db_pool_max                     = "50"

--- a/infra/aws/terraform/grn-staging/main.tf
+++ b/infra/aws/terraform/grn-staging/main.tf
@@ -259,7 +259,7 @@ module "grn_staging" {
   tc_skills_extraction_api_url           = "https://test.skills.globalrefugee.net"
   web_admin                              = "https://test.globalrefugee.net/admin-portal"
   web_portal                             = "https://test.globalrefugee.net/candidate-portal"
-  tc_instance_type                       = "TBB"
+  tc_instance_type                       = "GRN"
 
   # Secrets: loaded from secrets.auto.tfvars
   aws_access_key             = var.aws_access_key

--- a/infra/aws/terraform/grn-staging/main.tf
+++ b/infra/aws/terraform/grn-staging/main.tf
@@ -1,0 +1,299 @@
+# This file is the main entry for GRN staging infrastructure in the OPC AWS staging account.
+# It runs alongside opc-staging in the same account (164804461258) with separate state and resources.
+
+# Secrets loaded from secrets.auto.tfvars and passed through to the child module
+variable "aws_access_key" {
+  description = "AWS access key for S3 access"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "aws_secret_key" {
+  description = "AWS secret key for S3 access"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "duolingo_api_secret" {
+  description = "Duolingo API secret"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "es_password" {
+  description = "Elasticsearch password (todo: retire elasticsearch)"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "email_password" {
+  description = "Email password"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "drive_id" {
+  description = "Google Drive candidate data drive ID"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "drive_rootfolder" {
+  description = "Google Drive candidate root folder ID"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "drive_list_folders_id" {
+  description = "Google Drive list folders drive ID"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "drive_list_folders_root_id" {
+  description = "Google Drive list folders root ID"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "drive_private_key" {
+  description = "Google Drive private key (PEM format with literal \\n)"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "drive_private_key_id" {
+  description = "Google Drive private key ID"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "jwt_secret" {
+  description = "JWT secret"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "preset_api_token" {
+  description = "Preset API token"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "preset_secret" {
+  description = "Preset secret"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "preset_workspace_id" {
+  description = "Preset workspace ID"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "sf_consumer_key" {
+  description = "Salesforce connected app consumer key"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "sf_private_key" {
+  description = "Salesforce private key"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "sf_user" {
+  description = "Salesforce user for access token"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "slack_channel_id" {
+  description = "Slack channel ID for job posts (test: C048GS1KHPG, live: C029WMY6H1U)"
+  type        = string
+}
+
+variable "slack_token" {
+  description = "Slack token"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "spring_datasource_password" {
+  description = "Spring datasource (RDS) password"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "tc_api_key" {
+  description = "TC API key"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "translation_password" {
+  description = "Translation password"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "tc_boot_admin_password" {
+  description = "System admin password for TC"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+# Same OPC staging account as opc-staging
+provider "aws" {
+  region = "eu-west-2"
+
+  assume_role {
+    role_arn = "arn:aws:iam::164804461258:role/opc-staging-terraform-exec"
+  }
+}
+
+locals {
+  common_tags = {
+    Project     = "GRN"
+    Application = "TC-Server"
+    Environment = "staging"
+    ManagedBy   = "terraform"
+  }
+}
+
+# GRN staging: parallel deployment in OPC staging account, domain test.globalrefugee.net
+module "grn_staging" {
+  source = "../"
+
+  common_tags = local.common_tags
+
+  # ECS configuration (separate ECR repo in same account to avoid name conflict with opc-staging)
+  app                    = "grn"
+  env                    = "staging"
+  site_domain            = "test.globalrefugee.net"
+  ecr_repository_name    = "grn-core"
+  container_image        = "164804461258.dkr.ecr.eu-west-2.amazonaws.com/grn-core:grn-staging"
+  container_port  = 8080
+  ecs_tasks_count = 1
+  fargate_cpu     = 512
+  fargate_memory  = 2048
+
+  # Database configuration
+  db_enable               = true
+  db_public_access       = false
+  db_multi_az            = false
+  db_instance_class      = "db.t3.medium"
+  db_engine_version      = "17.5"
+  db_family              = "postgres17"
+  db_major_engine_version = "17"
+  db_name                = "tcplus"
+
+  availability_zones = ["eu-west-2a", "eu-west-2b", "eu-west-2c"]
+
+  # Redis cache (unique cluster id in same account)
+  cache_enable          = true
+  cache_cluster_id      = "grn-staging-cache"
+  cache_node_type       = "cache.t3.micro"
+  cache_num_cache_nodes = 3
+  cache_engine_version  = "7.1"
+  cache_port            = 6379
+
+  # SSM-backed application parameters
+  s3_bucket                              = "files.tbbtalent.org" # todo: confirm or set GRN bucket
+  environment                            = "grn-staging"
+  email_default                          = "-"
+  email_test_override                    = "-"
+  email_user                             = "-"
+  email_type                             = "SMTP"
+  es_url                                 = "https://tc-staging.es.us-east-1.aws.found.io:9243" # todo: retire or set GRN
+  es_username                            = "elastic"
+  gradle_home                            = "/usr/local/gradle"
+  java_home                              = "/usr/lib/jvm/java"
+  logbuilder_include_cpu_utilization     = "true"
+  logbuilder_include_memory_utilization  = "true"
+  m2                                     = "/usr/local/apache-maven/bin"
+  m2_home                                = "/usr/local/apache-maven"
+  server_port                            = "8080"
+  server_url                             = "https://test.globalrefugee.net/"
+  sf_base_classic_url                    = "https://talentbeyondboundaries--sfstaging.sandbox.my.salesforce.com/" # todo: set GRN if different
+  sf_base_lightning_url                  = "https://talentbeyondboundaries--sfstaging.sandbox.lightning.force.com"
+  sf_base_login_url                      = "https://test.salesforce.com/"
+  spring_client_url                      = "-"
+  spring_datasource_url                  = "" # use RDS created by this stack
+  spring_datasource_username            = "tctalent"
+  spring_db_pool_max                     = "50"
+  spring_db_pool_min                     = "20"
+  spring_servlet_max_file_size           = "10MB"
+  spring_servlet_max_request_size       = "10MB"
+  tc_api_url                             = "https://test.api.globalrefugee.net"
+  tc_cors_urls                           = "https://test.globalrefugee.net,https://www.test.globalrefugee.net"
+  tc_db_copy_config                      = "data.sharing/tcCopies.xml"
+  tc_destinations                        = "Australia,Canada,New Zealand,United Kingdom"
+  tc_skills_extraction_api_url           = "https://test.skills.globalrefugee.net"
+  web_admin                              = "https://test.globalrefugee.net/admin-portal"
+  web_portal                             = "https://test.globalrefugee.net/candidate-portal"
+  tc_instance_type                       = "TBB"
+
+  # Secrets: loaded from secrets.auto.tfvars
+  aws_access_key             = var.aws_access_key
+  aws_secret_key             = var.aws_secret_key
+  duolingo_api_secret        = var.duolingo_api_secret
+  es_password                = var.es_password
+  email_password             = var.email_password
+  drive_id                   = var.drive_id
+  drive_rootfolder           = var.drive_rootfolder
+  drive_list_folders_id      = var.drive_list_folders_id
+  drive_list_folders_root_id = var.drive_list_folders_root_id
+  drive_private_key          = var.drive_private_key
+  drive_private_key_id       = var.drive_private_key_id
+  jwt_secret                 = var.jwt_secret
+  preset_api_token           = var.preset_api_token
+  preset_secret              = var.preset_secret
+  preset_workspace_id        = var.preset_workspace_id
+  sf_consumer_key            = var.sf_consumer_key
+  sf_private_key             = var.sf_private_key
+  sf_user                    = var.sf_user
+  slack_channel_id           = var.slack_channel_id
+  slack_token                = var.slack_token
+  spring_datasource_password = var.spring_datasource_password
+  tc_api_key                 = var.tc_api_key
+  translation_password       = var.translation_password
+  tc_boot_admin_password     = var.tc_boot_admin_password
+}
+
+terraform {
+  required_version = ">= 1.3.0"
+
+  backend "s3" {
+    bucket         = "opc-shared-terraform-state"
+    key            = "staging/grn/terraform.tfstate"
+    region         = "eu-west-2"
+    dynamodb_table = "opc-terraform-locks"
+    encrypt        = "true"
+  }
+}

--- a/infra/aws/terraform/opc-staging/main.tf
+++ b/infra/aws/terraform/opc-staging/main.tf
@@ -251,7 +251,9 @@ module "tc-plus-staging" {
   sf_base_lightning_url                  = "https://talentbeyondboundaries--sfstaging.sandbox.lightning.force.com"
   sf_base_login_url                      = "https://test.salesforce.com/"
   spring_client_url                      = "-" # todo: confirm if used/needed
-  spring_datasource_url                  = "jdbc:postgresql://tbbtalent-prod.cy7icd7y1lyr.us-east-1.rds.amazonaws.com:5432/tctalent" # legacy TBB DB -- in parallel to local RDS
+  # Legacy TBB DB. This stack also creates an OPC RDS (unused while URL is set).
+  # To point the service at the OPC RDS instead, set spring_datasource_url = "" and apply; then restart ECS to pick up the new SSM value.
+  spring_datasource_url                  = "jdbc:postgresql://tbbtalent-prod.cy7icd7y1lyr.us-east-1.rds.amazonaws.com:5432/tctalent"
   spring_datasource_username             = "tctalent"
   spring_db_pool_max                     = "50"
   spring_db_pool_min                     = "20"

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -203,6 +203,8 @@ jib {
             image = "164804461258.dkr.ecr.eu-west-2.amazonaws.com/tc-core:tc-server-staging"
         } else if (project.hasProperty("opc-prod")) {
             image = "289896345557.dkr.ecr.eu-west-2.amazonaws.com/tc-core:tc-server-prod"
+        } else if (project.hasProperty("grn-staging")) {
+            image = "164804461258.dkr.ecr.eu-west-2.amazonaws.com/grn-core:grn-staging"
         }
         credHelper = 'ecr-login'
     }


### PR DESCRIPTION
This PR - 

- introduces infrastructure to deploy a new GRN (Global Refugee Network) staging environment

This will run alongside the existing OPC staging TC deployment in the same AWS account. 

