### PR TITLE
3323 configure tbb prod task definition for new translation service and document old s3 configuration

### DIFF
--- a/infra/aws/terraform/grn-prod/README.md
+++ b/infra/aws/terraform/grn-prod/README.md
@@ -106,9 +106,27 @@ This environment has `cloudfront_enable = true`, which creates:
 | ACM certificate (CloudFront) | us-east-1 | TLS cert for CloudFront (AWS requires us-east-1) |
 
 The S3 bucket is fully private (public access blocked). CloudFront reads files via OAC. The application
-writes files to S3 using static AWS credentials injected via SSM environment variables.
+writes files to S3 using the ECS task role (see [S3 credentials and ECS task role](#s3-credentials-and-ecs-task-role) below).
 
 The bucket name is available to the application as the `AWS_S3_CANDIDATE_FILES_BUCKET` environment variable.
+
+## S3 credentials and ECS task role
+
+The application references two distinct sets of AWS credentials for S3 access:
+
+| Environment variable | Source | Used by |
+|---------------------|--------|---------|
+| `AWS_CREDENTIALS_ACCESSKEY` / `AWS_CREDENTIALS_SECRETKEY` | SSM (from `secrets.auto.tfvars`) | Legacy `AwsConfiguration` / `S3ResourceHelper` |
+| `AWS_CREDENTIALS_APP_ACCESSKEY` / `AWS_CREDENTIALS_APP_SECRETKEY` | **Not set** (empty) | `S3Config` (candidate files, translations) |
+
+`AWS_CREDENTIALS_APP_ACCESSKEY` and `AWS_CREDENTIALS_APP_SECRETKEY` are **not managed by Terraform**
+and have no corresponding SSM parameters. They resolve to empty strings at runtime. When blank,
+`S3Config` falls back to the AWS default credential provider chain, which in ECS resolves to the
+**task role** (`<app>-<env>-fargate-task-role`). The task role has an S3 policy granting access to
+the configured buckets (`s3_bucket`, `translations_bucket`, and `candidate_files_bucket`).
+
+This is intentional — using the task role avoids long-lived static IAM user credentials for S3
+operations performed by the newer code paths.
 
 ## State and coexistence with opc-prod
 

--- a/infra/aws/terraform/grn-prod/main.tf
+++ b/infra/aws/terraform/grn-prod/main.tf
@@ -243,6 +243,7 @@ module "grn_prod" {
   s3_bucket                             = "files.tbbtalent.org" # todo: confirm or set GRN bucket
   translations_bucket                   = "translations.globalrefugee.net"
   translations_folder                   = "translations"
+  s3_region                             = "eu-west-2"
   environment                           = "grn-prod"
   email_default                         = "noreply@globalrefugee.net"
   email_test_override                   = "-"

--- a/infra/aws/terraform/grn-staging/README.md
+++ b/infra/aws/terraform/grn-staging/README.md
@@ -105,9 +105,27 @@ This environment has `cloudfront_enable = true`, which creates:
 | ACM certificate (CloudFront) | us-east-1 | TLS cert for CloudFront (AWS requires us-east-1) |
 
 The S3 bucket is fully private (public access blocked). CloudFront reads files via OAC. The application
-writes files to S3 using static AWS credentials injected via SSM environment variables.
+writes files to S3 using the ECS task role (see [S3 credentials and ECS task role](#s3-credentials-and-ecs-task-role) below).
 
 The bucket name is available to the application as the `AWS_S3_CANDIDATE_FILES_BUCKET` environment variable.
+
+## S3 credentials and ECS task role
+
+The application references two distinct sets of AWS credentials for S3 access:
+
+| Environment variable | Source | Used by |
+|---------------------|--------|---------|
+| `AWS_CREDENTIALS_ACCESSKEY` / `AWS_CREDENTIALS_SECRETKEY` | SSM (from `secrets.auto.tfvars`) | Legacy `AwsConfiguration` / `S3ResourceHelper` |
+| `AWS_CREDENTIALS_APP_ACCESSKEY` / `AWS_CREDENTIALS_APP_SECRETKEY` | **Not set** (empty) | `S3Config` (candidate files, translations) |
+
+`AWS_CREDENTIALS_APP_ACCESSKEY` and `AWS_CREDENTIALS_APP_SECRETKEY` are **not managed by Terraform**
+and have no corresponding SSM parameters. They resolve to empty strings at runtime. When blank,
+`S3Config` falls back to the AWS default credential provider chain, which in ECS resolves to the
+**task role** (`<app>-<env>-fargate-task-role`). The task role has an S3 policy granting access to
+the configured buckets (`s3_bucket`, `translations_bucket`, and `candidate_files_bucket`).
+
+This is intentional — using the task role avoids long-lived static IAM user credentials for S3
+operations performed by the newer code paths.
 
 ## State and coexistence with opc-staging
 

--- a/infra/aws/terraform/grn-staging/main.tf
+++ b/infra/aws/terraform/grn-staging/main.tf
@@ -243,6 +243,7 @@ module "grn_staging" {
   s3_bucket                             = "files.tbbtalent.org" # todo: confirm or set GRN bucket
   translations_bucket                   = "translations.test.globalrefugee.net"
   translations_folder                   = "translations"
+  s3_region                             = "eu-west-2"
   environment                           = "grn-staging"
   email_default                         = "-"
   email_test_override                   = "-"

--- a/infra/aws/terraform/opc-prod/README.md
+++ b/infra/aws/terraform/opc-prod/README.md
@@ -69,6 +69,24 @@ parameters with real values:
   - `SPRING_DATASOURCE_URL` is built from the RDS endpoint (when `db_enable=true`)
   - `REDIS_HOST` and `REDIS_PORT` are set from the ElastiCache cluster (when `cache_enable=true`)
 
+## S3 credentials and ECS task role
+
+The application references two distinct sets of AWS credentials for S3 access:
+
+| Environment variable | Source | Used by |
+|---------------------|--------|---------|
+| `AWS_CREDENTIALS_ACCESSKEY` / `AWS_CREDENTIALS_SECRETKEY` | SSM (from `secrets.auto.tfvars`) | Legacy `AwsConfiguration` / `S3ResourceHelper` |
+| `AWS_CREDENTIALS_APP_ACCESSKEY` / `AWS_CREDENTIALS_APP_SECRETKEY` | **Not set** (empty) | `S3Config` (candidate files, translations) |
+
+`AWS_CREDENTIALS_APP_ACCESSKEY` and `AWS_CREDENTIALS_APP_SECRETKEY` are **not managed by Terraform**
+and have no corresponding SSM parameters. They resolve to empty strings at runtime. When blank,
+`S3Config` falls back to the AWS default credential provider chain, which in ECS resolves to the
+**task role** (`<app>-<env>-fargate-task-role`). The task role has an S3 policy granting access to
+the configured buckets (`s3_bucket`, `translations_bucket`, and `candidate_files_bucket`).
+
+This is intentional — using the task role avoids long-lived static IAM user credentials for S3
+operations performed by the newer code paths.
+
 ## Secret and parameter updates
 
 To update any of the secrets or parameters, simply update the relevant SSM parameter directly in the

--- a/infra/aws/terraform/opc-prod/main.tf
+++ b/infra/aws/terraform/opc-prod/main.tf
@@ -248,6 +248,7 @@ module "tc-plus-prod" {
   s3_bucket                             = "files.tbbtalent.org" # todo: confirm bucket name
   translations_bucket                   = "translations.tctalent.org"
   translations_folder                   = "translations"
+  s3_region                             = "eu-west-2"
   environment                           = "opc-prod"
   email_default                         = "-" # todo: confirm if used/needed
   email_test_override                   = "-" # todo: set prod value

--- a/infra/aws/terraform/opc-staging/README.md
+++ b/infra/aws/terraform/opc-staging/README.md
@@ -69,6 +69,24 @@ all SSM parameters with real values:
   - `SPRING_DATASOURCE_URL` is built from the RDS endpoint (when `db_enable=true`)
   - `REDIS_HOST` and `REDIS_PORT` are set from the ElastiCache cluster (when `cache_enable=true`)
 
+## S3 credentials and ECS task role
+
+The application references two distinct sets of AWS credentials for S3 access:
+
+| Environment variable | Source | Used by |
+|---------------------|--------|---------|
+| `AWS_CREDENTIALS_ACCESSKEY` / `AWS_CREDENTIALS_SECRETKEY` | SSM (from `secrets.auto.tfvars`) | Legacy `AwsConfiguration` / `S3ResourceHelper` |
+| `AWS_CREDENTIALS_APP_ACCESSKEY` / `AWS_CREDENTIALS_APP_SECRETKEY` | **Not set** (empty) | `S3Config` (candidate files, translations) |
+
+`AWS_CREDENTIALS_APP_ACCESSKEY` and `AWS_CREDENTIALS_APP_SECRETKEY` are **not managed by Terraform**
+and have no corresponding SSM parameters. They resolve to empty strings at runtime. When blank,
+`S3Config` falls back to the AWS default credential provider chain, which in ECS resolves to the
+**task role** (`<app>-<env>-fargate-task-role`). The task role has an S3 policy granting access to
+the configured buckets (`s3_bucket`, `translations_bucket`, and `candidate_files_bucket`).
+
+This is intentional — using the task role avoids long-lived static IAM user credentials for S3
+operations performed by the newer code paths.
+
 ## Secret and parameter updates
 
 To update any of the secrets or parameters, simply update the relevant SSM parameter directly in the

--- a/infra/aws/terraform/opc-staging/main.tf
+++ b/infra/aws/terraform/opc-staging/main.tf
@@ -248,6 +248,7 @@ module "tc-plus-staging" {
   s3_bucket                             = "files.tbbtalent.org" # todo: confirm bucket name
   translations_bucket                   = "translations.test.tctalent.org"
   translations_folder                   = "translations"
+  s3_region                             = "eu-west-2"
   environment                           = "opc-staging"
   email_default                         = "UPDATE_DEFAULT_EMAIL_HERE"                         # todo: confirm if used/needed
   email_test_override                   = "john@cameronfoundation.org"                        # todo: change to shared address

--- a/infra/aws/terraform/parameters.tf
+++ b/infra/aws/terraform/parameters.tf
@@ -32,6 +32,12 @@ resource "aws_ssm_parameter" "translations_folder" {
   value = var.translations_folder
 }
 
+resource "aws_ssm_parameter" "s3_region" {
+  name  = "/${var.app}/${var.env}/S3_REGION"
+  type  = "String"
+  value = var.s3_region
+}
+
 resource "aws_ssm_parameter" "candidate_files_bucket" {
   count = var.cloudfront_enable ? 1 : 0
   name  = "/${var.app}/${var.env}/S3_CANDIDATE_FILES_BUCKET"

--- a/infra/aws/terraform/variables.tf
+++ b/infra/aws/terraform/variables.tf
@@ -218,6 +218,12 @@ variable "translations_folder" {
   description = "S3 folder/prefix for translations"
 }
 
+variable "s3_region" {
+  type        = string
+  description = "AWS region for the Spring S3 client (s3.region)"
+  default     = "eu-west-2"
+}
+
 variable "environment" {
   type        = string
   description = "Denotes running environment (e.g., opc-staging, opc-prod)"

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -267,7 +267,7 @@ aws:
   # required by TranslationMigrationService via S3ResourceHelper to access TBB S3
   # resources in us-east-1 during migration to OPC-managed S3 buckets.
   # When all services are fully migrated to OPC AWS, aws.s3/S3ResourceHelper can
-  # be retired.
+  # be retired. (See Git issue #3324)
   s3:
     bucketName: ${AWS_S3_BUCKETNAME:dev.files.tbbtalent.org}
     region: us-east-1

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -230,7 +230,7 @@ google:
     publishedSheetWideColumn: 300
 
 s3:
-  region: eu-west-2
+  region: ${S3_REGION:eu-west-2}
   # For dev this should be set in tc-secrets.
   #GRN instance uses these keys for both candidate file S3 storage and S3 translations
   #TBB instance does not use these keys. For S3 storage of translations it uses the keys in 

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -266,6 +266,9 @@ aws:
     bucketName: ${AWS_S3_BUCKETNAME:dev.files.tbbtalent.org}
     region: us-east-1
     max-size: 52428800
+    # Used by SystemUploadApi (GET /api/system/upload/policy/{s3Key}) as a key prefix.
+    # No frontend callers target this endpoint, the property is likely vestigial.
+    # It does not need to be replicated in the s3: config.
     upload-folder: temp
   credentials:
     # For dev this should be set in tc-secrets

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -262,6 +262,12 @@ candidate-file-urls:
   public-base-url: ${SERVER_URL:http://localhost:8080}
   
 aws:
+  # Legacy S3 configuration retained for translation file migration support.
+  # The primary app S3 client now uses the s3: block above, but aws.s3 is still
+  # required by TranslationMigrationService via S3ResourceHelper to access TBB S3
+  # resources in us-east-1 during migration to OPC-managed S3 buckets.
+  # When all services are fully migrated to OPC AWS, aws.s3/S3ResourceHelper can
+  # be retired.
   s3:
     bucketName: ${AWS_S3_BUCKETNAME:dev.files.tbbtalent.org}
     region: us-east-1


### PR DESCRIPTION
This PR -

- adds s3 region environment variable
- sets the s3 region via terraform for all terraform deployments
- documents the vestigial upload-folder config property
- documents the aws.s3 configuration (as distinct from the new s3 configuration)