### PR TITLE
update service assignment unique index

### DIFF
--- a/server/src/main/resources/db/migration/V2_7__update_service_assignment_unique_index.sql
+++ b/server/src/main/resources/db/migration/V2_7__update_service_assignment_unique_index.sql
@@ -1,0 +1,5 @@
+DROP INDEX IF EXISTS sa_assigned_per_resource_uq_idx;
+
+CREATE UNIQUE INDEX IF NOT EXISTS sa_assigned_per_resource_candidate_uq_idx
+    ON service_assignment(resource_id, candidate_id)
+    WHERE status = 'ASSIGNED' AND resource_id IS NOT NULL;


### PR DESCRIPTION
Tiny PR with only a Flyway migration that fixes an issue with a unique index that was preventing shared resource assignments to multiple candidates.

The script is written to be idempotent since the fix has already been manually applied to the unique index in all GRN and TBB staging and prod environments to remedy the bug.