### PR TITLE
3361 translations on dev required grntbb instance aws credentials

### DIFF
--- a/server/src/main/java/org/tctalent/server/configuration/properties/S3Properties.java
+++ b/server/src/main/java/org/tctalent/server/configuration/properties/S3Properties.java
@@ -31,14 +31,20 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class S3Properties {
 
     /**
-     * AWS access key
+     * AWS app credentials.
+     * In staging and production environments these fields are empty; S3 access is granted
+     * instead via the ECS task role assigned to the Fargate container.
      */
     private String accessKey;
+    private String secretKey;
 
     /**
-     * AWS secret key
+     * Per-instance-type translation bucket names for local development.
+     * These are selected at runtime based on tc.instance-type when S3_TRANSLATIONS_BUCKET
+     * is not explicitly set.
      */
-    private String secretKey;
+    private String tbbTranslationsBucket;
+    private String grnTranslationsBucket;
 
     /**
      * Max file size

--- a/server/src/main/java/org/tctalent/server/storage/S3TranslationStorageService.java
+++ b/server/src/main/java/org/tctalent/server/storage/S3TranslationStorageService.java
@@ -24,6 +24,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 import org.tctalent.server.configuration.properties.S3Properties;
@@ -52,6 +53,8 @@ public class S3TranslationStorageService {
     private final S3Client s3Client;
     private final S3Properties s3Properties;
     private final ObjectMapper objectMapper = new ObjectMapper();
+    @Value("${tc.instance-type}")
+    private String instanceType;
 
     /**
      * Retrieves the translation JSON file for the specified language from S3 and parses it into a Map.
@@ -153,7 +156,14 @@ public class S3TranslationStorageService {
     }
 
     private String getTranslationsBucket() {
-        return s3Properties.getTranslationsBucket();
+        String configuredTranslationsBucket = s3Properties.getTranslationsBucket();
+        if (StringUtils.hasText(configuredTranslationsBucket)) {
+            return configuredTranslationsBucket;
+        }
+        if ("GRN".equalsIgnoreCase(instanceType)) {
+            return s3Properties.getGrnTranslationsBucket();
+        }
+        return s3Properties.getTbbTranslationsBucket();
     }
 
     private String getTranslationsPrefix() {

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -231,19 +231,17 @@ google:
 
 s3:
   region: ${S3_REGION:eu-west-2}
-  # For dev this should be set in tc-secrets.
-  #GRN instance uses these keys for both candidate file S3 storage and S3 translations
-  #TBB instance does not use these keys. For S3 storage of translations it uses the keys in 
-  #aws.s3 (see below)  
+  # For local dev this should be set in tc-secrets.
+  # ECS environments intentionally leave these empty and use task-role credentials.
   access-key: ${AWS_CREDENTIALS_APP_ACCESSKEY:}
   secret-key: ${AWS_CREDENTIALS_APP_SECRETKEY:}
   max-size: 52428800
   candidate-files-bucket: ${S3_CANDIDATE_FILES_BUCKET:candidate-files.test.globalrefugee.net}
-  
-  #GRN staging Instance default
-  translations-bucket: ${S3_TRANSLATIONS_BUCKET:translations.test.globalrefugee.net}
-  #TBB staging Instance default
-#  translations-bucket: ${S3_TRANSLATIONS_BUCKET:dev.files.tbbtalent.org}
+
+  # ECS environments set this via SSM; local dev falls back to per-instance defaults below.
+  translations-bucket: ${S3_TRANSLATIONS_BUCKET:}
+  tbb-translations-bucket: ${S3_TBB_TRANSLATIONS_BUCKET:translations.test.tctalent.org}
+  grn-translations-bucket: ${S3_GRN_TRANSLATIONS_BUCKET:translations.test.globalrefugee.net}
   translations-folder: ${S3_TRANSLATIONS_FOLDER:translations}
 
 candidate-file-urls:


### PR DESCRIPTION
This PR fixes an issue where translations could be accidentally read and written from the unintended environment. 

Makes a clear distinction between GRN and TBB translations for local devs based on instance type. 

Separately, but related, the credentials required by local devs to use the new S3 staging buckets have been shared.