### PR TITLE
2896 Update Step 8 Candidate Portal registration destinations

### DIFF
--- a/infra/aws/terraform/grn-prod/main.tf
+++ b/infra/aws/terraform/grn-prod/main.tf
@@ -281,7 +281,7 @@ module "grn_prod" {
   tc_db_copy_config               = "data.sharing/tcCopies.xml"
 
   # todo: this list can be expanded -- see backlog ticket
-  tc_destinations                 = "Australia,Canada,New Zealand,United Kingdom"
+  tc_destinations                 = "Australia,Belgium,Canada,France,Germany,Ireland,Italy,Slovakia,Spain,United Kingdom,United States"
 
   tc_skills_extraction_api_url    = "https://skills.globalrefugee.net"
   web_admin                       = "https://globalrefugee.net/admin-portal"

--- a/infra/aws/terraform/grn-staging/main.tf
+++ b/infra/aws/terraform/grn-staging/main.tf
@@ -274,7 +274,7 @@ module "grn_staging" {
   tc_api_url                      = "https://test.api.globalrefugee.net"
   tc_cors_urls                    = "https://test.globalrefugee.net,https://www.test.globalrefugee.net"
   tc_db_copy_config               = "data.sharing/tcCopies.xml"
-  tc_destinations                 = "Australia,Canada,New Zealand,United Kingdom"
+  tc_destinations                 = "Australia,Belgium,Canada,France,Germany,Ireland,Italy,Slovakia,Spain,United Kingdom,United States"
   tc_skills_extraction_api_url    = "https://test.skills.globalrefugee.net"
   web_admin                       = "https://test.globalrefugee.net/admin-portal"
   web_portal                      = "https://test.globalrefugee.net/candidate-portal"

--- a/infra/aws/terraform/opc-prod/main.tf
+++ b/infra/aws/terraform/opc-prod/main.tf
@@ -277,7 +277,7 @@ module "tc-plus-prod" {
   tc_api_url                            = "https://api.plus.tctalent.org"               # todo: set TC API URL
   tc_cors_urls                          = "https://tctalent.org"                        # todo: set prod CORS URLs
   tc_db_copy_config                     = "data.sharing/tcCopies.xml"                   # todo: can this be retired?
-  tc_destinations                       = "Australia,Canada,New Zealand,United Kingdom" # todo: set TC destinations
+  tc_destinations                       = "Australia,Belgium,Canada,France,Germany,Ireland,Italy,Slovakia,Spain,United Kingdom,United States" # todo: set TC destinations
   tc_skills_extraction_api_url          = "https://skills.plus.tctalent.org"            # todo: confirm prod URL
   web_admin                             = "https://plus.tctalent.org/admin-portal"
   web_portal                            = "https://plus.tctalent.org/candidate-portal"

--- a/infra/aws/terraform/opc-staging/main.tf
+++ b/infra/aws/terraform/opc-staging/main.tf
@@ -279,7 +279,7 @@ module "tc-plus-staging" {
   tc_api_url                      = "https://test.api.tctalent.org"
   tc_cors_urls                    = "https://tctalent-test.org,https://*.d2jx6ziu0w8kq9.amplifyapp.com,https://*.d1bt868vpd541m.amplifyapp.com"
   tc_db_copy_config               = "data.sharing/tcCopies.xml"                   # todo: can this be retired?
-  tc_destinations                 = "Australia,Canada,New Zealand,United Kingdom" # todo: set TC destinations
+  tc_destinations                 = "Australia,Belgium,Canada,France,Germany,Ireland,Italy,Slovakia,Spain,United Kingdom,United States" # todo: set TC destinations
   tc_skills_extraction_api_url    = "https://test.skills.tctalent.org"
   web_admin                       = "https://tctalent-test.org/admin-portal"
   web_portal                      = "https://tctalent-test.org/candidate-portal"

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -9,7 +9,7 @@ tc:
     #See SystemAdminConfiguration.java.
     boot-admin-password: ${TC_BOOT_ADMIN_PASSWORD:}
 
-  destinations: ${TC_DESTINATIONS:Australia,Canada,New Zealand,United Kingdom}
+  destinations: ${TC_DESTINATIONS:Australia,Belgium,Canada,France,Germany,Ireland,Italy,Slovakia,Spain,United Kingdom,United States}
 
   flyway:
     repair: true  #  Set this to true if you need to repair the Flyway history.


### PR DESCRIPTION
Candidate portal:
<img width="2880" height="3940" alt="screencapture-localhost-4200-register-2026-04-23-11_29_23 (1)" src="https://github.com/user-attachments/assets/536c1b2f-2b74-46f7-b908-ab38f353ec14" />
<img width="1307" height="502" alt="Screenshot 2026-04-23 at 4 04 18 PM" src="https://github.com/user-attachments/assets/cad0dba0-bfb2-42db-b6db-5770de6c4ed5" />

Admin Portal:
<img width="938" height="642" alt="Screenshot 2026-04-23 at 4 04 44 PM" src="https://github.com/user-attachments/assets/188dee3b-0491-4c6f-9ee2-24778fb5a417" />

