### PR TITLE
add logging for migrate-translations admin api

### DIFF
--- a/server/src/main/java/org/tctalent/server/api/admin/SystemAdminApi.java
+++ b/server/src/main/java/org/tctalent/server/api/admin/SystemAdminApi.java
@@ -307,13 +307,29 @@ public class SystemAdminApi {
         String normalizedDestinationPrefix = normalizeS3Prefix(
             StringUtils.isBlank(destinationPrefix) ? "translations" : destinationPrefix);
 
+        LogBuilder.builder(log)
+            .user(authService.getLoggedInUser())
+            .action("MigrateTranslations")
+            .message(sourceBucket + "/" + normalizedSourcePrefix
+                + " -> " + destinationBucket + "/" + normalizedDestinationPrefix)
+            .logInfo();
+
+        long startMs = System.currentTimeMillis();
         int copiedCount = translationMigrationService.migrateBucketContents(
             sourceBucket, normalizedSourcePrefix, destinationBucket, normalizedDestinationPrefix);
+        long durationMs = System.currentTimeMillis() - startMs;
+
+        LogBuilder.builder(log)
+            .user(authService.getLoggedInUser())
+            .action("MigrateTranslations")
+            .message("Completed: " + copiedCount + " file(s) in " + durationMs + "ms")
+            .logInfo();
 
         return Map.of(
             "status", "success",
             "mode", "relay-copy",
             "copiedCount", copiedCount,
+            "durationMs", durationMs,
             "sourceBucket", sourceBucket,
             "sourcePrefix", normalizedSourcePrefix,
             "destinationBucket", destinationBucket,

--- a/server/src/main/java/org/tctalent/server/storage/TranslationMigrationService.java
+++ b/server/src/main/java/org/tctalent/server/storage/TranslationMigrationService.java
@@ -19,10 +19,12 @@ import java.io.File;
 import java.nio.file.Files;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 import org.tctalent.server.exception.FileDownloadException;
 import org.tctalent.server.exception.ServiceException;
+import org.tctalent.server.logging.LogBuilder;
 import org.tctalent.server.service.db.aws.S3ResourceHelper;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -46,6 +48,7 @@ import software.amazon.awssdk.services.s3.model.S3Object;
  *
  * @author sadatmalik
  */
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class TranslationMigrationService {
@@ -59,20 +62,42 @@ public class TranslationMigrationService {
         String normalizedSourcePrefix = normalizePrefix(sourcePrefix);
         String normalizedDestinationPrefix = normalizePrefix(destinationPrefix);
 
+        LogBuilder.builder(log)
+            .action("MigrateTranslations")
+            .message("Starting: " + sourceBucket + "/" + normalizedSourcePrefix
+                + " -> " + destinationBucket + "/" + normalizedDestinationPrefix)
+            .logInfo();
+
         List<S3Object> objects = s3ResourceHelper.listObjectSummaries(sourceBucket,
             normalizedSourcePrefix);
         if (objects.isEmpty()) {
+            LogBuilder.builder(log)
+                .action("MigrateTranslations")
+                .message("No files found under " + normalizedSourcePrefix + " in " + sourceBucket)
+                .logWarn();
             throw new ServiceException("migration_empty",
                 "No files found under " + normalizedSourcePrefix + " in " + sourceBucket);
         }
 
+        LogBuilder.builder(log)
+            .action("MigrateTranslations")
+            .message("Found " + objects.size() + " file(s) to migrate")
+            .logInfo();
+
         int copiedCount = 0;
+        long startMs = System.currentTimeMillis();
         for (S3Object obj : objects) {
             String sourceKey = obj.key();
             String relativePath = sourceKey.startsWith(normalizedSourcePrefix)
                 ? sourceKey.substring(normalizedSourcePrefix.length())
                 : sourceKey;
             String destinationKey = normalizedDestinationPrefix + relativePath;
+
+            LogBuilder.builder(log)
+                .action("MigrateTranslations")
+                .message("[" + (copiedCount + 1) + "/" + objects.size() + "] Copying: "
+                    + sourceKey + " -> " + destinationKey)
+                .logInfo();
 
             File downloaded = null;
             try {
@@ -100,6 +125,12 @@ public class TranslationMigrationService {
                 }
             }
         }
+
+        long durationMs = System.currentTimeMillis() - startMs;
+        LogBuilder.builder(log)
+            .action("MigrateTranslations")
+            .message("Complete: " + copiedCount + " file(s) copied in " + durationMs + "ms")
+            .logInfo();
 
         return copiedCount;
     }

--- a/ui/admin-portal/src/app/components/settings/admin-api/admin-api.component.html
+++ b/ui/admin-portal/src/app/components/settings/admin-api/admin-api.component.html
@@ -90,5 +90,5 @@
 </div>
 <div class="mt-4" *ngIf="error">
   <hr>
-  <pre>{{error}}</pre>
+  <pre>{{ error?.error?.message || error?.message || error }}</pre>
 </div>

--- a/ui/admin-portal/src/app/components/settings/admin-api/admin-api.component.ts
+++ b/ui/admin-portal/src/app/components/settings/admin-api/admin-api.component.ts
@@ -83,12 +83,22 @@ export class AdminApiComponent implements OnInit {
       this.error = null;
       this.adminService.call(this.form.value.apicall).subscribe(
         (response: string) => {
-          // If the response string is present and not empty, set ack to response;
-          // otherwise, default to "Done"
-          this.ack = response && response.trim().length > 0 ? response : "Done";
+          if (response && response.trim().length > 0) {
+            this.ack = this.tryFormatJson(response) ?? response;
+          } else {
+            this.ack = 'Done';
+          }
         },
         (error) => {this.error = error}
       )
+    }
+  }
+
+  private tryFormatJson(s: string): string | null {
+    try {
+      return JSON.stringify(JSON.parse(s), null, 2);
+    } catch {
+      return null;
     }
   }
 


### PR DESCRIPTION
This PR -

- Adds server logging for migrate-translations
- Displays response/error in admin-api on api command completion or failure

