### PR TITLE
added page size selection to lists and searches

### DIFF
--- a/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.html
+++ b/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.html
@@ -276,7 +276,7 @@
       </ng-select>
     </tc-field>
 
-    <!-- Results summary for searches -->
+    <!-- Results count (searches only) -->
     <div *ngIf="!isSavedList()"
          class="d-flex text-muted small align-items-baseline flex-wrap-reverse justify-content-sm-start pb-3">
       <div class="d-flex flex-grow-1 justify-content-end">
@@ -483,6 +483,18 @@
     >
       {{actionSuccessMessage}}
     </tc-alert>
+
+    <!-- Page-size selector -->
+    <div class="d-flex align-items-center gap-2 text-muted small mt-3 pb-1">
+      <label class="mb-0">Per page:</label>
+      <ng-select class="tc-select page-size-select"
+                 [items]="pageSizeOptions"
+                 [searchable]="false"
+                 [clearable]="false"
+                 [ngModel]="pageSize"
+                 (ngModelChange)="onPageSizeChange($event)">
+      </ng-select>
+    </div>
 
     <!-- Table of list contents - plus candidate details of selected candidate -->
     <div class="py-2">

--- a/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.scss
+++ b/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.scss
@@ -151,3 +151,7 @@ td a {
 .heading-row tc-icon {
   cursor: pointer;
 }
+
+.page-size-select {
+  width: 5rem;
+}

--- a/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.spec.ts
+++ b/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.spec.ts
@@ -16,7 +16,7 @@
 
 import {ShowCandidatesComponent} from "./show-candidates.component";
 import {ComponentFixture, fakeAsync, TestBed, tick} from "@angular/core/testing";
-import {ReactiveFormsModule, UntypedFormBuilder} from "@angular/forms";
+import {FormsModule, ReactiveFormsModule, UntypedFormBuilder} from "@angular/forms";
 import {SortedByComponent} from "../../util/sort/sorted-by.component";
 import {HttpClientTestingModule} from "@angular/common/http/testing";
 import {RouterTestingModule} from "@angular/router/testing";
@@ -26,6 +26,7 @@ import {
   NgbPaginationModule,
   NgbTypeaheadModule
 } from "@ng-bootstrap/ng-bootstrap";
+import {NgSelectModule} from "@ng-select/ng-select";
 import {DatePipe, TitleCasePipe} from "@angular/common";
 import {CandidateService} from "../../../services/candidate.service";
 import {
@@ -93,7 +94,9 @@ describe('ShowCandidatesComponent', () => {
         RouterTestingModule,
         NgbTypeaheadModule,
         NgbPaginationModule,
-        ReactiveFormsModule
+        FormsModule,
+        ReactiveFormsModule,
+        NgSelectModule
       ],
       providers: [
         UntypedFormBuilder,
@@ -447,5 +450,80 @@ describe('ShowCandidatesComponent', () => {
     expect(component.error).toBe('Action failed');
     expect(component.actionSuccessMessage).toBeNull();
   }));
+
+  describe('page size preference', () => {
+    const triggerSourceChange = () => component.ngOnChanges({
+      candidateSource: {
+        currentValue: component.candidateSource,
+        previousValue: null,
+        firstChange: true,
+        isFirstChange: () => true
+      }
+    });
+
+    beforeEach(() => {
+      mockCandidateSourceCandidateService.searchPaged.and.returnValue(
+        of({content: [], totalElements: 0, number: 0, size: 20})
+      );
+    });
+
+    it('should fall back to 20 when no preference is stored and @Input is not set', fakeAsync(() => {
+      mockLocalStorageService.get.and.returnValue(null);
+      component.pageSize = undefined as any;
+
+      triggerSourceChange();
+      tick();
+
+      expect(component.pageSize).toBe(20);
+    }));
+
+    it('should fall back to 20 when stored value is not a valid option', fakeAsync(() => {
+      mockLocalStorageService.get.and.callFake((key: string) =>
+        key.endsWith('PageSize') ? '42' : null
+      );
+      component.pageSize = undefined as any;
+
+      triggerSourceChange();
+      tick();
+
+      expect(component.pageSize).toBe(20);
+    }));
+
+    it('should restore a valid stored preference', fakeAsync(() => {
+      mockLocalStorageService.get.and.callFake((key: string) =>
+        key.endsWith('PageSize') ? '50' : null
+      );
+
+      triggerSourceChange();
+      tick();
+
+      expect(component.pageSize).toBe(50);
+    }));
+
+    it('should keep a valid @Input value when no preference is stored', fakeAsync(() => {
+      mockLocalStorageService.get.and.returnValue(null);
+      component.pageSize = 50;
+
+      triggerSourceChange();
+      tick();
+
+      expect(component.pageSize).toBe(50);
+    }));
+
+    it('onPageSizeChange should update pageSize, reset pageNumber, persist preference and trigger search',
+      () => {
+      spyOn(component, 'doSearch');
+      mockLocalStorageService.set.calls.reset();
+
+      component.onPageSizeChange(50);
+
+      expect(component.pageSize).toBe(50);
+      expect(component.pageNumber).toBe(1);
+      expect(mockLocalStorageService.set).toHaveBeenCalledWith(
+        jasmine.stringContaining('PageSize'), '50'
+      );
+      expect(component.doSearch).toHaveBeenCalledWith(true);
+    });
+  });
 
 });

--- a/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.ts
+++ b/ui/admin-portal/src/app/components/candidates/show/show-candidates.component.ts
@@ -125,6 +125,8 @@ import {
   ServiceList
 } from "../../../model/service-list";
 
+export type CandidatePageSize = 20 | 50 | 100;
+
 interface CachedTargetList {
   sourceID: number;
   listID: number;
@@ -143,7 +145,9 @@ export class ShowCandidatesComponent extends CandidateSourceBaseComponent implem
   @Input() showBreadcrumb: boolean = true;
   @Input() isKeywordSearch: boolean = false;
   @Input() declare pageNumber: number;
-  @Input() declare pageSize: number;
+  @Input() declare pageSize: CandidatePageSize;
+
+  readonly pageSizeOptions: CandidatePageSize[] = [20, 50, 100];
   @Input() searchRequest: SearchCandidateRequestPaged;
   @Output() candidateSelection = new EventEmitter();
   @Output() editSource = new EventEmitter();
@@ -348,6 +352,48 @@ export class ShowCandidatesComponent extends CandidateSourceBaseComponent implem
   }
 
   /**
+   * Returns the localStorage key used to persist the page-size preference for the current source.
+   */
+  private pageSizeKey(): string {
+    return getCandidateSourceType(this.candidateSource) + this.candidateSource.id + 'PageSize';
+  }
+
+  /**
+   * Reads the persisted page-size preference for the current source and applies it to this.pageSize.
+   * Priority: localStorage > @Input pageSize (if valid) > 20.
+   */
+  private loadPageSizePreference(): void {
+    const stored = this.localStorageService.get(this.pageSizeKey());
+    const parsed = parseInt(String(stored), 10) as CandidatePageSize;
+    if (this.pageSizeOptions.includes(parsed)) {
+      this.pageSize = parsed;
+      return;
+    }
+    if (this.pageSizeOptions.includes(this.pageSize)) {
+      return;
+    }
+    this.pageSize = 20;
+  }
+
+  /**
+   * Persists the current page size preference for the current source.
+   */
+  private savePageSizePreference(): void {
+    this.localStorageService.set(this.pageSizeKey(), String(this.pageSize));
+  }
+
+  /**
+   * Called when the user changes the per-page size selector.
+   * Resets to page 1, persists the preference, and re-fetches.
+   */
+  onPageSizeChange(size: CandidatePageSize): void {
+    this.pageSize = size;
+    this.pageNumber = 1;
+    this.savePageSizePreference();
+    this.doSearch(true);
+  }
+
+  /**
    * Restores candidate profile search card to previous px distance from top if > 0.
    */
   public setSearchCardScrollTop() {
@@ -373,9 +419,9 @@ export class ShowCandidatesComponent extends CandidateSourceBaseComponent implem
           //Set the selected fields to be displayed.
           this.loadSelectedFields();
 
-          //Retrieve the list previously used for saving selections from this
-          // source (if any)
+          //Retrieve the list previously used for saving selections from this source (if any).
           this.restoreTargetListFromCache();
+          this.loadPageSizePreference();
           this.doSearch(true);
           // Set the selected candidates (List only) to null when changing candidate source.
           this.selectedCandidates = [];


### PR DESCRIPTION
# #3045 — Configurable page size for submission lists

## What and why

Users working with large submission lists had no way to see more than 20 candidates at a time, making high-level review and bulk operations slow. This PR adds a **Per page** dropdown (20 / 50 / 100) above the candidate table in the submission list view.

The preference is stored in `localStorage` per source, so each list and search remembers its own setting independently across sessions. No backend changes were required — `pageSize` was already part of every paged request.

## Changes

| File | What changed |
|---|---|
| `show-candidates.component.ts` | `CandidatePageSize` union type; `pageSizeOptions` constant; `pageSizeKey()`, `loadPageSizePreference()`, `savePageSizePreference()`, `onPageSizeChange()` methods; preference loaded before first search on source change |
| `show-candidates.component.html` | Per-page `ng-select` dropdown positioned above the candidate table |
| `show-candidates.component.scss` | `.page-size-select` width rule |

## Tests added

New `describe('page size preference')` block in `show-candidates.component.spec.ts`:

- Falls back to 20 when no preference is stored and `@Input` is unset
- Falls back to 20 for an invalid stored value
- Restores a valid stored preference
- Keeps a valid `@Input` value when no preference is stored
- `onPageSizeChange` resets page number, persists preference, and triggers a fresh search
