### PR TITLE
Document DB dump order before Spring build

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,10 @@ in `application.yml` to define a password for that user.
 Alternately, ask TC developers for a `pg_dump` of the database. The advantage of the the dump
 is that you will get a database populated with a lot of test data and users. 
 
+> **Important:** Apply the DB dump before attempting to run the Spring build. Otherwise, an initial
+> schema will be created that conflicts with the dump, requiring you to reset Docker containers and
+> volumes before trying again.
+
 Note that the dump does not have to be recent. 
 The software will automatically apply any required updates to the database definition, driven by 
 Flyway files stored in GitHub. 


### PR DESCRIPTION
## Summary

This PR adds a short README warning that the local DB dump should be applied before attempting to run the Spring build. If Spring/Flyway runs first against the empty Docker Compose database, it can create an initial schema that conflicts with the dump and forces a developer to reset Docker containers and volumes before trying again.

Closes #2962

## Why I chose this item

I am new to contributing to this software and wanted to start with a small, low-risk issue that helps future contributors get set up successfully. Issue #2962 is a good first contribution because it is documentation-only, clearly scoped, and directly addresses a setup trap that has already affected developers.

My aim here is simply to make myself useful to the project while learning the contribution workflow, codebase structure, and local development setup.

## What changed

- Added a concise Important note in the README database setup section.
- Kept the wording close to the issue suggestion.
- Limited the change to the README only.

## Contribution guideline alignment

- Forked the upstream repository and opened this PR from my fork, following the fork-and-pull model.
- Branched from upstream staging, as requested in the contribution guidelines.
- Kept the branch name descriptive and tied to the issue: 2962-readme-apply-db-dump-before-build.
- Kept the patch narrow and documentation-only.
- Avoided bundling in adjacent suggestions from the issue thread, such as changing spring.jpa.hibernate.ddl-auto, because that appears to be a separate configuration decision rather than the direct README fix requested here.

## Validation

- Reviewed the README context around local DB dump setup.
- Confirmed the branch is based on staging.
- Ran git diff --check successfully.
- Did not run the Spring build locally because this issue is specifically about avoiding a premature Spring/Flyway run before applying the DB dump.