### PR TITLE
Update chatbot visibility logic for GRN instance type on local and staging only

### DIFF
--- a/ui/candidate-portal/src/app/components/app.component.html
+++ b/ui/candidate-portal/src/app/components/app.component.html
@@ -19,4 +19,4 @@
   Loading ...
 </ng-container>
 <router-outlet *ngIf="!loading"></router-outlet>
-<app-chatbot *ngIf="isTBBPartner"></app-chatbot>
+<app-chatbot *ngIf="showTcChatbot"></app-chatbot>

--- a/ui/candidate-portal/src/app/components/app.component.spec.ts
+++ b/ui/candidate-portal/src/app/components/app.component.spec.ts
@@ -145,13 +145,13 @@ describe('AppComponent', () => {
       expect(component.showTcChatbot).toBe(false);
     }));
 
-    it('should hide chatbot for GRN instances in local', fakeAsync(() => {
+    it('should show chatbot for GRN instances in local', fakeAsync(() => {
       environment.environmentName = 'local';
       authServiceSpy.getTcInstanceType.and.returnValue(TcInstanceType.GRN);
       fixture.detectChanges();
       tick();
 
-      expect(component.showTcChatbot).toBe(false);
+      expect(component.showTcChatbot).toBe(true);
     }));
 
     it('should recompute chatbot visibility when user login state changes', fakeAsync(() => {

--- a/ui/candidate-portal/src/app/components/app.component.spec.ts
+++ b/ui/candidate-portal/src/app/components/app.component.spec.ts
@@ -16,15 +16,17 @@
 
 import { ComponentFixture, fakeAsync, TestBed, tick, waitForAsync } from '@angular/core/testing';
 import { ActivatedRoute, Router } from '@angular/router';
-import { BehaviorSubject, of, throwError } from 'rxjs';
+import { BehaviorSubject } from 'rxjs';
 import { AppComponent } from './app.component';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { AuthenticationService } from '../services/authentication.service';
 import { ChatService } from '../services/chat.service';
 import { LanguageService } from '../services/language.service';
 import { LanguageLoader } from '../services/language.loader';
-import { BrandingService, BrandingInfo } from '../services/branding.service';
+import { BrandingService } from '../services/branding.service';
 import { User } from '../model/user';
+import { TcInstanceType } from '../model/tc-instance-type';
+import { environment } from '../../environments/environment';
 
 describe('AppComponent', () => {
   let component: AppComponent;
@@ -40,6 +42,7 @@ describe('AppComponent', () => {
   let languageLoadingSubject: BehaviorSubject<boolean>;
   let languageChangedSubject: BehaviorSubject<void>;
   let queryParamMapSubject: BehaviorSubject<any>;
+  let originalEnvironmentName: string;
 
   beforeEach(waitForAsync(() => {
     // Initialize subjects
@@ -51,10 +54,10 @@ describe('AppComponent', () => {
     });
 
     // Create spies
-    const authSpy = jasmine.createSpyObj('AuthenticationService', ['isAuthenticated']);
+    const authSpy = jasmine.createSpyObj('AuthenticationService', ['isAuthenticated', 'getTcInstanceType']);
     authSpy.loggedInUser$ = loggedInUserSubject.asObservable();
 
-    const brandingSpy = jasmine.createSpyObj('BrandingService', ['setPartnerAbbreviation', 'getBrandingInfoFromApi']);
+    const brandingSpy = jasmine.createSpyObj('BrandingService', ['setPartnerAbbreviation']);
     const chatSpy = jasmine.createSpyObj('ChatService', ['cleanUp']);
     const languageSpy = jasmine.createSpyObj('LanguageService', ['getSelectedLanguage', 'isSelectedLanguageRtl']);
     const languageLoadSpy = jasmine.createSpyObj('LanguageLoader', ['load']);
@@ -96,69 +99,69 @@ describe('AppComponent', () => {
   }));
 
   beforeEach(() => {
+    originalEnvironmentName = environment.environmentName;
     // Set default return values
     languageServiceSpy.getSelectedLanguage.and.returnValue('en');
     languageServiceSpy.isSelectedLanguageRtl.and.returnValue(false);
-    brandingServiceSpy.getBrandingInfoFromApi.and.returnValue(of({
-      logo: 'logo.png',
-      partnerName: 'Test Partner',
-      websiteUrl: 'https://test.com'
-    }));
+    authServiceSpy.getTcInstanceType.and.returnValue(TcInstanceType.TBB);
 
     fixture = TestBed.createComponent(AppComponent);
     component = fixture.componentInstance;
+  });
+
+  afterEach(() => {
+    environment.environmentName = originalEnvironmentName;
   });
 
   it('should create the app', () => {
     expect(component).toBeTruthy();
   });
 
-  describe('Branding Tests', () => {
-    it('should set isTBBPartner to true when partner is Talent Beyond Boundaries', fakeAsync(() => {
-      const tbbBrandingInfo: BrandingInfo = {
-        logo: 'tbb-logo.png',
-        partnerName: 'Talent Beyond Boundaries',
-        websiteUrl: 'https://talentbeyondboundaries.org'
-      };
-
-      brandingServiceSpy.getBrandingInfoFromApi.and.returnValue(of(tbbBrandingInfo));
-
+  describe('Chatbot Visibility Gate', () => {
+    it('should show chatbot for GRN instances in staging', fakeAsync(() => {
+      environment.environmentName = 'staging';
+      authServiceSpy.getTcInstanceType.and.returnValue(TcInstanceType.GRN);
       fixture.detectChanges();
       tick();
 
-      expect(component.isTBBPartner).toBe(true);
+      expect(component.showTcChatbot).toBe(true);
     }));
 
-    it('should set isTBBPartner to false for other partners', fakeAsync(() => {
-      const otherBrandingInfo: BrandingInfo = {
-        logo: 'other-logo.png',
-        partnerName: 'Other Partner',
-        websiteUrl: 'https://other.com'
-      };
-
-      brandingServiceSpy.getBrandingInfoFromApi.and.returnValue(of(otherBrandingInfo));
-
+    it('should hide chatbot for TBB instances in staging', fakeAsync(() => {
+      environment.environmentName = 'staging';
+      authServiceSpy.getTcInstanceType.and.returnValue(TcInstanceType.TBB);
       fixture.detectChanges();
       tick();
 
-      expect(component.isTBBPartner).toBe(false);
+      expect(component.showTcChatbot).toBe(false);
     }));
 
-    it('should set isTBBPartner to false on branding API error', fakeAsync(() => {
-      brandingServiceSpy.getBrandingInfoFromApi.and.returnValue(
-        throwError(() => new Error('API Error'))
-      );
-
+    it('should hide chatbot for GRN instances in prod', fakeAsync(() => {
+      environment.environmentName = 'prod';
+      authServiceSpy.getTcInstanceType.and.returnValue(TcInstanceType.GRN);
       fixture.detectChanges();
       tick();
 
-      expect(component.isTBBPartner).toBe(false);
+      expect(component.showTcChatbot).toBe(false);
     }));
 
-    it('should check branding when user login state changes', fakeAsync(() => {
+    it('should hide chatbot for GRN instances in local', fakeAsync(() => {
+      environment.environmentName = 'local';
+      authServiceSpy.getTcInstanceType.and.returnValue(TcInstanceType.GRN);
       fixture.detectChanges();
-      const initialCallCount = brandingServiceSpy.getBrandingInfoFromApi.calls.count();
+      tick();
 
+      expect(component.showTcChatbot).toBe(false);
+    }));
+
+    it('should recompute chatbot visibility when user login state changes', fakeAsync(() => {
+      environment.environmentName = 'staging';
+      authServiceSpy.getTcInstanceType.and.returnValue(TcInstanceType.TBB);
+      fixture.detectChanges();
+      tick();
+      expect(component.showTcChatbot).toBe(false);
+
+      authServiceSpy.getTcInstanceType.and.returnValue(TcInstanceType.GRN);
       const mockUser: User = {
         id: 1,
         username: 'testuser',
@@ -168,7 +171,7 @@ describe('AppComponent', () => {
       loggedInUserSubject.next(mockUser);
       tick();
 
-      expect(brandingServiceSpy.getBrandingInfoFromApi.calls.count()).toBeGreaterThan(initialCallCount);
+      expect(component.showTcChatbot).toBe(true);
     }));
   });
 
@@ -185,18 +188,16 @@ describe('AppComponent', () => {
       expect(brandingServiceSpy.setPartnerAbbreviation).toHaveBeenCalledWith('TBB');
     }));
 
-    it('should check branding when query params change', fakeAsync(() => {
-      fixture.detectChanges();
-      const initialCallCount = brandingServiceSpy.getBrandingInfoFromApi.calls.count();
-
+    it('should update partner abbreviation when query params change', fakeAsync(() => {
       const mockQueryParamMap = {
         get: (key: string) => key === 'p' ? 'PARTNER' : null
       };
 
+      fixture.detectChanges();
       queryParamMapSubject.next(mockQueryParamMap);
       tick();
 
-      expect(brandingServiceSpy.getBrandingInfoFromApi.calls.count()).toBeGreaterThan(initialCallCount);
+      expect(brandingServiceSpy.setPartnerAbbreviation).toHaveBeenCalledWith('PARTNER');
     }));
 
     it('should handle initial query params from snapshot', fakeAsync(() => {

--- a/ui/candidate-portal/src/app/components/app.component.ts
+++ b/ui/candidate-portal/src/app/components/app.component.ts
@@ -121,8 +121,8 @@ export class AppComponent implements OnInit {
 
   private updateChatbotVisibility(): void {
     const isGrnInstance = this.authenticationService.getTcInstanceType() === TcInstanceType.GRN;
-    const isStagingEnvironment = environment.environmentName === 'staging';
-    this.showTcChatbot = isGrnInstance && isStagingEnvironment;
+    const isEnabledEnvironment = ['local', 'staging'].includes(environment.environmentName);
+    this.showTcChatbot = isGrnInstance && isEnabledEnvironment;
   }
 
   private trackClarityViews() {

--- a/ui/candidate-portal/src/app/components/app.component.ts
+++ b/ui/candidate-portal/src/app/components/app.component.ts
@@ -23,8 +23,9 @@ import {User} from "../model/user";
 import {ActivatedRoute, NavigationEnd, Router} from "@angular/router";
 import {ChatService} from "../services/chat.service";
 import {environment} from "../../environments/environment";
-import {BrandingInfo, BrandingService} from "../services/branding.service";
+import {BrandingService} from "../services/branding.service";
 import Clarity from '@microsoft/clarity';
+import {TcInstanceType} from "../model/tc-instance-type";
 
 @Component({
   selector: 'app-root',
@@ -37,7 +38,7 @@ export class AppComponent implements OnInit {
   @HostBinding('class.rtl-wrapper') rtl: boolean = false;
 
   loading: boolean;
-  isTBBPartner: boolean = false;
+  showTcChatbot: boolean = false;
 
   constructor(private translate: TranslateService,
               private authenticationService: AuthenticationService,
@@ -56,7 +57,7 @@ export class AppComponent implements OnInit {
     this.authenticationService.loggedInUser$.subscribe(
       (user) => {
         this.onChangedLogin(user);
-        this.checkBranding();
+        this.updateChatbotVisibility();
       }
     )
 
@@ -81,7 +82,6 @@ export class AppComponent implements OnInit {
     this.route.queryParamMap.subscribe(
       (params) => {
         this.brandingService.setPartnerAbbreviation(params.get('p'));
-        this.checkBranding();
       }
     );
 
@@ -90,7 +90,7 @@ export class AppComponent implements OnInit {
     if (initialParams['p']) {
       this.brandingService.setPartnerAbbreviation(initialParams['p']);
     }
-    this.checkBranding();
+    this.updateChatbotVisibility();
 
     // this language will be used as a fallback when a translation isn't
     // found in the current language. This forces loading of translations.
@@ -119,22 +119,10 @@ export class AppComponent implements OnInit {
     this.router.navigate(['login']);
   }
 
-  private checkBranding(): void {
-    // Use getBrandingInfoFromApi to get actual partner name for both registered and unregistered users
-    this.brandingService.getBrandingInfoFromApi().subscribe(
-      (response: BrandingInfo) => {
-        console.log('Branding API response:', response);
-        console.log('Partner name:', response.partnerName);
-        this.isTBBPartner = response.partnerName === "Talent Beyond Boundaries";
-        console.log('isTBBPartner set to:', this.isTBBPartner);
-      },
-      (error) => {
-        console.error('Error fetching branding info:', error);
-        // On error, default to hiding chatbot
-        this.isTBBPartner = false;
-        console.log('isTBBPartner set to false due to error');
-      }
-    );
+  private updateChatbotVisibility(): void {
+    const isGrnInstance = this.authenticationService.getTcInstanceType() === TcInstanceType.GRN;
+    const isStagingEnvironment = environment.environmentName === 'staging';
+    this.showTcChatbot = isGrnInstance && isStagingEnvironment;
   }
 
   private trackClarityViews() {


### PR DESCRIPTION
This PR -- 

- updates the logic for displaying the chatbot in the candidate portal
- replaces the previous partner-based check with GRN instance-type and local/staging environment check

