### PR TITLE
3359 standardise environment variable values to stagingprod across all terraform deployments

### DIFF
--- a/infra/aws/terraform/grn-prod/main.tf
+++ b/infra/aws/terraform/grn-prod/main.tf
@@ -244,7 +244,7 @@ module "grn_prod" {
   translations_bucket                   = "translations.globalrefugee.net"
   translations_folder                   = "translations"
   s3_region                             = "eu-west-2"
-  environment                           = "grn-prod"
+  environment                           = "prod"
   email_default                         = "noreply@globalrefugee.net"
   email_test_override                   = "-"
   email_user                            = "noreply@globalrefugee.net"

--- a/infra/aws/terraform/grn-staging/main.tf
+++ b/infra/aws/terraform/grn-staging/main.tf
@@ -244,7 +244,7 @@ module "grn_staging" {
   translations_bucket                   = "translations.test.globalrefugee.net"
   translations_folder                   = "translations"
   s3_region                             = "eu-west-2"
-  environment                           = "grn-staging"
+  environment                           = "staging"
   email_default                         = "-"
   email_test_override                   = "-"
   email_user                            = "-"

--- a/infra/aws/terraform/opc-prod/main.tf
+++ b/infra/aws/terraform/opc-prod/main.tf
@@ -249,7 +249,7 @@ module "tc-plus-prod" {
   translations_bucket                   = "translations.tctalent.org"
   translations_folder                   = "translations"
   s3_region                             = "eu-west-2"
-  environment                           = "opc-prod"
+  environment                           = "prod"
   email_default                         = "-" # todo: confirm if used/needed
   email_test_override                   = "-" # todo: set prod value
   email_user                            = "-" # todo: confirm if used/needed

--- a/infra/aws/terraform/opc-staging/main.tf
+++ b/infra/aws/terraform/opc-staging/main.tf
@@ -249,7 +249,7 @@ module "tc-plus-staging" {
   translations_bucket                   = "translations.test.tctalent.org"
   translations_folder                   = "translations"
   s3_region                             = "eu-west-2"
-  environment                           = "opc-staging"
+  environment                           = "staging"
   email_default                         = "UPDATE_DEFAULT_EMAIL_HERE"                         # todo: confirm if used/needed
   email_test_override                   = "john@cameronfoundation.org"                        # todo: change to shared address
   email_user                            = "UPDATE_EMAIL_USER_HERE"                            # todo: confirm if used/needed

--- a/infra/aws/terraform/variables.tf
+++ b/infra/aws/terraform/variables.tf
@@ -226,7 +226,7 @@ variable "s3_region" {
 
 variable "environment" {
   type        = string
-  description = "Denotes running environment (e.g., opc-staging, opc-prod)"
+  description = "Denotes running environment; must match app enum values (local, staging, prod)"
 }
 
 variable "email_default" {


### PR DESCRIPTION
This PR fixes all terraform environments to use staging/prod ENVIRONMENT parameter values. 

This aligns with the values in the server side Environment enum. 

Even though the enum is presently unused, the update in this PR prevents any misalignment with future use.