### PR TITLE
Disable DPA enforcement (interim) + fix login DPA split-logic bug

### DIFF
--- a/server/src/main/java/org/tctalent/server/configuration/properties/DpaProperties.java
+++ b/server/src/main/java/org/tctalent/server/configuration/properties/DpaProperties.java
@@ -25,4 +25,5 @@ import org.springframework.context.annotation.Configuration;
 @Data
 public class DpaProperties {
   private Long dpaVisibilityDelayDays;
+  private boolean enabled;
 }

--- a/server/src/main/java/org/tctalent/server/service/db/impl/PartnerServiceImpl.java
+++ b/server/src/main/java/org/tctalent/server/service/db/impl/PartnerServiceImpl.java
@@ -395,6 +395,10 @@ public class PartnerServiceImpl implements PartnerService {
     }
     @Transactional
     public boolean requiresDpaAcceptance() {
+        if (!dpaProperties.isEnabled()) {
+            return false;
+        }
+
         User user = authService.getLoggedInUser()
             .orElseThrow(() -> new InvalidSessionException("Not logged in"));
         PartnerImpl partner = user.getPartner();

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -307,5 +307,5 @@ tc-skills-extraction-service:
   apiKey: ${TC_SKILLS_EXTRACTION_API_KEY:}
 
 dpa:
-  # Used in EmailHelper
   dpaVisibilityDelayDays: ${DPA_VISIBILITY_DELAY_DAYS:90}
+  enabled: ${DPA_ENABLED:false}

--- a/ui/admin-portal/src/app/components/login/login.component.ts
+++ b/ui/admin-portal/src/app/components/login/login.component.ts
@@ -17,17 +17,13 @@
 import {Component, OnInit} from '@angular/core';
 import {UntypedFormBuilder, UntypedFormGroup, Validators} from "@angular/forms";
 import {ActivatedRoute, Router} from "@angular/router";
-import {DtoType, LoginRequest} from "../../model/base";
+import {LoginRequest} from "../../model/base";
 import {User} from "../../model/user";
 import {EncodedQrImage} from "../../util/qr";
 import {ShowQrCodeComponent} from "../util/qr/show-qr-code/show-qr-code.component";
 import {NgbModal} from "@ng-bootstrap/ng-bootstrap";
 import {AuthenticationService} from "../../services/authentication.service";
 import {environment} from "../../../environments/environment";
-import {Partner} from "../../model/partner";
-import {TermsInfoDto, TermsType} from "../../model/terms-info-dto";
-import {forkJoin} from "rxjs";
-import {TermsInfoService} from "../../services/terms-info.service";
 import {PartnerService} from "../../services/partner.service";
 import {AuthorizationService} from "../../services/authorization.service";
 
@@ -52,7 +48,6 @@ export class LoginComponent implements OnInit {
               private modalService: NgbModal,
               private route: ActivatedRoute,
               private partnerService: PartnerService,
-              private termsInfoService: TermsInfoService,
               private router: Router) {
   }
 
@@ -149,38 +144,24 @@ export class LoginComponent implements OnInit {
   }
 
   private checkMfaAndDpa() {
-    const user: User = this.authenticationService.getLoggedInUser();
-    // Check if user is a source partner (based on role or partner association)
-    if (this.authorizationService.isSourcePartner()) {
-      // Fetch current DPA and partner info
-      forkJoin({
-        'currentDpa': this.termsInfoService.getCurrentByType(TermsType.OPC_STANDARD_DATA_PROCESSING_AGREEMENT),
-        'partner': this.partnerService.getPartner(user.partner.id, DtoType.MINIMAL)
-      }).subscribe(
-        results => {
-          this.checkDpaStatus(results.partner, results.currentDpa);
-        },
-        error => {
-          this.error = error;
-          this.loading = false;
-        }
-      );
-    } else {
+    if (!this.authorizationService.isSourcePartner()) {
       // Non-partner users skip DPA check and proceed to MFA
       this.checkMfaSetup();
+      return;
     }
-  }
-
-  private checkDpaStatus(partner: Partner, currentDpa: TermsInfoDto) {
-    // Check if partner has accepted the latest DPA
-    if (partner.sourcePartner && (partner.acceptedDataProcessingAgreementId == null
-      || partner.acceptedDataProcessingAgreementId !== currentDpa.id)) {
-      // Redirect to DPA acceptance page, ignoring returnUrl
-      this.router.navigateByUrl('/dpa');
-    } else {
-      // Proceed to MFA check if DPA is accepted
-      this.checkMfaSetup();
-    }
+    this.partnerService.requiresDpaAcceptance().subscribe({
+      next: (requiresDpa: boolean) => {
+        if (requiresDpa) {
+          this.router.navigateByUrl('/dpa');
+        } else {
+          this.checkMfaSetup();
+        }
+      },
+      error: error => {
+        this.error = error;
+        this.loading = false;
+      }
+    });
   }
 }
 


### PR DESCRIPTION
This PR --

- disables DPA enforcement (interim)
- adds dpa.enabled flag (default false) to backend config
  - can be enabled (when needed) per environment by setting DPA_ENABLED=true in AWS SSM
  - no code change or release needed
- refactors login DPA check to use the backend requiresDpaAcceptance() endpoint (same as DpaGuard)
  - removing a split-logic bug where login and the route guard applied different DPA rules
