### PR TITLE
2937-highlighting-matches-in-search-results-does-not-only-highlight-words

### DIFF
--- a/ui/admin-portal/src/app/directives/highlight-search.directive.spec.ts
+++ b/ui/admin-portal/src/app/directives/highlight-search.directive.spec.ts
@@ -13,7 +13,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
-import {TestBed, ComponentFixture} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {Component, DebugElement} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {LowercaseDirective} from './lowercase.directive';
@@ -28,10 +28,10 @@ import {SearchQueryService} from "../services/search-query.service";
   template: `
     <div appLowercase></div>
     <div class="highlight" appHighlightSearch>Angular is amazing. Learn Angular today!</div>
+    <div id="word-boundary-test" appHighlightSearch>It is a bite writing situation.</div>
   `
 })
 class TestComponent {}
-
 describe('DirectiveModule', () => {
   let fixture: ComponentFixture<TestComponent>;
   let debugElement: DebugElement;
@@ -126,5 +126,20 @@ describe('DirectiveModule', () => {
     fixture.destroy();
 
     expect(destroySpy).toHaveBeenCalled();
+  });
+
+  it('should not highlight a search term inside another word', () => {
+    searchTerms$.next(['it']);
+    fixture.detectChanges();
+
+    const testElement = fixture.nativeElement.querySelector('#word-boundary-test');
+    const spans = testElement.querySelectorAll('span.highlight');
+
+    expect(spans.length).toBe(1);
+    expect(spans[0].textContent).toBe('It');
+
+    expect(testElement.innerHTML).not.toContain('b<span class="highlight">it</span>e');
+    expect(testElement.innerHTML).not.toContain('wr<span class="highlight">it</span>ing');
+    expect(testElement.innerHTML).not.toContain('s<span class="highlight">it</span>uation');
   });
 });

--- a/ui/admin-portal/src/app/directives/highlight-search.directive.ts
+++ b/ui/admin-portal/src/app/directives/highlight-search.directive.ts
@@ -96,12 +96,14 @@ export class HighlightSearchDirective implements OnInit, OnDestroy, AfterContent
 
   private createTermsRegex(searchTerms: string[]): RegExp {
     // Escape special regex characters in terms then join them with '|' to match any of them
-    const termsRegex = searchTerms.map(term =>
-        term.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&')
-    ).join('|');
+    const termsRegex = searchTerms
+    .filter(term => term && term.trim().length > 0) // This avoids building bad regex patterns from empty strings.
+    .map(term => term.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&'))
+    .join('|');
 
-    // Return a regex that finds any of the terms
-    return new RegExp(`(${termsRegex})`, 'gi');
+    // Match terms only when not inside another word.
+    // Prevents "it" matching "bite", "writing", etc.
+    return new RegExp(`(?<![\\p{L}\\p{N}_])(${termsRegex})(?![\\p{L}\\p{N}_])`, 'giu');
   }
 
   private highlightInTextNode(node: Node, regex: RegExp): void {


### PR DESCRIPTION
I investigated the highlight behavior for keyword search results.

As John mentioned on the ticket description the issue was not with the candidate search itself. The backend/Postgres text search correctly returns candidates only when the query term matches as a word. The problem was in the frontend highlighting logic used in the CV Matches tab.

The existing **highlight regex** matched the search term anywhere inside the text, so a query like it could highlight it inside words such as bite, writing, or situation. This created many false highlights even though the returned candidates were correct.

I updated the highlight regex in:

`ui/admin-portal/src/app/directives/highlight-search.directive.ts`

The change now:

- filters out empty search terms before building the regex
- keeps escaping special regex characters
- uses Unicode-aware word-boundary checks so terms are only highlighted when they are not inside another word
- prevents cases like **it** being highlighted inside **bite or writing**