### PR TITLE
3268 copy translations from tbb prod aws s3 to grn prod aws s3

### DIFF
--- a/infra/aws/terraform/computing.tf
+++ b/infra/aws/terraform/computing.tf
@@ -85,6 +85,64 @@ resource "aws_iam_role_policy_attachment" "ecs_task_execution_role_policy_attach
   policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
 }
 
+resource "aws_iam_role" "ecs_task_role" {
+  name = "${var.app}-${var.env}-fargate-task-role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow",
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+locals {
+  s3_data_bucket_arns = compact([
+    var.s3_bucket != "" ? "arn:aws:s3:::${var.s3_bucket}" : "",
+    var.translations_bucket != "" ? "arn:aws:s3:::${var.translations_bucket}" : "",
+    var.candidate_files_bucket != "" ? "arn:aws:s3:::${var.candidate_files_bucket}" : ""
+  ])
+  s3_data_object_arns = [for arn in local.s3_data_bucket_arns : "${arn}/*"]
+}
+
+resource "aws_iam_policy" "ecs_task_s3_policy" {
+  name = "${var.app}-${var.env}-fargate-task-s3-policy"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:ListBucket",
+          "s3:GetBucketLocation"
+        ]
+        Resource = local.s3_data_bucket_arns
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:DeleteObject",
+          "s3:AbortMultipartUpload"
+        ]
+        Resource = local.s3_data_object_arns
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_task_role_policy_attachment_s3" {
+  role       = aws_iam_role.ecs_task_role.name
+  policy_arn = aws_iam_policy.ecs_task_s3_policy.arn
+}
+
 # ALB
 module "alb" {
   source             = "terraform-aws-modules/alb/aws"
@@ -249,6 +307,7 @@ resource "aws_ecs_task_definition" "web-app" {
   requires_compatibilities = ["FARGATE"]
   network_mode             = "awsvpc"
   execution_role_arn       = aws_iam_role.ecs_task_execution_role.arn
+  task_role_arn            = aws_iam_role.ecs_task_role.arn
   cpu                      = var.fargate_cpu
   memory                   = var.fargate_memory
   container_definitions = jsonencode([

--- a/infra/aws/terraform/grn-staging/main.tf
+++ b/infra/aws/terraform/grn-staging/main.tf
@@ -241,6 +241,8 @@ module "grn_staging" {
   cloudfront_enable                     = true
   candidate_files_bucket                = "candidate-files.test.globalrefugee.net"
   s3_bucket                             = "files.tbbtalent.org" # todo: confirm or set GRN bucket
+  translations_bucket                   = "translations.test.globalrefugee.net"
+  translations_folder                   = "translations"
   environment                           = "grn-staging"
   email_default                         = "-"
   email_test_override                   = "-"

--- a/infra/aws/terraform/opc-prod/main.tf
+++ b/infra/aws/terraform/opc-prod/main.tf
@@ -246,7 +246,7 @@ module "tc-plus-prod" {
   # SSM-backed application parameters (stored in SSM, injected into ECS task)
   # Non-secrets: provided directly here
   s3_bucket                             = "files.tbbtalent.org" # todo: confirm bucket name
-  translations_bucket                   = "files.tbbtalent.org"
+  translations_bucket                   = "translations.tctalent.org"
   translations_folder                   = "translations"
   environment                           = "opc-prod"
   email_default                         = "-" # todo: confirm if used/needed

--- a/infra/aws/terraform/opc-prod/main.tf
+++ b/infra/aws/terraform/opc-prod/main.tf
@@ -246,6 +246,8 @@ module "tc-plus-prod" {
   # SSM-backed application parameters (stored in SSM, injected into ECS task)
   # Non-secrets: provided directly here
   s3_bucket                             = "files.tbbtalent.org" # todo: confirm bucket name
+  translations_bucket                   = "files.tbbtalent.org"
+  translations_folder                   = "translations"
   environment                           = "opc-prod"
   email_default                         = "-" # todo: confirm if used/needed
   email_test_override                   = "-" # todo: set prod value

--- a/infra/aws/terraform/opc-staging/main.tf
+++ b/infra/aws/terraform/opc-staging/main.tf
@@ -246,6 +246,8 @@ module "tc-plus-staging" {
   # SSM-backed application parameters (stored in SSM, injected into ECS task)
   # Non-secrets: provided directly here
   s3_bucket                             = "files.tbbtalent.org" # todo: confirm bucket name
+  translations_bucket                   = "files.tbbtalent.org"
+  translations_folder                   = "translations"
   environment                           = "opc-staging"
   email_default                         = "UPDATE_DEFAULT_EMAIL_HERE"                         # todo: confirm if used/needed
   email_test_override                   = "john@cameronfoundation.org"                        # todo: change to shared address

--- a/infra/aws/terraform/opc-staging/main.tf
+++ b/infra/aws/terraform/opc-staging/main.tf
@@ -246,7 +246,7 @@ module "tc-plus-staging" {
   # SSM-backed application parameters (stored in SSM, injected into ECS task)
   # Non-secrets: provided directly here
   s3_bucket                             = "files.tbbtalent.org" # todo: confirm bucket name
-  translations_bucket                   = "files.tbbtalent.org"
+  translations_bucket                   = "translations.test.tctalent.org"
   translations_folder                   = "translations"
   environment                           = "opc-staging"
   email_default                         = "UPDATE_DEFAULT_EMAIL_HERE"                         # todo: confirm if used/needed

--- a/infra/aws/terraform/parameters.tf
+++ b/infra/aws/terraform/parameters.tf
@@ -20,9 +20,21 @@ resource "aws_ssm_parameter" "s3_bucket" {
   value = var.s3_bucket
 }
 
+resource "aws_ssm_parameter" "translations_bucket" {
+  name  = "/${var.app}/${var.env}/S3_TRANSLATIONS_BUCKET"
+  type  = "String"
+  value = var.translations_bucket
+}
+
+resource "aws_ssm_parameter" "translations_folder" {
+  name  = "/${var.app}/${var.env}/S3_TRANSLATIONS_FOLDER"
+  type  = "String"
+  value = var.translations_folder
+}
+
 resource "aws_ssm_parameter" "candidate_files_bucket" {
   count = var.cloudfront_enable ? 1 : 0
-  name  = "/${var.app}/${var.env}/AWS_S3_CANDIDATE_FILES_BUCKET"
+  name  = "/${var.app}/${var.env}/S3_CANDIDATE_FILES_BUCKET"
   type  = "String"
   value = aws_s3_bucket.candidate_files[0].bucket
 }

--- a/infra/aws/terraform/prod/main.tf
+++ b/infra/aws/terraform/prod/main.tf
@@ -40,6 +40,8 @@ module "website" {
   aws_access_key                  = var.aws_access_key
   aws_secret_key                  = var.aws_secret_key
   s3_bucket                       = var.s3_bucket
+  translations_bucket             = var.translations_bucket
+  translations_folder             = var.translations_folder
   es_password                     = var.es_password
   es_url                          = var.es_url
   es_username                     = var.es_username

--- a/infra/aws/terraform/prod/variables.tf
+++ b/infra/aws/terraform/prod/variables.tf
@@ -50,6 +50,14 @@ variable "s3_bucket" {
   type = string
 }
 
+variable "translations_bucket" {
+  type = string
+}
+
+variable "translations_folder" {
+  type = string
+}
+
 variable "es_password" {
   type = string
 }

--- a/infra/aws/terraform/s3.tf
+++ b/infra/aws/terraform/s3.tf
@@ -67,3 +67,44 @@ resource "aws_s3_bucket_policy" "candidate_files" {
     ]
   })
 }
+
+resource "aws_s3_bucket" "translations" {
+  bucket = var.translations_bucket
+
+  tags = merge(
+    {
+      Name = var.translations_bucket
+    },
+    var.common_tags,
+    {
+      Purpose = "Translations"
+    }
+  )
+}
+
+resource "aws_s3_bucket_public_access_block" "translations" {
+  bucket = aws_s3_bucket.translations.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "translations" {
+  bucket = aws_s3_bucket.translations.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_versioning" "translations" {
+  bucket = aws_s3_bucket.translations.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}

--- a/infra/aws/terraform/test/main.tf
+++ b/infra/aws/terraform/test/main.tf
@@ -44,6 +44,8 @@ module "website" {
   aws_access_key                  = var.aws_access_key
   aws_secret_key                  = var.aws_secret_key
   s3_bucket                       = var.s3_bucket
+  translations_bucket             = var.translations_bucket
+  translations_folder             = var.translations_folder
   es_password                     = var.es_password
   es_url                          = var.es_url
   es_username                     = var.es_username

--- a/infra/aws/terraform/test/variables.tf
+++ b/infra/aws/terraform/test/variables.tf
@@ -50,6 +50,14 @@ variable "s3_bucket" {
   type = string
 }
 
+variable "translations_bucket" {
+  type = string
+}
+
+variable "translations_folder" {
+  type = string
+}
+
 variable "es_password" {
   type = string
 }

--- a/infra/aws/terraform/variables.tf
+++ b/infra/aws/terraform/variables.tf
@@ -208,6 +208,16 @@ variable "s3_bucket" {
   description = "S3 bucket name"
 }
 
+variable "translations_bucket" {
+  type        = string
+  description = "S3 bucket name for translations"
+}
+
+variable "translations_folder" {
+  type        = string
+  description = "S3 folder/prefix for translations"
+}
+
 variable "environment" {
   type        = string
   description = "Denotes running environment (e.g., opc-staging, opc-prod)"

--- a/server/src/main/java/org/tctalent/server/api/admin/SystemAdminApi.java
+++ b/server/src/main/java/org/tctalent/server/api/admin/SystemAdminApi.java
@@ -124,7 +124,6 @@ import org.tctalent.server.service.db.SavedListService;
 import org.tctalent.server.service.db.SavedSearchService;
 import org.tctalent.server.service.db.UserService;
 import org.tctalent.server.service.db.cache.CacheService;
-import org.tctalent.server.storage.S3TranslationStorageService;
 import org.tctalent.server.storage.TranslationMigrationService;
 import org.tctalent.server.util.filesystem.GoogleFileSystemDrive;
 import org.tctalent.server.util.filesystem.GoogleFileSystemFile;
@@ -285,6 +284,17 @@ public class SystemAdminApi {
         this.userService = userService;
     }
 
+    /**
+     * One-off relay migration endpoint for copying translation files between buckets that are
+     * accessed by different AWS identities/accounts. This performs a download (legacy source)
+     * followed by upload (configured destination), rather than S3 server-side copy.
+     *
+     * @param sourceBucket Source S3 bucket name (i.e. legacy TBB bucket)
+     * @param destinationBucket Destination S3 bucket name (i.e. GRN/OPC translations bucket)
+     * @param sourcePrefix Optional source prefix/folder. Defaults to {@code translations}.
+     * @param destinationPrefix Optional destination prefix/folder. Defaults to {@code translations}.
+     * @return Status map including copy mode and number of copied objects
+     */
     @GetMapping("migrate-translations")
     public Map<String, Object> migrateTranslations(
         @RequestParam("sourceBucket") String sourceBucket,

--- a/server/src/main/java/org/tctalent/server/api/admin/SystemAdminApi.java
+++ b/server/src/main/java/org/tctalent/server/api/admin/SystemAdminApi.java
@@ -123,8 +123,9 @@ import org.tctalent.server.service.db.SalesforceService;
 import org.tctalent.server.service.db.SavedListService;
 import org.tctalent.server.service.db.SavedSearchService;
 import org.tctalent.server.service.db.UserService;
-import org.tctalent.server.service.db.aws.S3ResourceHelper;
 import org.tctalent.server.service.db.cache.CacheService;
+import org.tctalent.server.storage.S3TranslationStorageService;
+import org.tctalent.server.storage.TranslationMigrationService;
 import org.tctalent.server.util.filesystem.GoogleFileSystemDrive;
 import org.tctalent.server.util.filesystem.GoogleFileSystemFile;
 import org.tctalent.server.util.filesystem.GoogleFileSystemFolder;
@@ -162,6 +163,7 @@ public class SystemAdminApi {
     private final ChatPostRepository chatPostRepository;
     private final PartnerRepository partnerRepository;
     private final CacheService cacheService;
+    private final TranslationMigrationService translationMigrationService;
 
     private final SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
 
@@ -229,7 +231,7 @@ public class SystemAdminApi {
         JobChatUserRepository jobChatUserRepository,
         ChatPostRepository chatPostRepository,
         SavedSearchRepository savedSearchRepository,
-        S3ResourceHelper s3ResourceHelper,
+        TranslationMigrationService translationMigrationService,
         GoogleDriveConfig googleDriveConfig,
         CacheService cacheService,
         BackgroundProcessingService backgroundProcessingService,
@@ -266,6 +268,7 @@ public class SystemAdminApi {
         this.jobChatRepository = jobChatRepository;
         this.jobChatUserRepository = jobChatUserRepository;
         this.chatPostRepository = chatPostRepository;
+        this.translationMigrationService = translationMigrationService;
         this.googleDriveConfig = googleDriveConfig;
         this.cacheService = cacheService;
         this.backgroundProcessingService = backgroundProcessingService;
@@ -280,6 +283,36 @@ public class SystemAdminApi {
         this.tcApiService = tcApiService;
         this.linkedInService = linkedInService;
         this.userService = userService;
+    }
+
+    @GetMapping("migrate-translations")
+    public Map<String, Object> migrateTranslations(
+        @RequestParam("sourceBucket") String sourceBucket,
+        @RequestParam("destinationBucket") String destinationBucket,
+        @RequestParam(value = "sourcePrefix", required = false) String sourcePrefix,
+        @RequestParam(value = "destinationPrefix", required = false) String destinationPrefix) {
+
+        String normalizedSourcePrefix = normalizeS3Prefix(
+            StringUtils.isBlank(sourcePrefix) ? "translations" : sourcePrefix);
+        String normalizedDestinationPrefix = normalizeS3Prefix(
+            StringUtils.isBlank(destinationPrefix) ? "translations" : destinationPrefix);
+
+        int copiedCount = translationMigrationService.migrateBucketContents(
+            sourceBucket, normalizedSourcePrefix, destinationBucket, normalizedDestinationPrefix);
+
+        return Map.of(
+            "status", "success",
+            "mode", "relay-copy",
+            "copiedCount", copiedCount,
+            "sourceBucket", sourceBucket,
+            "sourcePrefix", normalizedSourcePrefix,
+            "destinationBucket", destinationBucket,
+            "destinationPrefix", normalizedDestinationPrefix
+        );
+    }
+
+    private String normalizeS3Prefix(String prefix) {
+        return prefix.endsWith("/") ? prefix : prefix + "/";
     }
 
     /**

--- a/server/src/main/java/org/tctalent/server/configuration/S3Config.java
+++ b/server/src/main/java/org/tctalent/server/configuration/S3Config.java
@@ -23,8 +23,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.util.StringUtils;
 import org.tctalent.server.configuration.properties.S3Properties;
-import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -56,7 +56,8 @@ public class S3Config {
                 )
             );
         } else {
-            builder.credentialsProvider(AnonymousCredentialsProvider.create());
+            // Uses ECS task role credentials (or any standard AWS default provider source).
+            builder.credentialsProvider(DefaultCredentialsProvider.builder().build());
         }
         return builder.build();
     }

--- a/server/src/main/java/org/tctalent/server/configuration/SecurityConfiguration.java
+++ b/server/src/main/java/org/tctalent/server/configuration/SecurityConfiguration.java
@@ -374,6 +374,8 @@ public class SecurityConfiguration {
                 // POST: VIEW TRANSLATIONS
                 .requestMatchers(HttpMethod.POST, "/api/admin/translation/*").hasAnyRole( "SYSTEMADMIN", "ADMIN", "PARTNERADMIN", "SEMILIMITED", "LIMITED", "READONLY")
 
+                // GET: MIGRATE TRANSLATIONS BETWEEN DIFFERENT AWS IDENTITIES
+                .requestMatchers(HttpMethod.GET, "/api/admin/system/migrate-translations").hasRole("SYSTEMADMIN")
 
                 /*
                  * CANDIDATE INTAKE ENDPOINTS

--- a/server/src/main/java/org/tctalent/server/configuration/properties/S3Properties.java
+++ b/server/src/main/java/org/tctalent/server/configuration/properties/S3Properties.java
@@ -55,4 +55,16 @@ public class S3Properties {
      * Example: candidate-files.globalrefugee.net
      */
     private String candidateFilesBucket;
+
+    /**
+     * S3 bucket for translation JSON files.
+     * Example: translations.globalrefugee.net
+     */
+    private String translationsBucket;
+
+    /**
+     * S3 folder/prefix within the translations bucket.
+     * Example: translations
+     */
+    private String translationsFolder;
 }

--- a/server/src/main/java/org/tctalent/server/service/db/aws/S3ResourceHelper.java
+++ b/server/src/main/java/org/tctalent/server/service/db/aws/S3ResourceHelper.java
@@ -318,6 +318,26 @@ public class S3ResourceHelper {
         return results;
     }
 
+    public List<S3Object> listObjectSummaries(String bucket, String prefix) {
+        List<S3Object> results = new ArrayList<>();
+
+        String token = null;
+        do {
+            ListObjectsV2Response response = s3Client.listObjectsV2(
+                ListObjectsV2Request.builder()
+                    .bucket(bucket)
+                    .prefix(prefix)
+                    .continuationToken(token)
+                    .build()
+            );
+
+            results.addAll(response.contents());
+            token = response.nextContinuationToken();
+        } while (token != null);
+
+        return results;
+    }
+
     public List<S3Object> filterMigratedObjects(List<S3Object> objects) {
         return objects.stream()
             .filter(o -> !o.key().contains("/migrated/"))

--- a/server/src/main/java/org/tctalent/server/service/db/impl/TranslationServiceImpl.java
+++ b/server/src/main/java/org/tctalent/server/service/db/impl/TranslationServiceImpl.java
@@ -16,18 +16,11 @@
 
 package org.tctalent.server.service.db.impl;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.File;
-import java.io.IOException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.tomcat.util.http.fileupload.FileUploadException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
 import org.springframework.lang.Nullable;
@@ -35,7 +28,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.tctalent.server.exception.EntityExistsException;
 import org.tctalent.server.exception.NoSuchObjectException;
-import org.tctalent.server.exception.ServiceException;
 import org.tctalent.server.model.db.AbstractTranslatableDomainObject;
 import org.tctalent.server.model.db.Translation;
 import org.tctalent.server.model.db.User;
@@ -44,27 +36,25 @@ import org.tctalent.server.request.translation.CreateTranslationRequest;
 import org.tctalent.server.request.translation.UpdateTranslationRequest;
 import org.tctalent.server.security.AuthService;
 import org.tctalent.server.service.db.TranslationService;
-import org.tctalent.server.service.db.aws.S3ResourceHelper;
+import org.tctalent.server.storage.S3TranslationStorageService;
 import org.tctalent.server.util.html.HtmlSanitizer;
 
 @Service
 public class TranslationServiceImpl implements TranslationService {
 
     private final TranslationRepository translationRepository;
-    private final S3ResourceHelper s3ResourceHelper;
+    private final S3TranslationStorageService s3TranslationStorageService;
     private final AuthService authService;
-    private final Environment environment;
 
     private Map<String, Object> englishS3Translations;
 
     @Autowired
     public TranslationServiceImpl(TranslationRepository translationRepository,
-                                  S3ResourceHelper s3ResourceHelper,
+                                  S3TranslationStorageService s3TranslationStorageService,
                                   Environment environment,
                                   AuthService authService) {
-        this.s3ResourceHelper = s3ResourceHelper;
+        this.s3TranslationStorageService = s3TranslationStorageService;
         this.authService = authService;
-        this.environment = environment;
         this.translationRepository = translationRepository;
         // Skip S3 call in test profile
         if (!List.of(environment.getActiveProfiles()).contains("test")) {
@@ -140,37 +130,15 @@ public class TranslationServiceImpl implements TranslationService {
 
     @Override
     public Map<String, Object> getTranslationFile(String language) {
-        try {
-            File file = this.s3ResourceHelper.downloadFile(this.s3ResourceHelper.getS3Bucket(),
-                    "translations/" + language + ".json");
-            return new ObjectMapper().readValue(file, Map.class);
-        } catch (IOException e) {
-            throw new ServiceException("json_error", "Error reading JSON file from s3", e);
-        }
+        return s3TranslationStorageService.getTranslationFile(language);
     }
 
     @Override
     public void updateTranslationFile(String language, Map<String, Object> translations) {
-        try {
-            String json = new ObjectMapper().writeValueAsString(translations);
-            SimpleDateFormat fmt = new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss");
-
-            this.s3ResourceHelper.copyObject(
-                    "translations/" + language + ".json",
-                    "translations/old-versions/" + language + ".json." + fmt.format(new Date()));
-
-            this.s3ResourceHelper.uploadFile(this.s3ResourceHelper.getS3Bucket(), json,
-                    "translations/" + language + ".json", "text/json");
-
-            if ("en".equals(language)) {
-                englishS3Translations = translations;
-            }
-        } catch (JsonProcessingException e) {
-            throw new ServiceException("invalid_json", "The translation data could not be converted to JSON", e);
-        } catch (FileUploadException e) {
-            throw new ServiceException("file_upload", "The JSON file could not be uploaded to s3", e);
+        s3TranslationStorageService.updateTranslationFile(language, translations);
+        if ("en".equals(language)) {
+            englishS3Translations = translations;
         }
-
     }
 
     @Override
@@ -189,7 +157,7 @@ public class TranslationServiceImpl implements TranslationService {
         Object value = map;
 
         for (String key : keys) {
-            value = ((Map)value).get(key.toUpperCase());
+            value = ((Map<?, ?>) value).get(key.toUpperCase());
             if (value == null) {
                 break;
             }
@@ -197,8 +165,6 @@ public class TranslationServiceImpl implements TranslationService {
 
         return value;
     }
-
-
 
 }
 

--- a/server/src/main/java/org/tctalent/server/storage/S3TranslationStorageService.java
+++ b/server/src/main/java/org/tctalent/server/storage/S3TranslationStorageService.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2026 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+package org.tctalent.server.storage;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.tctalent.server.configuration.properties.S3Properties;
+import org.tctalent.server.exception.ServiceException;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.s3.model.S3Object;
+
+/**
+ * Service for managing translation JSON files in S3.
+ *
+ * @author sadatmalik
+ */
+@Service
+@RequiredArgsConstructor
+public class S3TranslationStorageService {
+
+    private final S3Client s3Client;
+    private final S3Properties s3Properties;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    /**
+     * Retrieves the translation JSON file for the specified language from S3 and parses it into a Map.
+     *
+     * @param language The language code (e.g., "en", "fr") for which to retrieve the translation file.
+     * @return A Map representing the contents of the translation JSON file.
+     * @throws ServiceException if there is an error reading the file from S3 or parsing the JSON.
+     */
+    public Map<String, Object> getTranslationFile(String language) {
+        try (ResponseInputStream<GetObjectResponse> in = s3Client.getObject(
+            GetObjectRequest.builder()
+                .bucket(getTranslationsBucket())
+                .key(getTranslationFileKey(language))
+                .build())
+        ) {
+          return objectMapper.readValue(in, new TypeReference<Map<String, Object>>() {});
+        } catch (IOException e) {
+          throw new ServiceException("json_error", "Error reading JSON file from s3", e);
+        }
+    }
+
+    public void updateTranslationFile(String language, Map<String, Object> translations) {
+        final byte[] jsonBytes;
+        try {
+            jsonBytes = objectMapper.writeValueAsString(translations).getBytes(StandardCharsets.UTF_8);
+        } catch (JsonProcessingException e) {
+            throw new ServiceException("invalid_json",
+                "The translation data could not be converted to JSON", e);
+        }
+
+        String currentKey = getTranslationFileKey(language);
+        String archivedKey = getTranslationsPrefix() + "old-versions/" + language
+            + ".json." + new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss").format(new Date());
+        String bucket = getTranslationsBucket();
+
+        try {
+            s3Client.copyObject(CopyObjectRequest.builder()
+                .sourceBucket(bucket)
+                .sourceKey(currentKey)
+                .destinationBucket(bucket)
+                .destinationKey(archivedKey)
+                .build());
+
+            s3Client.putObject(
+                PutObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(currentKey)
+                    .contentType("text/json")
+                    .contentLength((long) jsonBytes.length)
+                    .build(),
+                RequestBody.fromBytes(jsonBytes)
+            );
+        } catch (Exception e) {
+            throw new ServiceException("file_upload", "The JSON file could not be uploaded to s3", e);
+        }
+    }
+
+    public void copyBucketContents(String sourceBucket, String sourcePrefix,
+        String destinationBucket, String destinationPrefix) {
+
+        String normalizedSourcePrefix = normalizePrefix(sourcePrefix);
+        String normalizedDestinationPrefix = normalizePrefix(destinationPrefix);
+        String token = null;
+        boolean foundObjects = false;
+
+        do {
+            ListObjectsV2Request request = ListObjectsV2Request.builder()
+                .bucket(sourceBucket)
+                .prefix(normalizedSourcePrefix)
+                .continuationToken(token)
+                .build();
+
+            ListObjectsV2Response response = s3Client.listObjectsV2(request);
+
+            for (S3Object obj : response.contents()) {
+                foundObjects = true;
+                String sourceKey = obj.key();
+                String relativePath = sourceKey.startsWith(normalizedSourcePrefix)
+                    ? sourceKey.substring(normalizedSourcePrefix.length())
+                    : sourceKey;
+                String newKey = normalizedDestinationPrefix + relativePath;
+
+                s3Client.copyObject(CopyObjectRequest.builder()
+                    .sourceBucket(sourceBucket)
+                    .sourceKey(sourceKey)
+                    .destinationBucket(destinationBucket)
+                    .destinationKey(newKey)
+                    .build());
+            }
+
+            token = response.nextContinuationToken();
+        } while (token != null);
+
+        if (!foundObjects) {
+            throw S3Exception.builder()
+                .message("No files found under " + normalizedSourcePrefix)
+                .build();
+        }
+    }
+
+    private String getTranslationsBucket() {
+        return s3Properties.getTranslationsBucket();
+    }
+
+    private String getTranslationsPrefix() {
+        String configuredFolder = s3Properties.getTranslationsFolder();
+        if (!StringUtils.hasText(configuredFolder)) {
+            configuredFolder = "translations";
+        }
+        return configuredFolder.endsWith("/") ? configuredFolder : configuredFolder + "/";
+    }
+
+    private String getTranslationFileKey(String language) {
+        return getTranslationsPrefix() + language + ".json";
+    }
+
+    private String normalizePrefix(String prefix) {
+        if (!StringUtils.hasText(prefix)) {
+            return "";
+        }
+        return prefix.endsWith("/") ? prefix : prefix + "/";
+    }
+}

--- a/server/src/main/java/org/tctalent/server/storage/TranslationMigrationService.java
+++ b/server/src/main/java/org/tctalent/server/storage/TranslationMigrationService.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2026 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+package org.tctalent.server.storage;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.tctalent.server.exception.FileDownloadException;
+import org.tctalent.server.exception.ServiceException;
+import org.tctalent.server.service.db.aws.S3ResourceHelper;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Object;
+
+/**
+ * One-off migration service for seeding a new GRN translations bucket from a legacy TBB S3 source.
+ *
+ * <p>This service bridges two distinct AWS identities:
+ * <ul>
+ *   <li>Source — TBB account (us-east-1), accessed via {@link S3ResourceHelper}</li>
+ *   <li>Destination — GRN / OPC account (eu-west-2), accessed via {@link S3TranslationStorageService}</li>
+ * </ul>
+ *
+ * <p>Because a server-side S3 CopyObject cannot cross account boundaries without explicit
+ * bucket-policy grants, this service performs a client-side relay: download from source, upload to
+ * destination.
+ *
+ * <p><strong>Remove this class once all target environments have been seeded.</strong>
+ *
+ * @author sadatmalik
+ */
+@Service
+@RequiredArgsConstructor
+public class TranslationMigrationService {
+
+    private final S3ResourceHelper s3ResourceHelper;
+    private final S3Client s3Client;
+
+    public int migrateBucketContents(String sourceBucket, String sourcePrefix,
+        String destinationBucket, String destinationPrefix) {
+
+        String normalizedSourcePrefix = normalizePrefix(sourcePrefix);
+        String normalizedDestinationPrefix = normalizePrefix(destinationPrefix);
+
+        List<S3Object> objects = s3ResourceHelper.listObjectSummaries(sourceBucket,
+            normalizedSourcePrefix);
+        if (objects.isEmpty()) {
+            throw new ServiceException("migration_empty",
+                "No files found under " + normalizedSourcePrefix + " in " + sourceBucket);
+        }
+
+        int copiedCount = 0;
+        for (S3Object obj : objects) {
+            String sourceKey = obj.key();
+            String relativePath = sourceKey.startsWith(normalizedSourcePrefix)
+                ? sourceKey.substring(normalizedSourcePrefix.length())
+                : sourceKey;
+            String destinationKey = normalizedDestinationPrefix + relativePath;
+
+            File downloaded = null;
+            try {
+                downloaded = s3ResourceHelper.downloadFile(sourceBucket, sourceKey);
+                s3Client.putObject(
+                    PutObjectRequest.builder()
+                        .bucket(destinationBucket)
+                        .key(destinationKey)
+                        .contentLength(downloaded.length())
+                        .build(),
+                    RequestBody.fromFile(downloaded)
+                );
+                copiedCount++;
+            } catch (FileDownloadException e) {
+                throw e;
+            } catch (Exception e) {
+                throw new ServiceException("migration_failed",
+                    "Failed to migrate " + sourceKey + " to " + destinationKey, e);
+            } finally {
+                if (downloaded != null) {
+                    try {
+                        Files.deleteIfExists(downloaded.toPath());
+                    } catch (Exception ignored) {
+                    }
+                }
+            }
+        }
+
+        return copiedCount;
+    }
+
+    private String normalizePrefix(String prefix) {
+        if (!StringUtils.hasText(prefix)) {
+            return "";
+        }
+        return prefix.endsWith("/") ? prefix : prefix + "/";
+    }
+}

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -251,6 +251,8 @@ candidate-file-urls:
 aws:
   s3:
     bucketName: ${AWS_S3_BUCKETNAME:dev.files.tbbtalent.org}
+    translationsBucket: ${AWS_S3_TRANSLATIONS_BUCKET:dev.files.tbbtalent.org}
+    translationsFolder: ${AWS_S3_TRANSLATIONS_FOLDER:translations}
     region: us-east-1
     max-size: 52428800
     upload-folder: temp

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -237,6 +237,8 @@ s3:
   secret-key: ${AWS_CREDENTIALS_APP_SECRETKEY:}
   max-size: 52428800
   candidate-files-bucket: ${S3_CANDIDATE_FILES_BUCKET:candidate-files.test.globalrefugee.net}
+  translations-bucket: ${S3_TRANSLATIONS_BUCKET:dev.files.tbbtalent.org}
+  translations-folder: ${S3_TRANSLATIONS_FOLDER:translations}
 
 candidate-file-urls:
   share-secret-key: ${SHARE_URL_SECRETKEY:}
@@ -251,8 +253,6 @@ candidate-file-urls:
 aws:
   s3:
     bucketName: ${AWS_S3_BUCKETNAME:dev.files.tbbtalent.org}
-    translationsBucket: ${AWS_S3_TRANSLATIONS_BUCKET:dev.files.tbbtalent.org}
-    translationsFolder: ${AWS_S3_TRANSLATIONS_FOLDER:translations}
     region: us-east-1
     max-size: 52428800
     upload-folder: temp


### PR DESCRIPTION
This PR -- 

- supports translation files in dedicated S3 buckets across all environments
- terraforms IAM roles and policies for secure task S3 access
- adds a system admin API endpoint for migrating translation files between legacy to new S3 buckets

