### PR TITLE
Independent deployment support for GRN and TBB production images

### DIFF
--- a/.github/workflows/tc-prod-build-deploy.yml
+++ b/.github/workflows/tc-prod-build-deploy.yml
@@ -62,8 +62,8 @@ jobs:
           GOOGLE_DRIVE_PRIVATEKEYID: ${{ secrets.GOOGLE_DRIVE_PRIVATEKEYID }}
           SF_PRIVATE_KEY: ${{ secrets.SF_PRIVATE_KEY }}
 
-  deploy-tbb:
-    name: Deploy to TBB Prod
+  deploy-tc-prod:
+    name: Deploy to TC Prod (TBB + OPC)
     runs-on: ubuntu-latest
     needs: build-and-test
     if: github.event_name == 'workflow_dispatch' && (github.event.inputs.target_env == 'tbb' || github.event.inputs.target_env == 'both')
@@ -91,8 +91,18 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
 
-      - name: Deploy to TBB with Jib
+      - name: Deploy to TBB legacy prod with Jib
         run: ./gradlew jib -Ptbb-prod -x test
+
+      - name: Configure AWS credentials for OPC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_OPC_PROD }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_OPC_PROD }}
+          aws-region: eu-west-2
+
+      - name: Deploy to OPC prod with Jib
+        run: ./gradlew jib -Popc-prod -x test
 
   deploy-grn:
     name: Deploy to GRN Prod

--- a/.github/workflows/tc-prod-build-deploy.yml
+++ b/.github/workflows/tc-prod-build-deploy.yml
@@ -66,6 +66,7 @@ jobs:
     name: Deploy to TC Prod (TBB + OPC)
     runs-on: ubuntu-latest
     needs: build-and-test
+    environment: production-tbb
     if: github.event_name == 'workflow_dispatch' && (github.event.inputs.target_env == 'tbb' || github.event.inputs.target_env == 'both')
 
     steps:
@@ -108,6 +109,7 @@ jobs:
     name: Deploy to GRN Prod
     runs-on: ubuntu-latest
     needs: build-and-test
+    environment: production-grn
     if: github.event_name == 'workflow_dispatch' && (github.event.inputs.target_env == 'grn' || github.event.inputs.target_env == 'both')
 
     steps:

--- a/.github/workflows/tc-prod-build-deploy.yml
+++ b/.github/workflows/tc-prod-build-deploy.yml
@@ -8,10 +8,21 @@ name: tc-prod-build-deploy
 on:
   push:
     branches: [ master ]
+  workflow_dispatch:
+    inputs:
+      target_env:
+        description: "Production deployment target"
+        required: true
+        default: grn
+        type: choice
+        options:
+          - grn
+          - tbb
+          - both
 
 jobs:
-  build-and-deploy:
-    name: Build, Test and Deploy to Prod
+  build-and-test:
+    name: Build and Test
     runs-on: ubuntu-latest
 
     steps:
@@ -51,7 +62,27 @@ jobs:
           GOOGLE_DRIVE_PRIVATEKEYID: ${{ secrets.GOOGLE_DRIVE_PRIVATEKEYID }}
           SF_PRIVATE_KEY: ${{ secrets.SF_PRIVATE_KEY }}
 
-      # --- Deploy to TBB Prod (us-east-1) ---
+  deploy-tbb:
+    name: Deploy to TBB Prod
+    runs-on: ubuntu-latest
+    needs: build-and-test
+    if: github.event_name == 'workflow_dispatch' && (github.event.inputs.target_env == 'tbb' || github.event.inputs.target_env == 'both')
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+
+      - name: Install credential helper - for jib
+        run: sudo apt update && sudo apt install amazon-ecr-credential-helper
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
 
       - name: Configure AWS credentials for TBB
         uses: aws-actions/configure-aws-credentials@v4
@@ -61,16 +92,36 @@ jobs:
           aws-region: us-east-1
 
       - name: Deploy to TBB with Jib
-        run: ./gradlew jib -Pprod-tc-system -x test
+        run: ./gradlew jib -Ptbb-prod -x test
 
-      # --- Deploy to OPC Prod (eu-west-2) ---
+  deploy-grn:
+    name: Deploy to GRN Prod
+    runs-on: ubuntu-latest
+    needs: build-and-test
+    if: github.event_name == 'workflow_dispatch' && (github.event.inputs.target_env == 'grn' || github.event.inputs.target_env == 'both')
 
-      - name: Configure AWS credentials for OPC
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+
+      - name: Install credential helper - for jib
+        run: sudo apt update && sudo apt install amazon-ecr-credential-helper
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Configure AWS credentials for GRN
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_OPC_PROD }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_OPC_PROD }}
           aws-region: eu-west-2
 
-      - name: Deploy to OPC with Jib
-        run: ./gradlew jib -Popc-prod -x test
+      - name: Deploy to GRN with Jib
+        run: ./gradlew jib -Pgrn-prod -x test

--- a/README.md
+++ b/README.md
@@ -531,20 +531,23 @@ for additional documentation.
 
 ### Master branch ###
 
-The main branch is "master". We only merge and push into "master" when we are
-ready to deploy to production (rebuild and upload of build artifacts to the
-production environment is automatic, triggered by any push to "master".
-See Deployment section below).
+The main branch is "master". We only merge into "master" when code is ready for production. A push 
+to "master" automatically runs the build and test pipeline but does **not** automatically deploy to 
+any production environment. Production image deployments to GRN and TC (TBB + OPC) are triggered
+independently and manually — see the
+[Release Runbook wiki](https://github.com/Talent-Catalog/talentcatalog/wiki/Release#release-runbook)
+for full details.
 
-Master should only be accessed directly when staging
-is merged into it, triggering deployment to production. You should not
+Master should only be accessed directly when staging is merged into it. You should not
 do normal development in Master.
 
 ### Staging branch ###
 
 The "staging" branch is used for code which is potentially ready to go into
-production. Code is pushed into production by merging staging into master and
-then pushing master. See Deployment section below.
+production. Code is promoted to production by merging staging into master. Production deployments 
+are then triggered manually via GitHub Actions — see the
+[Release wiki](https://github.com/Talent-Catalog/talentcatalog/wiki/Release) for the
+release runbook.
 
 Staging is a shared resource so you should only push changes there when
 you have finished changes which you are confident will build without error

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -195,15 +195,36 @@ jib {
         ]
     }
     to {
+        // TBB staging (legacy)
         if (project.hasProperty("test-tc-system")) {
             image = "231168606641.dkr.ecr.us-east-1.amazonaws.com/test-ecs"
-        } else if (project.hasProperty("prod-tc-system")) {
+        }
+
+        // TBB production (legacy)
+        else if (project.hasProperty("tbb-prod") || project.hasProperty("prod-tc-system")) {
             image = "968457613372.dkr.ecr.us-east-1.amazonaws.com/talent-catalog"
-        } else if (project.hasProperty("opc-staging")) {
+        }
+
+        // OPC staging (TC)
+        else if (project.hasProperty("opc-staging")) {
             image = "164804461258.dkr.ecr.eu-west-2.amazonaws.com/tc-core:tc-server-staging"
-        } else if (project.hasProperty("opc-prod")) {
+        }
+
+        // OPC production (TC)
+        else if (project.hasProperty("opc-prod")) {
             image = "289896345557.dkr.ecr.eu-west-2.amazonaws.com/tc-core:tc-server-prod"
         }
+
+        // GRN staging
+         else if (project.hasProperty("grn-staging")) {
+            image = "164804461258.dkr.ecr.eu-west-2.amazonaws.com/grn-core:grn-staging"
+         }
+
+        // GRN production
+        else if (project.hasProperty("grn-prod")) {
+            image = "289896345557.dkr.ecr.eu-west-2.amazonaws.com/grn-core:grn-prod"
+        }
+
         credHelper = 'ecr-login'
     }
 }

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -216,9 +216,9 @@ jib {
         }
 
         // GRN staging
-         else if (project.hasProperty("grn-staging")) {
+        else if (project.hasProperty("grn-staging")) {
             image = "164804461258.dkr.ecr.eu-west-2.amazonaws.com/grn-core:grn-staging"
-         }
+        }
 
         // GRN production
         else if (project.hasProperty("grn-prod")) {


### PR DESCRIPTION
This PR -

- splits the production deployment workflow for TBB and GRN images
- updates project Readme and Wiki release runbook accordingly

