### PR TITLE
Remove hardcoded secrets from configs

### DIFF
--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -107,7 +107,7 @@ spring:
     driverClassName: org.postgresql.Driver
     url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/tctalent}
     username: tctalent
-    password: ${SPRING_DATASOURCE_PASSWORD:tctalent}
+    password: ${SPRING_DATASOURCE_PASSWORD}
     hikari:
       maximum-pool-size: ${SPRING_DBPOOL_MAX:10}
       minimum-idle:  ${SPRING_DBPOOL_MIN:10}
@@ -138,7 +138,7 @@ management:
       enabled: false
 
 jwt:
-  secret: ${JWT_SECRET:RX4bokONoSrrNLM6CMTij9iG9jHFG5VfsN1zIi9UqDGK3pQXASG7xMEga2VrAj3P1SNmywqnWRoTXnltuJ5l+A==}
+  secret: ${JWT_SECRET}
   # This equates to 24 hours in milliseconds
   expirationInMs: 86400000
 
@@ -323,7 +323,7 @@ anthropic:
 
 #Support for in context language translation
 translation:
-  password: ${TRANSLATION_PASSWORD:TGFM}
+  password: ${TRANSLATION_PASSWORD}
 
 #Identifies the running environment — AWS task definitions hold the corresponding value, e.g. 'prod'/'staging'
 #Options for injecting into code: https://www.baeldung.com/spring-boot-properties-env-variables

--- a/server/src/test/resources/application-test.yml
+++ b/server/src/test/resources/application-test.yml
@@ -10,7 +10,8 @@ spring:
       - org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
       - org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration
 jwt:
-  secret: RX4bokONoSrrNLM6CMTij9iG9jHFG5VfsN1zIi9UqDGK3pQXASG7xMEga2VrAj3P1SNmywqnWRoTXnltuJ5l+A==
+  # test-only dummy Base64 key
+  secret: 6ss8CX6p45KwLbet7/2xTMHU3zha11vmIgKlh7H6EKf8e9Hge0ic+LPN7s8NupAMVj2CpaiVdU34/f9DC01EcA==
   # This equates to 24 hours in milliseconds
   expirationInMs: 86400000
 


### PR DESCRIPTION
Replace hardcoded default secrets in application.yml with environment-variable placeholders for datasource password, JWT secret, and translation password to avoid shipping sensitive values. Add a test-only dummy Base64 JWT secret in application-test.yml to keep tests working without exposing production secrets.