### PR TITLE
3279 grn dev stating showing tc logo for grn instance

### DIFF
--- a/server/src/main/java/org/tctalent/server/service/db/impl/BrandingServiceImpl.java
+++ b/server/src/main/java/org/tctalent/server/service/db/impl/BrandingServiceImpl.java
@@ -39,8 +39,13 @@ import org.tctalent.server.service.db.UserService;
 @Slf4j
 @RequiredArgsConstructor
 public class BrandingServiceImpl implements BrandingService {
+    private static final String GRN_LOGO = "assets/images/grnLogoDark.svg";
+    private static final String GRN_NAME = "GRN";
+    private static final String GRN_WEBSITE_URL = "https://openpathwaycollective.org/globalrefugeenetwork";
+
     private final PartnerService partnerService;
     private final UserService userService;
+    private final TcInstanceService tcInstanceService;
 
     /**
      * Returns the branding information for a partner.
@@ -51,6 +56,9 @@ public class BrandingServiceImpl implements BrandingService {
     @Override
     @NonNull
     public BrandingInfo getBrandingInfo(@Nullable String partnerAbbreviation) {
+        if (tcInstanceService.isGRN()) {
+            return createGrnBrandingInfo();
+        }
 
         User user = userService.getLoggedInUser();
 
@@ -86,6 +94,14 @@ public class BrandingServiceImpl implements BrandingService {
         }
 
         return extractBrandingInfoFromPartner(partner);
+    }
+
+    private @NotNull BrandingInfo createGrnBrandingInfo() {
+        BrandingInfo info = new BrandingInfo();
+        info.setLogo(GRN_LOGO);
+        info.setPartnerName(GRN_NAME);
+        info.setWebsiteUrl(GRN_WEBSITE_URL);
+        return info;
     }
 
     private @NotNull BrandingInfo extractBrandingInfoFromPartner(@NonNull Partner partner) {

--- a/server/src/test/java/org/tctalent/server/service/db/impl/BrandingServiceImplTest.java
+++ b/server/src/test/java/org/tctalent/server/service/db/impl/BrandingServiceImplTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -50,6 +51,7 @@ class BrandingServiceImplTest {
 
     @Mock PartnerService partnerService;
     @Mock UserService userService;
+    @Mock TcInstanceService tcInstanceService;
     @Mock User user;
 
     @InjectMocks
@@ -57,11 +59,27 @@ class BrandingServiceImplTest {
 
     @BeforeEach
     void setUp() {
+        given(tcInstanceService.isGRN()).willReturn(false);
         partner.setSourcePartner(true);
         partner.setRegistrationLandingPage(LANDING_PAGE);
         partner.setLogo(LOGO);
         partner.setName(PARTNER_NAME);
         partner.setWebsiteUrl(WEBSITE_URL);
+    }
+
+    @Test
+    @DisplayName("get branding info returns GRN branding for GRN instances")
+    void canGetBrandingInfoForGrnInstance() {
+        given(tcInstanceService.isGRN()).willReturn(true);
+
+        BrandingInfo info = brandingService.getBrandingInfo("source-partner");
+
+        assertNotNull(info);
+        assertEquals("assets/images/grnLogoDark.svg", info.getLogo());
+        assertEquals("GRN", info.getPartnerName());
+        assertEquals("https://openpathwaycollective.org/", info.getWebsiteUrl());
+        assertNull(info.getLandingPage());
+        verifyNoInteractions(userService, partnerService);
     }
 
     @Test
@@ -103,13 +121,6 @@ class BrandingServiceImplTest {
 
     private void verifyBrandingInfo(BrandingInfo info) {
         assertEquals(LANDING_PAGE, info.getLandingPage());
-        assertEquals(LOGO, info.getLogo());
-        assertEquals(PARTNER_NAME, info.getPartnerName());
-        assertEquals(WEBSITE_URL, info.getWebsiteUrl());
-    }
-
-    private void verifyNonSourcePartnerBrandingInfo(BrandingInfo info) {
-        assertNull(info.getLandingPage());
         assertEquals(LOGO, info.getLogo());
         assertEquals(PARTNER_NAME, info.getPartnerName());
         assertEquals(WEBSITE_URL, info.getWebsiteUrl());

--- a/ui/candidate-portal/src/app/services/branding.service.spec.ts
+++ b/ui/candidate-portal/src/app/services/branding.service.spec.ts
@@ -142,8 +142,22 @@ describe('BrandingService', () => {
       httpMock.expectNone(apiUrl);
     });
 
-    it('should return API branding info when user is registered', () => {
+    it('should return GRN branding info for registered GRN instances', () => {
       authServiceSpy.isRegistered.and.returnValue(true);
+      authServiceSpy.getTcInstanceType.and.returnValue(TcInstanceType.GRN);
+
+      service.getBrandingInfo().subscribe(brandingInfo => {
+        expect(brandingInfo.logo).toBe('assets/images/grnLogoDark.svg');
+        expect(brandingInfo.partnerName).toBe('GRN');
+        expect(brandingInfo.websiteUrl).toBe('https://openpathwaycollective.org/');
+      });
+
+      httpMock.expectNone(apiUrl);
+    });
+
+    it('should return API branding info when user is registered on TBB instances', () => {
+      authServiceSpy.isRegistered.and.returnValue(true);
+      authServiceSpy.getTcInstanceType.and.returnValue(TcInstanceType.TBB);
 
       const mockBrandingInfo: BrandingInfo = {
         logo: 'registered-logo.png',
@@ -160,14 +174,27 @@ describe('BrandingService', () => {
       req.flush(mockBrandingInfo);
     });
 
-    it('should return API branding info for registered GRN instances', () => {
-      authServiceSpy.isRegistered.and.returnValue(true);
-      authServiceSpy.getTcInstanceType.and.returnValue(TcInstanceType.GRN);
+    it('should return default branding info when user is not registered on TBB instances', () => {
+      authServiceSpy.isRegistered.and.returnValue(false);
+      authServiceSpy.getTcInstanceType.and.returnValue(TcInstanceType.TBB);
+
+      service.getBrandingInfo().subscribe(brandingInfo => {
+        expect(brandingInfo.logo).toBe('assets/images/tc-logo-2.png');
+        expect(brandingInfo.partnerName).toBe('a Talent Catalog partner');
+        expect(brandingInfo.websiteUrl).toBe('');
+      });
+
+      httpMock.expectNone(apiUrl);
+    });
+
+    it('should return API branding info when instance type is unknown and user is not registered', () => {
+      authServiceSpy.isRegistered.and.returnValue(false);
+      authServiceSpy.getTcInstanceType.and.returnValue(null);
 
       const mockBrandingInfo: BrandingInfo = {
-        logo: 'registered-grn-partner-logo.png',
-        partnerName: 'Registered GRN Partner',
-        websiteUrl: 'https://partner.example.com'
+        logo: 'unregistered-logo.png',
+        partnerName: 'Unregistered Partner',
+        websiteUrl: 'https://unregistered.com'
       };
 
       service.getBrandingInfo().subscribe(brandingInfo => {
@@ -177,19 +204,6 @@ describe('BrandingService', () => {
       const req = httpMock.expectOne(apiUrl);
       expect(req.request.method).toBe('GET');
       req.flush(mockBrandingInfo);
-    });
-
-    it('should return default branding info when user is not registered', () => {
-      authServiceSpy.isRegistered.and.returnValue(false);
-
-      service.getBrandingInfo().subscribe(brandingInfo => {
-        expect(brandingInfo.logo).toBe('assets/images/tc-logo-2.png');
-        expect(brandingInfo.partnerName).toBe('a Talent Catalog partner');
-        expect(brandingInfo.websiteUrl).toBe('');
-      });
-
-      // No HTTP request should be made for unregistered users
-      httpMock.expectNone(apiUrl);
     });
   });
 

--- a/ui/candidate-portal/src/app/services/branding.service.ts
+++ b/ui/candidate-portal/src/app/services/branding.service.ts
@@ -37,29 +37,38 @@ export class BrandingService {
   constructor(private http: HttpClient, private authenticationService: AuthenticationService) { }
 
   getBrandingInfo(): Observable<BrandingInfo> {
+    // GRN instance — always GRN branding
+    if (this.authenticationService.getTcInstanceType() === TcInstanceType.GRN) {
+      let brandingInfo: BrandingInfo = {
+        logo: 'assets/images/grnLogoDark.svg',
+        partnerName: 'GRN',
+        websiteUrl: 'https://openpathwaycollective.org/'
+      };
+      return of(brandingInfo);
+    }
+
+    // Registered TBB user — partner-specific branding from API
     if (this.authenticationService.isRegistered()) {
       let url = `${this.apiUrl}`;
       if (this.partnerAbbreviation) {
         url += `?p=${this.partnerAbbreviation}`;
       }
       return this.http.get<BrandingInfo>(url);
-    } else {
-      if (this.authenticationService.getTcInstanceType() === TcInstanceType.GRN) {
-        let brandingInfo: BrandingInfo = {
-          logo: 'assets/images/grnLogoDark.svg',
-          partnerName: 'GRN',
-          websiteUrl: 'https://openpathwaycollective.org/'
-        };
-        return of(brandingInfo);
-      }
+    }
 
+    // Known TBB instance, unregistered — TC branding
+    if (this.authenticationService.getTcInstanceType() === TcInstanceType.TBB) {
       let brandingInfo: BrandingInfo = {
         logo: "assets/images/tc-logo-2.png",
         partnerName: "a Talent Catalog partner",
         websiteUrl: ""
-      }
+      };
       return of(brandingInfo);
     }
+
+    // Unknown instance type (pre-login, no tc_instance_type in storage yet)
+    // — call API so server can resolve based on its TC_INSTANCE_TYPE config
+    return this.getBrandingInfoFromApi();
   }
 
   /**


### PR DESCRIPTION
This pull request updates the branding logic for both backend and frontend to consistently provide "GRN" branding for GRN instances.

- Updated BrandingServiceImpl to return GRN-specific branding info when the instance is a GRN instance, using the new tcInstanceService.isGRN() check and a dedicated createGrnBrandingInfo() method.
- Refactored BrandingService into always return GRN branding for GRN instances, regardless of registration status. For TBB instances, returns partner branding if registered, or default TC branding if not; for unknown instance types, falls back to API call.