### PR TITLE
3310 need to extract text from uploaded cvs

### DIFF
--- a/server/src/main/java/org/tctalent/server/api/admin/CandidateAttachmentAdminApi.java
+++ b/server/src/main/java/org/tctalent/server/api/admin/CandidateAttachmentAdminApi.java
@@ -98,7 +98,8 @@ public class CandidateAttachmentAdminApi {
      */
     @Deprecated
     @PostMapping()
-    public Map<String, Object> createCandidateAttachment(@RequestBody CreateCandidateAttachmentRequest request) {
+    public Map<String, Object> createCandidateAttachment(@RequestBody CreateCandidateAttachmentRequest request)
+        throws IOException {
         CandidateAttachment candidateAttachment = candidateAttachmentService.createCandidateAttachment(request);
         return candidateAttachmentDto().build(candidateAttachment);
     }

--- a/server/src/main/java/org/tctalent/server/api/portal/CandidateAttachmentPortalApi.java
+++ b/server/src/main/java/org/tctalent/server/api/portal/CandidateAttachmentPortalApi.java
@@ -67,7 +67,8 @@ public class CandidateAttachmentPortalApi {
     }
 
     @PostMapping()
-    public Map<String, Object> createCandidateAttachment(@RequestBody CreateCandidateAttachmentRequest request) {
+    public Map<String, Object> createCandidateAttachment(@RequestBody CreateCandidateAttachmentRequest request)
+        throws IOException {
         CandidateAttachment candidateAttachment = candidateAttachmentService.createCandidateAttachment(request);
         return candidateAttachmentDto().build(candidateAttachment);
     }

--- a/server/src/main/java/org/tctalent/server/model/db/CandidateAttachment.java
+++ b/server/src/main/java/org/tctalent/server/model/db/CandidateAttachment.java
@@ -86,10 +86,6 @@ public class CandidateAttachment extends AbstractAuditableDomainObject<Long> imp
      */
     private String textExtract;
 
-    //todo Eventually get rid of this cv attribute altogether - replacing it with just uploadType
-    //For now they duplicate each other
-    private boolean cv;
-
     /**
      * The type of the attachment: CV, Passport etc. 
      */
@@ -117,6 +113,10 @@ public class CandidateAttachment extends AbstractAuditableDomainObject<Long> imp
     @Column(name = "sha256_hex")
     private String sha256Hex;
 
+    public boolean isCv() {
+        return UploadType.cv.equals(uploadType);
+    }
+    
     public CandidateAttachment() {
     }
 }

--- a/server/src/main/java/org/tctalent/server/repository/db/CandidateAttachmentRepository.java
+++ b/server/src/main/java/org/tctalent/server/repository/db/CandidateAttachmentRepository.java
@@ -39,14 +39,12 @@ public interface CandidateAttachmentRepository extends JpaRepository<CandidateAt
             + " left join a.candidate c "
             + " where c.id = :candidateId "
             + " and a.uploadType = :uploadType ")
-    List<CandidateAttachment> findByCandidateIdAndType(@Param("candidateId") Long candidateId,
+    List<CandidateAttachment> findByCandidateIdAndUploadType(@Param("candidateId") Long candidateId,
                                                          @Param("uploadType") UploadType uploadType);
 
     Page<CandidateAttachment> findByCandidateId(Long candidateId, Pageable request);
 
     List<CandidateAttachment> findByCandidateId(Long candidateId);
-
-    List<CandidateAttachment> findByCandidateIdAndCv(Long candidateId, boolean cv);
 
     @Query(" select distinct a from CandidateAttachment a "
             + " left join a.candidate c "

--- a/server/src/main/java/org/tctalent/server/request/attachment/CreateCandidateAttachmentRequest.java
+++ b/server/src/main/java/org/tctalent/server/request/attachment/CreateCandidateAttachmentRequest.java
@@ -45,8 +45,6 @@ public class CreateCandidateAttachmentRequest implements StoredFile {
      */
     private String url;
 
-    private Boolean cv;
-
     private UploadType uploadType;
 
     /**

--- a/server/src/main/java/org/tctalent/server/request/attachment/UpdateCandidateAttachmentRequest.java
+++ b/server/src/main/java/org/tctalent/server/request/attachment/UpdateCandidateAttachmentRequest.java
@@ -16,39 +16,17 @@
 
 package org.tctalent.server.request.attachment;
 
+import lombok.Getter;
+import lombok.Setter;
+import org.tctalent.server.files.UploadType;
+
+@Getter
+@Setter
 public class UpdateCandidateAttachmentRequest {
 
     private Long id;
     private String name;
     private String url;
-    private Boolean cv;
-
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public String getUrl() {
-        return url;
-    }
-
-    public void setUrl(String url) {
-        this.url = url;
-    }
-
-    public Boolean getCv() { return cv; }
-
-    public void setCv(Boolean cv) { this.cv = cv; }
+    private UploadType uploadType;
 }
 

--- a/server/src/main/java/org/tctalent/server/service/db/CandidateAttachmentService.java
+++ b/server/src/main/java/org/tctalent/server/service/db/CandidateAttachmentService.java
@@ -49,7 +49,8 @@ public interface CandidateAttachmentService {
 
     List<CandidateAttachment> listCandidateAttachments(Long candidateId);
 
-    CandidateAttachment createCandidateAttachment(CreateCandidateAttachmentRequest request);
+    CandidateAttachment createCandidateAttachment(CreateCandidateAttachmentRequest request)
+        throws IOException;
 
     void deleteCandidateAttachment(Long id);
 

--- a/server/src/main/java/org/tctalent/server/service/db/impl/CandidateAttachmentsServiceImpl.java
+++ b/server/src/main/java/org/tctalent/server/service/db/impl/CandidateAttachmentsServiceImpl.java
@@ -98,7 +98,7 @@ public class CandidateAttachmentsServiceImpl implements CandidateAttachmentServi
 
     @Override
     public List<CandidateAttachment> listCandidateAttachmentsByType(ListByUploadTypeRequest request) {
-        return candidateAttachmentRepository.findByCandidateIdAndType(request.getCandidateId(), request.getUploadType());
+        return candidateAttachmentRepository.findByCandidateIdAndUploadType(request.getCandidateId(), request.getUploadType());
     }
 
     @Override
@@ -114,7 +114,7 @@ public class CandidateAttachmentsServiceImpl implements CandidateAttachmentServi
     public List<CandidateAttachment> listCandidateCvs(Long candidateId) {
         Candidate candidate = candidateRepository.findById(candidateId)
                 .orElseThrow(() -> new NoSuchObjectException(Candidate.class, candidateId));
-        return candidateAttachmentRepository.findByCandidateIdAndCv(candidate.getId(), true);
+        return candidateAttachmentRepository.findByCandidateIdAndUploadType(candidate.getId(), UploadType.cv);
     }
 
     @Override
@@ -125,7 +125,8 @@ public class CandidateAttachmentsServiceImpl implements CandidateAttachmentServi
     }
 
     @Override
-    public CandidateAttachment createCandidateAttachment(CreateCandidateAttachmentRequest request) {
+    public CandidateAttachment createCandidateAttachment(CreateCandidateAttachmentRequest request)
+        throws IOException {
         User user = authService.getLoggedInUser()
                 .orElseThrow(() -> new InvalidSessionException("Not logged in"));
 
@@ -147,7 +148,6 @@ public class CandidateAttachmentsServiceImpl implements CandidateAttachmentServi
         attachment.setCandidate(candidate);
         attachment.setMigrated(false);
         attachment.setAuditFields(user);
-        attachment.setCv(UploadType.cv.equals(request.getUploadType()));
         
         //Add a publicId
         String publicId = publicIDService.generatePublicID();
@@ -165,7 +165,12 @@ public class CandidateAttachmentsServiceImpl implements CandidateAttachmentServi
                 break; 
             case grnfile:
                 //Compute url.
-                attachment.setUrl(fileUrlService.createApplicationUrl(attachment)); 
+                attachment.setUrl(fileUrlService.createApplicationUrl(attachment));
+                
+                if (attachment.isCv()) {
+                    String text = extractTextFromAttachment(attachment);
+                    attachment.setTextExtract(text);
+                }
                 break;
             case link:
                 attachment.setUrl(request.getUrl());
@@ -181,10 +186,20 @@ public class CandidateAttachmentsServiceImpl implements CandidateAttachmentServi
         //Now update candidate audit fields and potentially update candidate text to take
         //account of any cv text in the attachment we just updated above.
         candidate.setAuditFields(user);
-        boolean updateCandidateText = request.getCv() != null ? request.getCv() : false;
+        boolean updateCandidateText = UploadType.cv.equals(request.getUploadType());
         candidateService.save(candidate, true, updateCandidateText);
 
         return attachment;
+    }
+
+    private String extractTextFromAttachment(CandidateAttachment attachment) throws IOException {
+        if (!AttachmentType.grnfile.equals(attachment.getType())) {
+            throw new UnsupportedOperationException("extractTextFromAttachment is not supported");
+        }
+        
+        try (InputStream inputStream = storageService.openStream(attachment.getStorageKey())) {
+            return TextExtractHelper.getTextExtractFromStream(inputStream, attachment.getFileType());
+        } 
     }
 
     // Removed @Transactional to fix logged error ObjectDeletedException. There is a risk that now deleting from
@@ -412,8 +427,6 @@ public class CandidateAttachmentsServiceImpl implements CandidateAttachmentServi
             .contentType(file.getContentType())
             .build();
 
-        //TODO JC Need to do the textExtract if uploadType == UploadType.cv
-
         StoredFileInfo storedFileInfo = storageService.store(req);
         
         //Add in extra info
@@ -508,7 +521,6 @@ public class CandidateAttachmentsServiceImpl implements CandidateAttachmentServi
         req.setFileType(fileType);
         req.setUrl(uploadedFile.getUrl());
         req.setUploadType(uploadType);
-        req.setCv(uploadType == UploadType.cv);
         if(StringUtils.hasText(textExtract)) {
             req.setTextExtract(textExtract);
         }

--- a/server/src/main/java/org/tctalent/server/util/textExtract/TextExtractHelper.java
+++ b/server/src/main/java/org/tctalent/server/util/textExtract/TextExtractHelper.java
@@ -44,8 +44,9 @@ public class TextExtractHelper {
     }
 
     public static String getTextFromPDFFile(File srcFile) throws IOException {
-        FileInputStream fis = new FileInputStream(srcFile);
-        return getTextFromPDFStream(fis);
+        try (FileInputStream fis = new FileInputStream(srcFile)) {
+            return getTextFromPDFStream(fis);
+        }
     }
 
     public static String getTextFromDocxStream(InputStream inputStream) throws IOException {
@@ -57,8 +58,9 @@ public class TextExtractHelper {
     }
 
     public static String getTextFromDocxFile(File srcFile) throws IOException {
-        FileInputStream fis = new FileInputStream(srcFile);
-        return getTextFromDocxStream(fis);
+        try (FileInputStream fis = new FileInputStream(srcFile)) {
+            return getTextFromDocxStream(fis);
+        }
     }
 
     public static String getTextFromDocStream(InputStream inputStream) throws IOException {
@@ -70,8 +72,9 @@ public class TextExtractHelper {
     }
     
     public static String getTextFromDocFile(File srcFile) throws IOException {
-        FileInputStream fis = new FileInputStream(srcFile);
-        return getTextFromDocStream(fis);
+        try (FileInputStream fis = new FileInputStream(srcFile)) {
+            return getTextFromDocStream(fis);
+        }
     }
 
     public static String getTextFromTxtStream(InputStream inputStream) throws IOException {
@@ -102,7 +105,9 @@ public class TextExtractHelper {
             fileType = fileTypeOrName;
         }
         
-        return getTextExtractFromStream(new FileInputStream(file), fileType);
+        try (FileInputStream fis = new FileInputStream(file)) {
+            return getTextExtractFromStream(fis, fileType);
+        }
     }
 
     public static String getTextExtractFromStream(InputStream inputStream, String fileType)

--- a/server/src/main/java/org/tctalent/server/util/textExtract/TextExtractHelper.java
+++ b/server/src/main/java/org/tctalent/server/util/textExtract/TextExtractHelper.java
@@ -19,8 +19,7 @@ package org.tctalent.server.util.textExtract;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
+import java.io.InputStream;
 import java.util.regex.Pattern;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.text.PDFTextStripper;
@@ -32,10 +31,10 @@ import org.springframework.lang.Nullable;
 
 public class TextExtractHelper {
 
-    public static String getTextFromPDFFile(File srcFile) throws IOException {
+    public static String getTextFromPDFStream(InputStream inputStream) throws IOException {
         PDFTextStripper tStripper = new PDFTextStripper();
         tStripper.setSortByPosition(true);
-        PDDocument document = PDDocument.load(srcFile);
+        PDDocument document = PDDocument.load(inputStream);
         String pdfFileInText = "";
         if (!document.isEncrypted()) {
             pdfFileInText = tStripper.getText(document);
@@ -44,26 +43,39 @@ public class TextExtractHelper {
         return pdfFileInText.trim();
     }
 
-    public static String getTextFromDocxFile(File srcFile) throws IOException {
+    public static String getTextFromPDFFile(File srcFile) throws IOException {
         FileInputStream fis = new FileInputStream(srcFile);
-        XWPFDocument doc = new XWPFDocument(fis);
+        return getTextFromPDFStream(fis);
+    }
+
+    public static String getTextFromDocxStream(InputStream inputStream) throws IOException {
+        XWPFDocument doc = new XWPFDocument(inputStream);
         XWPFWordExtractor xwe = new XWPFWordExtractor(doc);
         String docxTxt = xwe.getText();
         xwe.close();
         return docxTxt;
     }
 
-    public static String getTextFromDocFile(File srcFile) throws IOException {
+    public static String getTextFromDocxFile(File srcFile) throws IOException {
         FileInputStream fis = new FileInputStream(srcFile);
-        HWPFDocument document = new HWPFDocument(fis);
+        return getTextFromDocxStream(fis);
+    }
+
+    public static String getTextFromDocStream(InputStream inputStream) throws IOException {
+        HWPFDocument document = new HWPFDocument(inputStream);
         WordExtractor we = new WordExtractor(document);
         String docTxt = we.getText();
         we.close();
         return docTxt;
     }
+    
+    public static String getTextFromDocFile(File srcFile) throws IOException {
+        FileInputStream fis = new FileInputStream(srcFile);
+        return getTextFromDocStream(fis);
+    }
 
-    public static String getTextFromTxtFile(File srcFile) throws IOException {
-        return new String(Files.readAllBytes(Paths.get(srcFile.getPath())));
+    public static String getTextFromTxtStream(InputStream inputStream) throws IOException {
+        return new String(inputStream.readAllBytes());
     }
 
     /**
@@ -89,17 +101,22 @@ public class TextExtractHelper {
         } else {
             fileType = fileTypeOrName;
         }
+        
+        return getTextExtractFromStream(new FileInputStream(file), fileType);
+    }
 
-        String s = null;
-        if ("pdf".equals(fileType)) {
-            s = getTextFromPDFFile(file);
-        } else if ("docx".equals(fileType)) {
-            s = getTextFromDocxFile(file);
-        } else if ("doc".equals(fileType)) {
-            s = getTextFromDocFile(file);
-        } else if ("txt".equals(fileType)) {
-            s = getTextFromTxtFile(file);
-        }
+    public static String getTextExtractFromStream(InputStream inputStream, String fileType)
+        throws IOException {
+        String s = switch (fileType) {
+            case "pdf", "application/pdf" -> getTextFromPDFStream(inputStream); 
+            case "doc", "application/msword" -> getTextFromDocStream(inputStream);
+            case "docx", 
+                 "application/vnd.openxmlformats-officedocument.wordprocessingml.document" -> 
+                getTextFromDocxStream(inputStream); 
+            case "txt", "text/plain" -> getTextFromTxtStream(inputStream);
+            default -> null;
+        };
+        
         if (s != null) {
             // Remove any null bytes to avoid problems like
             // PSQLException: ERROR: invalid byte sequence for encoding "UTF8"

--- a/server/src/main/java/org/tctalent/server/util/textExtract/TextExtractHelper.java
+++ b/server/src/main/java/org/tctalent/server/util/textExtract/TextExtractHelper.java
@@ -107,6 +107,10 @@ public class TextExtractHelper {
 
     public static String getTextExtractFromStream(InputStream inputStream, String fileType)
         throws IOException {
+        if (fileType == null) {
+            return null;
+        }
+
         String s = switch (fileType) {
             case "pdf", "application/pdf" -> getTextFromPDFStream(inputStream); 
             case "doc", "application/msword" -> getTextFromDocStream(inputStream);

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -255,8 +255,10 @@ candidate-file-urls:
   
   #In this configuration the server url points to Cloudfront which manages the routing to the
   #S3 origin of files if needed. So both origin and public URLs point to Cloudfront.
-  #The default localhost value is designed for testing on developer's local computers.
-  origin-base-url: ${SERVER_URL:http://localhost:8080} 
+  #The default values are designed for testing on developer's local computers uploading to GRN 
+  #staging's S3, where the localhost machine will intercept public urls, but downloads will
+  #come from the GRN staging S3.
+  origin-base-url: ${SERVER_URL:https://test.globalrefugee.net} 
   public-base-url: ${SERVER_URL:http://localhost:8080}
   
 aws:

--- a/server/src/test/java/org/tctalent/server/api/admin/CandidateAttachmentAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/CandidateAttachmentAdminApiTest.java
@@ -54,6 +54,7 @@ import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.multipart.MultipartFile;
+import org.tctalent.server.files.UploadType;
 import org.tctalent.server.model.db.AttachmentType;
 import org.tctalent.server.model.db.CandidateAttachment;
 import org.tctalent.server.request.attachment.CreateCandidateAttachmentRequest;
@@ -352,7 +353,7 @@ class CandidateAttachmentAdminApiTest extends ApiTestBase {
 
     private static CandidateAttachment getCandidateAttachments(boolean isCvOnly) {
         CandidateAttachment candidateAttachment = new CandidateAttachment();
-        candidateAttachment.setCv(isCvOnly);
+        candidateAttachment.setUploadType(isCvOnly ? UploadType.cv : UploadType.other);
         return candidateAttachment;
     }
 

--- a/server/src/test/java/org/tctalent/server/api/portal/CandidateAttachmentPortalApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/portal/CandidateAttachmentPortalApiTest.java
@@ -22,6 +22,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.multipart.MultipartFile;
+import org.tctalent.server.files.UploadType;
 import org.tctalent.server.model.db.AttachmentType;
 import org.tctalent.server.model.db.CandidateAttachment;
 import org.tctalent.server.model.db.User;
@@ -92,7 +93,7 @@ class CandidateAttachmentPortalApiTest {
   }
 
   @Test
-  void testCreateCandidateAttachment_Success() {
+  void testCreateCandidateAttachment_Success() throws IOException {
     CreateCandidateAttachmentRequest request = new CreateCandidateAttachmentRequest();
     CandidateAttachment attachment = createSampleAttachment();
     when(candidateAttachmentService.createCandidateAttachment(request)).thenReturn(attachment);
@@ -171,7 +172,7 @@ class CandidateAttachmentPortalApiTest {
     attachment.setUrl("path/to/test.pdf");
     attachment.setFileType("application/pdf");
     attachment.setMigrated(true);
-    attachment.setCv(true);
+    attachment.setUploadType(UploadType.cv);
     User createdBy = new User();
     createdBy.setId(1L);
     createdBy.setFirstName("John");

--- a/server/src/test/java/org/tctalent/server/integration/helper/TestDataFactory.java
+++ b/server/src/test/java/org/tctalent/server/integration/helper/TestDataFactory.java
@@ -935,7 +935,7 @@ public class TestDataFactory {
     candidateAttachment.setType(AttachmentType.googlefile);
     candidateAttachment.setFileType("pdf");
     candidateAttachment.setMigrated(true);
-    candidateAttachment.setCv(false);
+    candidateAttachment.setUploadType(UploadType.other);
     candidateAttachment.setUrl("TEST LOCATION");
     candidateAttachment.setUploadType(UploadType.idCard);
     candidateAttachment.setCreatedBy(createSystemUser());

--- a/server/src/test/java/org/tctalent/server/service/db/impl/CandidateAttachmentsServiceImplTest.java
+++ b/server/src/test/java/org/tctalent/server/service/db/impl/CandidateAttachmentsServiceImplTest.java
@@ -43,10 +43,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mapstruct.factory.Mappers;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -63,6 +65,7 @@ import org.tctalent.server.model.db.Candidate;
 import org.tctalent.server.model.db.CandidateAttachment;
 import org.tctalent.server.model.db.Role;
 import org.tctalent.server.model.db.User;
+import org.tctalent.server.model.db.mapper.StoredFileMapper;
 import org.tctalent.server.repository.db.CandidateAttachmentRepository;
 import org.tctalent.server.repository.db.CandidateRepository;
 import org.tctalent.server.request.PagedSearchRequest;
@@ -73,6 +76,7 @@ import org.tctalent.server.request.attachment.UpdateCandidateAttachmentRequest;
 import org.tctalent.server.security.AuthService;
 import org.tctalent.server.service.db.CandidateService;
 import org.tctalent.server.service.db.FileSystemService;
+import org.tctalent.server.service.db.PublicIDService;
 import org.tctalent.server.util.filesystem.GoogleFileSystemBaseEntity;
 import org.tctalent.server.util.filesystem.GoogleFileSystemDrive;
 import org.tctalent.server.util.filesystem.GoogleFileSystemFile;
@@ -102,12 +106,15 @@ public class CandidateAttachmentsServiceImplTest {
     private final static MockMultipartFile file = new MockMultipartFile("file",
         ORIGINAL_FILE_NAME,"application/pdf", "This is content".getBytes());
 
+    @Spy private StoredFileMapper storedFileMapper = Mappers.getMapper(StoredFileMapper.class);
     @Mock private CandidateAttachmentRepository candidateAttachmentRepository;
     @Mock private AuthService authService;
     @Mock private CandidateRepository candidateRepository;
     @Mock private CandidateService candidateService;
     @Mock private FileSystemService fileSystemService;
     @Mock private OutputStream outputStream;
+    @Mock private PublicIDService publicIDService;
+    @Mock private TcInstanceService tcInstanceService;
 
     @Captor private ArgumentCaptor<CandidateAttachment> attachmentCaptor;
 
@@ -178,7 +185,7 @@ public class CandidateAttachmentsServiceImplTest {
         request.setCandidateId(candidateId);
         request.setUploadType(UploadType.idCard);
 
-        given(candidateAttachmentRepository.findByCandidateIdAndType(candidateId, UploadType.idCard))
+        given(candidateAttachmentRepository.findByCandidateIdAndUploadType(candidateId, UploadType.idCard))
             .willReturn(attachmentList);
 
         assertEquals(attachmentList,
@@ -209,7 +216,7 @@ public class CandidateAttachmentsServiceImplTest {
     @DisplayName("should return list of cvs when candidate found")
     void listCandidateCvs_shouldReturnListOfCvs_whenCandidateFound() {
         given(candidateRepository.findById(candidateId)).willReturn(Optional.of(candidate));
-        given(candidateAttachmentRepository.findByCandidateIdAndCv(anyLong(), eq(true)))
+        given(candidateAttachmentRepository.findByCandidateIdAndUploadType(anyLong(), eq(UploadType.cv)))
             .willReturn(attachmentList);
 
         assertEquals(attachmentList, candidateAttachmentsService.listCandidateCvs(candidateId));
@@ -275,7 +282,7 @@ public class CandidateAttachmentsServiceImplTest {
 
     @Test
     @DisplayName("should create candidate attachment for link")
-    void createCandidateAttachment_shouldCreateCandidateAttachmentForLink() {
+    void createCandidateAttachment_shouldCreateCandidateAttachmentForLink() throws IOException {
         createRequest.setType(AttachmentType.link);
 
         given(authService.getLoggedInUser()).willReturn(Optional.of(ADMIN_USER));
@@ -295,9 +302,10 @@ public class CandidateAttachmentsServiceImplTest {
 
     @Test
     @DisplayName("should create candidate attachment for google file")
-    void createCandidateAttachment_shouldCreateCandidateAttachmentForGoogleFile() {
+    void createCandidateAttachment_shouldCreateCandidateAttachmentForGoogleFile()
+        throws IOException {
         createRequest.setType(AttachmentType.googlefile);
-        createRequest.setCv(true);
+        createRequest.setUploadType(UploadType.cv);
         createRequest.setFileType(FILE_TYPE);
         createRequest.setTextExtract(TEXT_EXTRACT);
 

--- a/server/src/test/java/org/tctalent/server/service/db/util/TextExtractHelperTest.java
+++ b/server/src/test/java/org/tctalent/server/service/db/util/TextExtractHelperTest.java
@@ -128,26 +128,31 @@ public class TextExtractHelperTest {
         List<CandidateAttachment> files = candidateAttachmentRepository.findByFileTypesAndMigrated(types, true);
         assertNotNull(files);
 
-        // Test with 10 from List
-        Set<CandidateAttachment> candidateAttachmentSet = new HashSet<>();
-        for (int i = 0; i < 10; i++) {
-            CandidateAttachment candidateAttachment = files.get(i);
-            candidateAttachmentSet.add(candidateAttachment);
-        }
-        assertEquals(10, candidateAttachmentSet.size());
+        if (!files.isEmpty()) {
 
-        // Use test set to loop through
-        for(CandidateAttachment file : candidateAttachmentSet) {
-            try {
-                String uniqueFilename = file.getUrl();
-                String destination = "candidate/migrated/" + uniqueFilename;
-                File srcFile = this.s3ResourceHelper.downloadFile(this.s3ResourceHelper.getS3Bucket(), destination);
-                String extractedText = TextExtractHelper.getTextExtractFromFile(srcFile, file.getFileType());
-                if (StringUtils.isNotBlank(extractedText)) {
-                    file.setTextExtract(extractedText);
+            // Test with 10 from List
+            Set<CandidateAttachment> candidateAttachmentSet = new HashSet<>();
+            for (int i = 0; i < 10; i++) {
+                CandidateAttachment candidateAttachment = files.get(i);
+                candidateAttachmentSet.add(candidateAttachment);
+            }
+            assertEquals(10, candidateAttachmentSet.size());
+
+            // Use test set to loop through
+            for (CandidateAttachment file : candidateAttachmentSet) {
+                try {
+                    String uniqueFilename = file.getUrl();
+                    String destination = "candidate/migrated/" + uniqueFilename;
+                    File srcFile = this.s3ResourceHelper.downloadFile(
+                        this.s3ResourceHelper.getS3Bucket(), destination);
+                    String extractedText = TextExtractHelper.getTextExtractFromFile(srcFile,
+                        file.getFileType());
+                    if (StringUtils.isNotBlank(extractedText)) {
+                        file.setTextExtract(extractedText);
+                    }
+                } catch (Exception e) {
+                    log.error("Could not extract text from " + file.getUrl(), e.getMessage());
                 }
-            } catch (Exception e) {
-                log.error("Could not extract text from " + file.getUrl(), e.getMessage());
             }
         }
     }
@@ -163,26 +168,28 @@ public class TextExtractHelperTest {
         List<CandidateAttachment> files = candidateAttachmentRepository.findByFileTypesAndMigrated(types, false);
         assertNotNull(files);
 
-        // Test with 10 from List
-        Set<CandidateAttachment> candidateAttachmentSet = new HashSet<>();
-        for (int i = 0; i < 5; i++) {
-            CandidateAttachment candidateAttachment = files.get(i);
-            candidateAttachmentSet.add(candidateAttachment);
-        }
-        assertEquals(5, candidateAttachmentSet.size());
+        if (!files.isEmpty()) {
+            // Test with 10 from List
+            Set<CandidateAttachment> candidateAttachmentSet = new HashSet<>();
+            for (int i = 0; i < 5; i++) {
+                CandidateAttachment candidateAttachment = files.get(i);
+                candidateAttachmentSet.add(candidateAttachment);
+            }
+            assertEquals(5, candidateAttachmentSet.size());
 
-        // Use test set to loop through
-        for(CandidateAttachment file : candidateAttachmentSet) {
-            try {
-                String uniqueFilename = file.getUrl();
-                String destination = "candidate/" + file.getCandidate().getCandidateNumber() + "/" + uniqueFilename;
-                File srcFile = this.s3ResourceHelper.downloadFile(this.s3ResourceHelper.getS3Bucket(), destination);
-                String extractedText = TextExtractHelper.getTextExtractFromFile(srcFile, file.getFileType());
-                if (StringUtils.isNotBlank(extractedText)) {
-                    file.setTextExtract(extractedText);
+            // Use test set to loop through
+            for(CandidateAttachment file : candidateAttachmentSet) {
+                try {
+                    String uniqueFilename = file.getUrl();
+                    String destination = "candidate/" + file.getCandidate().getCandidateNumber() + "/" + uniqueFilename;
+                    File srcFile = this.s3ResourceHelper.downloadFile(this.s3ResourceHelper.getS3Bucket(), destination);
+                    String extractedText = TextExtractHelper.getTextExtractFromFile(srcFile, file.getFileType());
+                    if (StringUtils.isNotBlank(extractedText)) {
+                        file.setTextExtract(extractedText);
+                    }
+                } catch (Exception e) {
+                    log.error("Could not extract text from " + file.getUrl(), e.getMessage());
                 }
-            } catch (Exception e) {
-                log.error("Could not extract text from " + file.getUrl(), e.getMessage());
             }
         }
     }
@@ -198,25 +205,29 @@ public class TextExtractHelperTest {
         List<CandidateAttachment> candidatePdfs = candidateAttachmentRepository.findByFileType("pdf");
         assertNotNull(candidatePdfs);
 
-        // Test with 10 from List
-        Set<CandidateAttachment> candidateAttachmentSet = new HashSet<>();
-        for (int i = 0; i < 10; i++) {
-            CandidateAttachment candidateAttachment;
-            candidateAttachment = candidatePdfs.get(i);
-            candidateAttachmentSet.add(candidateAttachment);
-        }
-        assertEquals(10, candidateAttachmentSet.size());
+        if (!candidatePdfs.isEmpty()) {
 
-        // Loop through test set using pdf text extract helper methods
-        for(CandidateAttachment pdf : candidateAttachmentSet){
-            try {
-                String uniqueFilename = pdf.getUrl();
-                String destination = "candidate/migrated/" + uniqueFilename;
-                File srcFile = this.s3ResourceHelper.downloadFile(this.s3ResourceHelper.getS3Bucket(), destination);
-                String pdfExtract = TextExtractHelper.getTextFromPDFFile(srcFile);
-                assertNotNull(pdfExtract);
-            } catch (Exception e) {
-                log.error("Could not extract text from " + pdf.getUrl(), e.getMessage());
+            // Test with 10 from List
+            Set<CandidateAttachment> candidateAttachmentSet = new HashSet<>();
+            for (int i = 0; i < 10; i++) {
+                CandidateAttachment candidateAttachment;
+                candidateAttachment = candidatePdfs.get(i);
+                candidateAttachmentSet.add(candidateAttachment);
+            }
+            assertEquals(10, candidateAttachmentSet.size());
+
+            // Loop through test set using pdf text extract helper methods
+            for (CandidateAttachment pdf : candidateAttachmentSet) {
+                try {
+                    String uniqueFilename = pdf.getUrl();
+                    String destination = "candidate/migrated/" + uniqueFilename;
+                    File srcFile = this.s3ResourceHelper.downloadFile(
+                        this.s3ResourceHelper.getS3Bucket(), destination);
+                    String pdfExtract = TextExtractHelper.getTextFromPDFFile(srcFile);
+                    assertNotNull(pdfExtract);
+                } catch (Exception e) {
+                    log.error("Could not extract text from " + pdf.getUrl(), e.getMessage());
+                }
             }
         }
     }
@@ -232,24 +243,28 @@ public class TextExtractHelperTest {
         List<CandidateAttachment> candidateDocs = candidateAttachmentRepository.findByFileType("docx");
         assertNotNull(candidateDocs);
 
-        // Create test set of docx files
-        Set<CandidateAttachment> candidateAttachmentSet = new HashSet<>();
-        for (int i = 0; i < 10; i++) {
-            CandidateAttachment candidateAttachment;
-            candidateAttachment = candidateDocs.get(i);
-            candidateAttachmentSet.add(candidateAttachment);
-        }
+        if (!candidateDocs.isEmpty()) {
 
-        // Loop through test set using docx text extract helper methods
-        for(CandidateAttachment docx : candidateAttachmentSet) {
-            try {
-                String uniqueFilename = docx.getUrl();
-                String destination = "candidate/migrated/" + uniqueFilename;
-                File srcFile = this.s3ResourceHelper.downloadFile(this.s3ResourceHelper.getS3Bucket(), destination);
-                String pdfExtract = TextExtractHelper.getTextFromDocxFile(srcFile);
-                assertNotNull(pdfExtract);
-            } catch (Exception e) {
-                log.error("Could not extract text from " + docx.getUrl(), e.getMessage());
+            // Create test set of docx files
+            Set<CandidateAttachment> candidateAttachmentSet = new HashSet<>();
+            for (int i = 0; i < 10; i++) {
+                CandidateAttachment candidateAttachment;
+                candidateAttachment = candidateDocs.get(i);
+                candidateAttachmentSet.add(candidateAttachment);
+            }
+
+            // Loop through test set using docx text extract helper methods
+            for (CandidateAttachment docx : candidateAttachmentSet) {
+                try {
+                    String uniqueFilename = docx.getUrl();
+                    String destination = "candidate/migrated/" + uniqueFilename;
+                    File srcFile = this.s3ResourceHelper.downloadFile(
+                        this.s3ResourceHelper.getS3Bucket(), destination);
+                    String pdfExtract = TextExtractHelper.getTextFromDocxFile(srcFile);
+                    assertNotNull(pdfExtract);
+                } catch (Exception e) {
+                    log.error("Could not extract text from " + docx.getUrl(), e.getMessage());
+                }
             }
         }
     }
@@ -265,26 +280,29 @@ public class TextExtractHelperTest {
         List<CandidateAttachment> candidateDocs = candidateAttachmentRepository.findByFileType("doc");
         assertNotNull(candidateDocs);
 
-        // Create test set of doc files
-        Set<CandidateAttachment> candidateAttachmentSet = new HashSet<>();
-        for (int i = 0; i < 10; i++) {
-            CandidateAttachment candidateAttachment;
-            candidateAttachment = candidateDocs.get(i);
-            candidateAttachmentSet.add(candidateAttachment);
-        }
+        if (!candidateDocs.isEmpty()) {
 
-        // Loop through test set using docx text extract helper methods
-        for(CandidateAttachment doc : candidateAttachmentSet) {
-            try{
-                String uniqueFilename = doc.getUrl();
-                String destination = "candidate/migrated/" + uniqueFilename;
-                File srcFile = this.s3ResourceHelper.downloadFile(this.s3ResourceHelper.getS3Bucket(), destination);
-                String pdfExtract = TextExtractHelper.getTextFromDocFile(srcFile);
-                assertNotNull(pdfExtract);
-            } catch (Exception e) {
-                log.error("Could not extract text from " + doc.getUrl(), e.getMessage());
+            // Create test set of doc files
+            Set<CandidateAttachment> candidateAttachmentSet = new HashSet<>();
+            for (int i = 0; i < 10; i++) {
+                CandidateAttachment candidateAttachment;
+                candidateAttachment = candidateDocs.get(i);
+                candidateAttachmentSet.add(candidateAttachment);
+            }
+
+            // Loop through test set using docx text extract helper methods
+            for (CandidateAttachment doc : candidateAttachmentSet) {
+                try {
+                    String uniqueFilename = doc.getUrl();
+                    String destination = "candidate/migrated/" + uniqueFilename;
+                    File srcFile = this.s3ResourceHelper.downloadFile(
+                        this.s3ResourceHelper.getS3Bucket(), destination);
+                    String pdfExtract = TextExtractHelper.getTextFromDocFile(srcFile);
+                    assertNotNull(pdfExtract);
+                } catch (Exception e) {
+                    log.error("Could not extract text from " + doc.getUrl(), e.getMessage());
+                }
             }
         }
-
     }
 }

--- a/ui/admin-portal/src/app/MockData/MockCandidate.ts
+++ b/ui/admin-portal/src/app/MockData/MockCandidate.ts
@@ -115,7 +115,6 @@ export class MockCandidate implements Candidate {
       updatedBy: mockUser,
       updatedDate: 1620000000000,
       migrated: false,
-      cv: false,
       uploadType: UploadType.other,
       fileType: 'pdf'
     },
@@ -129,7 +128,6 @@ export class MockCandidate implements Candidate {
       updatedBy: mockUser,
       updatedDate: 1620000000000,
       migrated: false,
-      cv: true,
       uploadType: UploadType.cv,
       fileType: 'pdf'
     }

--- a/ui/admin-portal/src/app/components/candidates/view/attachment/create/create-candidate-attachment.component.spec.ts
+++ b/ui/admin-portal/src/app/components/candidates/view/attachment/create/create-candidate-attachment.component.spec.ts
@@ -71,7 +71,6 @@ describe('CreateCandidateAttachmentComponent', () => {
       type: AttachmentType.link,
       name: 'Test Attachment',
       url: 'https://example.com',
-      cv: false,
       uploadType: UploadType.other
     };
 

--- a/ui/admin-portal/src/app/components/candidates/view/attachment/create/create-candidate-attachment.component.ts
+++ b/ui/admin-portal/src/app/components/candidates/view/attachment/create/create-candidate-attachment.component.ts
@@ -74,7 +74,6 @@ export class CreateCandidateAttachmentComponent implements OnInit {
     request.type = this.form.value.type;
     request.name = this.form.value.name;
     request.url = this.form.value.url;
-    request.cv = false;
     request.uploadType = UploadType.other;
     this.candidateAttachmentService.createAttachment(request).subscribe(
       (response) => this.modal.close(),

--- a/ui/admin-portal/src/app/components/candidates/view/attachment/view-candidate-attachment.component.html
+++ b/ui/admin-portal/src/app/components/candidates/view/attachment/view-candidate-attachment.component.html
@@ -73,7 +73,7 @@
           {{attachment.name}}
         </a>
         <span class="small text-dark"> - {{attachment.type}}</span>
-        <div class="d-inline ms-2" *ngIf="attachment.cv">
+        <div class="d-inline ms-2" *ngIf="attachment.uploadType === UploadType.cv">
           <app-cv-icon
             [candidate]="candidate"
             [attachment]="attachment"

--- a/ui/admin-portal/src/app/components/candidates/view/attachment/view-candidate-attachment.component.ts
+++ b/ui/admin-portal/src/app/components/candidates/view/attachment/view-candidate-attachment.component.ts
@@ -24,6 +24,7 @@ import {CreateCandidateAttachmentComponent} from './create/create-candidate-atta
 import {ConfirmationComponent} from '../../../util/confirm/confirmation.component';
 import {EditCandidateAttachmentComponent} from './edit/edit-candidate-attachment.component';
 import {CandidateService} from "../../../../services/candidate.service";
+import {UploadType} from "../../../../model/task";
 
 @Component({
   selector: 'app-view-candidate-attachment',
@@ -46,6 +47,10 @@ export class ViewCandidateAttachmentComponent implements OnInit {
 
   get AttachmentType() {
     return AttachmentType;
+  }
+  
+  get UploadType() {
+    return UploadType;
   }
 
   ngOnInit() {  }

--- a/ui/admin-portal/src/app/components/candidates/view/shareable-docs/shareable-docs.component.ts
+++ b/ui/admin-portal/src/app/components/candidates/view/shareable-docs/shareable-docs.component.ts
@@ -14,7 +14,15 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-import {Component, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChanges} from '@angular/core';
+import {
+  Component,
+  EventEmitter,
+  Input,
+  OnChanges,
+  OnInit,
+  Output,
+  SimpleChanges
+} from '@angular/core';
 import {Candidate, UpdateCandidateShareableDocsRequest} from "../../../../model/candidate";
 import {UntypedFormBuilder, UntypedFormGroup} from "@angular/forms";
 import {CandidateAttachment} from "../../../../model/candidate-attachment";
@@ -22,6 +30,7 @@ import {CandidateService} from "../../../../services/candidate.service";
 import {isSavedList} from "../../../../model/saved-list";
 import {CandidateSource} from "../../../../model/base";
 import {AuthorizationService} from "../../../../services/authorization.service";
+import {UploadType} from "../../../../model/task";
 
 @Component({
   selector: 'app-shareable-docs',
@@ -134,8 +143,9 @@ export class ShareableDocsComponent implements OnInit, OnChanges {
     return isSavedList(this.candidateSource);
   }
 
-  filterByCv(isCV: boolean) {
-    return this.candidate.candidateAttachments?.filter(a => a.cv === isCV);
+  filterByCv(isCv: boolean) {
+    return this.candidate.candidateAttachments?.filter(a =>
+      (isCv && a.uploadType === UploadType.cv) || (!isCv && a.uploadType !== UploadType.cv));
   }
 
   /**

--- a/ui/admin-portal/src/app/components/candidates/view/view-candidate.component.ts
+++ b/ui/admin-portal/src/app/components/candidates/view/view-candidate.component.ts
@@ -44,7 +44,17 @@ import {CreateChatRequest, JobChat, JobChatType} from "../../../model/chat";
 import {ChatService} from "../../../services/chat.service";
 import {DtoType} from "../../../model/base";
 import {LocalStorageService} from "../../../services/local-storage.service";
-import {catchError, concatMap, debounceTime, distinctUntilChanged, map, switchMap, takeUntil, tap} from "rxjs/operators";
+import {
+  catchError,
+  concatMap,
+  debounceTime,
+  distinctUntilChanged,
+  map,
+  switchMap,
+  takeUntil,
+  tap
+} from "rxjs/operators";
+import {UploadType} from "../../../model/task";
 
 @Component({
   selector: 'app-view-candidate',
@@ -567,7 +577,8 @@ export class ViewCandidateComponent extends MainSidePanelBase implements OnInit,
 
   private updateUploadedCvAvailable() {
     this.uploadedCvAvailable =
-      !!this.candidate?.candidateAttachments?.some(att => att.cv);
+      !!this.candidate?.candidateAttachments?.some(
+        att => att.uploadType === UploadType.cv);
   }
 
 }

--- a/ui/admin-portal/src/app/components/util/cv-icon/cv-icon.component.spec.ts
+++ b/ui/admin-portal/src/app/components/util/cv-icon/cv-icon.component.spec.ts
@@ -23,6 +23,7 @@ import {Candidate} from "../../../model/candidate";
 import {of, throwError} from "rxjs";
 import {DebugElement} from "@angular/core";
 import {By} from "@angular/platform-browser";
+import {UploadType} from "../../../model/task";
 
 describe('CvIconComponent', () => {
   let component: CvIconComponent;
@@ -67,7 +68,8 @@ describe('CvIconComponent', () => {
     const candidate: Candidate = mockCanidiate;
     component.candidate = candidate;
     component.getAttachments();
-    expect(component.cvs).toEqual(candidate.candidateAttachments.filter(attachment => attachment.cv));
+    expect(component.cvs).toEqual(candidate.candidateAttachments.filter(
+      attachment => attachment.uploadType === UploadType.cv));
   });
 
   it('should return true if user can view CV and cvs are present', () => {

--- a/ui/admin-portal/src/app/components/util/cv-icon/cv-icon.component.ts
+++ b/ui/admin-portal/src/app/components/util/cv-icon/cv-icon.component.ts
@@ -19,6 +19,7 @@ import {CandidateAttachment} from '../../../model/candidate-attachment';
 import {CandidateAttachmentService} from '../../../services/candidate-attachment.service';
 import {Candidate} from '../../../model/candidate';
 import {AuthorizationService} from "../../../services/authorization.service";
+import {UploadType} from "../../../model/task";
 
 /**
  * Clickable icon component that opens or DLs CVs uploaded to the given candidate's profile
@@ -65,7 +66,7 @@ export class CvIconComponent implements OnInit {
       // Only want to open/DL CV attachments (if we have them)
       if (this.candidate.candidateAttachments) {
         this.candidate.candidateAttachments.forEach(attachment => {
-          if (attachment.cv) {
+          if (attachment.uploadType === UploadType.cv) {
             this.cvs.push(attachment);
           }
         })

--- a/ui/admin-portal/src/app/model/candidate-attachment.spec.ts
+++ b/ui/admin-portal/src/app/model/candidate-attachment.spec.ts
@@ -30,7 +30,6 @@ describe('CandidateAttachmentRequest', () => {
     request.type = AttachmentType.file;
     request.name = 'Test File';
     request.url = 'uploads/test-file.pdf';
-    request.cv = true;
     request.uploadType = UploadType.cv;
     request.fileType = 'pdf';
 
@@ -38,7 +37,6 @@ describe('CandidateAttachmentRequest', () => {
     expect(request.type).toBe(AttachmentType.file);
     expect(request.name).toBe('Test File');
     expect(request.url).toBe('uploads/test-file.pdf');
-    expect(request.cv).toBe(true);
     expect(request.uploadType).toBe(UploadType.cv);
     expect(request.fileType).toBe('pdf');
     expect(request.folder).toBeUndefined();
@@ -50,14 +48,12 @@ describe('CandidateAttachmentRequest', () => {
     request.type = AttachmentType.link;
     request.name = 'Test Link';
     request.url = 'http://example.com';
-    request.cv = false;
     request.uploadType = UploadType.degree;
 
     expect(request.candidateId).toBe(1);
     expect(request.type).toBe(AttachmentType.link);
     expect(request.name).toBe('Test Link');
     expect(request.url).toBe('http://example.com');
-    expect(request.cv).toBe(false);
     expect(request.uploadType).toBe(UploadType.degree);
     expect(request.fileType).toBeUndefined();
     expect(request.folder).toBeUndefined();
@@ -69,7 +65,6 @@ describe('CandidateAttachmentRequest', () => {
     request.type = AttachmentType.googlefile;
     request.name = 'Google Drive';
     request.url = 'google-drive-link';
-    request.cv = true;
     request.uploadType = UploadType.englishExam;
     request.fileType = 'docx';
     request.folder = 'my-folder';
@@ -78,7 +73,6 @@ describe('CandidateAttachmentRequest', () => {
     expect(request.type).toBe(AttachmentType.googlefile);
     expect(request.name).toBe('Google Drive');
     expect(request.url).toBe('google-drive-link');
-    expect(request.cv).toBe(true);
     expect(request.uploadType).toBe(UploadType.englishExam);
     expect(request.fileType).toBe('docx');
     expect(request.folder).toBe('my-folder');
@@ -100,7 +94,6 @@ describe('CandidateAttachment', () => {
       updatedBy,
       updatedDate: Date.now(),
       migrated: false,
-      cv: true,
       uploadType: UploadType.degree,
       fileType: 'pdf'
     };
@@ -114,7 +107,6 @@ describe('CandidateAttachment', () => {
     expect(attachment.updatedBy).toBe(updatedBy);
     expect(attachment.updatedDate).toBeTruthy();
     expect(attachment.migrated).toBe(false);
-    expect(attachment.cv).toBe(true);
     expect(attachment.uploadType).toBe(UploadType.degree);
     expect(attachment.fileType).toBe('pdf');
   });

--- a/ui/admin-portal/src/app/model/candidate-attachment.ts
+++ b/ui/admin-portal/src/app/model/candidate-attachment.ts
@@ -25,17 +25,16 @@ export enum AttachmentType {
 
 export interface CandidateAttachment {
   id: number;
-  type: AttachmentType;
-  name: string;
-  url: string;
   createdBy: User;
   createdDate: number;
+  fileType: string;
+  migrated: boolean; // A flag determining is the file was migrated from the previous system
+  name: string;
+  type: AttachmentType;
   updatedBy: User
   updatedDate: number;
-  migrated: boolean; // A flag determining is the file was migrated from the previous system
-  cv: boolean;
   uploadType: UploadType;
-  fileType: string;
+  url: string;
 }
 
 export class CandidateAttachmentRequest {
@@ -43,7 +42,6 @@ export class CandidateAttachmentRequest {
   type: AttachmentType;
   name: string;
   url: string;
-  cv: boolean;
   uploadType: UploadType;
   fileType?: string; //Not needed for links
   folder?: string; //Only used by S3. Not needed for links or Google

--- a/ui/admin-portal/src/app/services/candidate-attachment.service.spec.ts
+++ b/ui/admin-portal/src/app/services/candidate-attachment.service.spec.ts
@@ -24,6 +24,7 @@ import {
 } from './candidate-attachment.service';
 import {environment} from '../../environments/environment';
 import {CandidateAttachment, CandidateAttachmentRequest} from '../model/candidate-attachment';
+import {UploadType} from "../model/task";
 
 describe('CandidateAttachmentService', () => {
   let service: CandidateAttachmentService;
@@ -49,7 +50,8 @@ describe('CandidateAttachmentService', () => {
 
   it('should search attachments', () => {
     const request: SearchCandidateAttachmentsRequest = { candidateId: 1, cvOnly: true };
-    const mockAttachments: CandidateAttachment[] = [{ id: 1, name: 'CV', url: '', fileType: 'pdf', cv: true } as CandidateAttachment];
+    const mockAttachments: CandidateAttachment[] =
+      [{ id: 1, name: 'CV', url: '', fileType: 'pdf', uploadType: UploadType.cv } as CandidateAttachment];
 
     service.search(request).subscribe((attachments) => {
       expect(attachments.length).toBe(1);
@@ -62,8 +64,10 @@ describe('CandidateAttachmentService', () => {
   });
 
   it('should create an attachment', () => {
-    const details: CandidateAttachmentRequest = { candidateId: 1, name: 'CV', fileType: 'pdf'} as CandidateAttachmentRequest;
-    const mockAttachment: CandidateAttachment = { id: 1, name: 'CV', url: '', fileType: 'pdf', cv: true } as CandidateAttachment;
+    const details: CandidateAttachmentRequest =
+      { candidateId: 1, name: 'CV', fileType: 'pdf'} as CandidateAttachmentRequest;
+    const mockAttachment: CandidateAttachment =
+      { id: 1, name: 'CV', url: '', fileType: 'pdf', uploadType: UploadType.cv } as CandidateAttachment;
 
     service.createAttachment(details).subscribe((attachment) => {
       expect(attachment).toEqual(mockAttachment);
@@ -75,7 +79,8 @@ describe('CandidateAttachmentService', () => {
   });
 
   it('should delete an attachment', () => {
-    const mockAttachment: CandidateAttachment = { id: 1, name: 'CV', url: '', fileType: 'pdf', cv: true } as CandidateAttachment;
+    const mockAttachment: CandidateAttachment =
+      { id: 1, name: 'CV', url: '', fileType: 'pdf', uploadType: UploadType.cv } as CandidateAttachment;
 
     service.deleteAttachment(1).subscribe((attachment) => {
       expect(attachment).toEqual(mockAttachment);
@@ -88,7 +93,8 @@ describe('CandidateAttachmentService', () => {
 
   it('should update an attachment', () => {
     const request: UpdateCandidateAttachmentRequest = { id: 1, name: 'Updated CV' };
-    const mockAttachment: CandidateAttachment = { id: 1, name: 'Updated CV', url: '', fileType: 'pdf', cv: true } as CandidateAttachment;
+    const mockAttachment: CandidateAttachment =
+      { id: 1, name: 'Updated CV', url: '', fileType: 'pdf', uploadType: UploadType.cv } as CandidateAttachment;
 
     service.updateAttachment(1, request).subscribe((attachment) => {
       expect(attachment).toEqual(mockAttachment);
@@ -101,7 +107,8 @@ describe('CandidateAttachmentService', () => {
 
   it('should list attachments by type', () => {
     const request: ListByUploadTypeRequest = { candidateId: 1, uploadType: 'pdf' };
-    const mockAttachments: CandidateAttachment[] = [{ id: 1, name: 'CV', url: '', fileType: 'pdf', cv: true } as CandidateAttachment];
+    const mockAttachments: CandidateAttachment[] =
+      [{ id: 1, name: 'CV', url: '', fileType: 'pdf', uploadType: UploadType.cv } as CandidateAttachment];
 
     service.listByType(request).subscribe((attachments) => {
       expect(attachments.length).toBe(1);

--- a/ui/admin-portal/src/app/services/candidate-attachment.service.ts
+++ b/ui/admin-portal/src/app/services/candidate-attachment.service.ts
@@ -34,7 +34,6 @@ export interface UpdateCandidateAttachmentRequest {
   id?: number;
   name?: string;
   url?: string;
-  cv?: boolean;
 }
 
 export interface SearchCandidateAttachmentsRequest {

--- a/ui/candidate-portal/src/app/components/common/candidate-attachments/candidate-attachments.component.ts
+++ b/ui/candidate-portal/src/app/components/common/candidate-attachments/candidate-attachments.component.ts
@@ -26,6 +26,7 @@ import {CandidateService} from '../../../services/candidate.service';
 import {forkJoin, Observable} from 'rxjs';
 import {UserService} from '../../../services/user.service';
 import {User} from '../../../model/user';
+import {UploadType} from "../../../model/task";
 
 @Component({
   selector: 'app-candidate-attachments',
@@ -99,7 +100,9 @@ export class CandidateAttachmentsComponent implements OnInit {
     this.candidateAttachmentService.listCandidateAttachments().subscribe(
       (response) => {
         if (!this.preview){
-          this.attachments = response.filter(att => att.cv === this.cv);
+          this.attachments = response.filter(att =>
+               this.cv && (att.uploadType === UploadType.cv)
+            || !this.cv && (att.uploadType !== UploadType.cv ));
         } else {
           this.attachments = response;
         }

--- a/ui/candidate-portal/src/app/model/candidate-attachment.ts
+++ b/ui/candidate-portal/src/app/model/candidate-attachment.ts
@@ -16,6 +16,7 @@
 
 import {Candidate} from './candidate';
 import {User} from './user';
+import {UploadType} from "./task";
 
 export enum AttachmentType {
   googlefile = 'googlefile',
@@ -23,48 +24,16 @@ export enum AttachmentType {
   link = 'link'
 }
 
-export enum UploadType {
-  conductEmployer = "conductEmployer",
-  conductEmployerTrans = "conductEmployerTrans",
-  conductMinistry = "conductMinistry",
-  conductMinistryTrans = "conductMinistryTrans",
-  cos = "cos",
-  cv = "cv",
-  degree = "degree",
-  degreeTranscript = "degreeTranscript",
-  degreeTranscriptTrans = "degreeTranscriptTrans",
-  englishExam = "englishExam",
-  licencing = "licencing",
-  licencingTrans = "licencingTrans",
-  offer = "offer",
-  otherId = "otherId",
-  otherIdTrans = "otherIdTrans",
-  passport = "passport",
-  policeCheck = "policeCheck",
-  policeCheckTrans = "policeCheckTrans",
-  proofAddress = "proofAddress",
-  proofAddressTrans = "proofAddressTrans",
-  references = "references",
-  residenceAttest = "residenceAttest",
-  residenceAttestTrans = "residenceAttestTrans",
-  studiedInEnglish = "studiedInEnglish",
-  other = "other",
-  vaccination = "vaccination",
-  vaccinationTran = "vaccinationTrans"
-}
-
-
 export interface CandidateAttachment {
   id?: number;
-  name: string;
-  url: string;
-  fileType: string;
-  type: AttachmentType;
-  migrated: boolean;
-  cv: boolean;
   candidate?: Candidate;
   createdBy: User;
   createdDate: string;
+  fileType: string;
+  migrated: boolean;
+  name: string;
+  type: AttachmentType;
   uploadType: UploadType;
+  url: string;
 
 }

--- a/ui/candidate-portal/src/app/services/candidate-attachment.service.ts
+++ b/ui/candidate-portal/src/app/services/candidate-attachment.service.ts
@@ -19,17 +19,14 @@ import {HttpClient} from "@angular/common/http";
 import {environment} from "../../environments/environment";
 import {Observable, throwError} from "rxjs";
 import {CandidateAttachment} from "../model/candidate-attachment";
-import {SearchResults} from "../model/search-results";
 import {saveBlob} from "../util/file";
 import {catchError, map} from "rxjs/operators";
 import {AuthenticationService} from "./authentication.service";
 
-//todo use this for other requests
 export interface UpdateCandidateAttachmentRequest {
   id?: number;
   name?: string;
   location?: string;
-  cv?: boolean;
 }
 
 @Injectable({
@@ -46,14 +43,6 @@ export class CandidateAttachmentService {
 
   listCandidateAttachments(): Observable<CandidateAttachment[]> {
     return this.http.get<CandidateAttachment[]>(`${this.apiUrl}`);
-  }
-
-  searchCandidateAttachments(request): Observable<SearchResults<CandidateAttachment>> {
-    return this.http.post<SearchResults<CandidateAttachment>>(`${this.apiUrl}/search`, request);
-  }
-
-  createAttachment(request): Observable<CandidateAttachment> {
-    return this.http.post<CandidateAttachment>(`${this.apiUrl}`, request);
   }
 
   deleteAttachment(id: number) {


### PR DESCRIPTION
As well as extracting text from uploaded GRN attachments, this also takes the opportunity to finally remove the redundant attachment cv field - replacing it with uploadType = UploadType.cv.
(It is still in the database - we can remove it in a subsequent release.)

This was actually causing a bug where cvs were not always having their text extracted - so I figured it was time to bite the bullet and get rid of it. Unfortunately it was used all over the place - hence the number of files. 