### PR TITLE
Fixes TC-1224 - access to s3 attachment for dev is not working

### DIFF
--- a/infra/aws/terraform/grn-prod/README.md
+++ b/infra/aws/terraform/grn-prod/README.md
@@ -117,16 +117,26 @@ The application references two distinct sets of AWS credentials for S3 access:
 | Environment variable | Source | Used by |
 |---------------------|--------|---------|
 | `AWS_CREDENTIALS_ACCESSKEY` / `AWS_CREDENTIALS_SECRETKEY` | SSM (from `secrets.auto.tfvars`) | Legacy `AwsConfiguration` / `S3ResourceHelper` |
-| `AWS_CREDENTIALS_APP_ACCESSKEY` / `AWS_CREDENTIALS_APP_SECRETKEY` | **Not set** (empty) | `S3Config` (candidate files, translations) |
+| `AWS_CREDENTIALS_APP_ACCESSKEY` / `AWS_CREDENTIALS_APP_SECRETKEY` | **Not set** (empty) in ECS — task role is used instead. | `S3Config` (candidate files, translations) |
 
 `AWS_CREDENTIALS_APP_ACCESSKEY` and `AWS_CREDENTIALS_APP_SECRETKEY` are **not managed by Terraform**
-and have no corresponding SSM parameters. They resolve to empty strings at runtime. When blank,
-`S3Config` falls back to the AWS default credential provider chain, which in ECS resolves to the
-**task role** (`<app>-<env>-fargate-task-role`). The task role has an S3 policy granting access to
-the configured buckets (`s3_bucket`, `translations_bucket`, and `candidate_files_bucket`).
+and have no corresponding SSM parameters. They resolve to empty strings at runtime in ECS.
+When blank, `S3Config` falls back to the AWS default credential provider chain, which in ECS
+resolves to the **task role** (`<app>-<env>-fargate-task-role`). The task role has an S3 policy
+granting access to the configured buckets (`s3_bucket`, `translations_bucket`, and
+`candidate_files_bucket`).
 
 This is intentional — using the task role avoids long-lived static IAM user credentials for S3
 operations performed by the newer code paths.
+
+### Local developer access — out of scope for production
+
+The shared developer IAM user used to support local-dev S3 access (`tc-dev-s3-access`, documented in
+the [grn-staging README](../grn-staging/README.md#local-developer-access--tc-dev-s3-access-iam-user))
+lives in the OPC staging account and is **explicitly scoped to staging buckets only**. Production
+GRN S3 buckets — including `candidate-files.globalrefugee.net` and `translations.globalrefugee.net`
+— are **not** accessible from any developer workstation. Production reads and writes are performed
+exclusively by the ECS task role described above.
 
 ## State and coexistence with opc-prod
 

--- a/infra/aws/terraform/grn-staging/README.md
+++ b/infra/aws/terraform/grn-staging/README.md
@@ -116,16 +116,36 @@ The application references two distinct sets of AWS credentials for S3 access:
 | Environment variable | Source | Used by |
 |---------------------|--------|---------|
 | `AWS_CREDENTIALS_ACCESSKEY` / `AWS_CREDENTIALS_SECRETKEY` | SSM (from `secrets.auto.tfvars`) | Legacy `AwsConfiguration` / `S3ResourceHelper` |
-| `AWS_CREDENTIALS_APP_ACCESSKEY` / `AWS_CREDENTIALS_APP_SECRETKEY` | **Not set** (empty) | `S3Config` (candidate files, translations) |
+| `AWS_CREDENTIALS_APP_ACCESSKEY` / `AWS_CREDENTIALS_APP_SECRETKEY` | **In ECS:** not set (empty) — task role is used instead. **Local dev:** populated from tc-secrets with the `tc-dev-s3-access` IAM user's keys. | `S3Config` (candidate files, translations) |
 
 `AWS_CREDENTIALS_APP_ACCESSKEY` and `AWS_CREDENTIALS_APP_SECRETKEY` are **not managed by Terraform**
-and have no corresponding SSM parameters. They resolve to empty strings at runtime. When blank,
-`S3Config` falls back to the AWS default credential provider chain, which in ECS resolves to the
-**task role** (`<app>-<env>-fargate-task-role`). The task role has an S3 policy granting access to
-the configured buckets (`s3_bucket`, `translations_bucket`, and `candidate_files_bucket`).
+and have no corresponding SSM parameters. They resolve to empty strings at runtime in ECS.
+When blank, `S3Config` falls back to the AWS default credential provider chain, which in ECS
+resolves to the **task role** (`<app>-<env>-fargate-task-role`). The task role has an S3 policy
+granting access to the configured buckets (`s3_bucket`, `translations_bucket`, and
+`candidate_files_bucket`).
 
 This is intentional — using the task role avoids long-lived static IAM user credentials for S3
 operations performed by the newer code paths.
+
+### Local developer access — `tc-dev-s3-access` IAM user
+
+For local development, `S3Config` cannot resolve credentials via the ECS task role, so a dedicated
+IAM user — `tc-dev-s3-access` — exists in the OPC staging AWS account (`164804461258`). Its access
+key / secret key pair is distributed to developers via tc-secrets as `AWS_CREDENTIALS_APP_ACCESSKEY`
+/ `AWS_CREDENTIALS_APP_SECRETKEY`.
+
+The user is **manually managed in the AWS console** (not in Terraform). Its policy is least-privilege
+and scoped to the three staging buckets it needs to reach:
+
+| Bucket | Purpose |
+|--------|---------|
+| `translations.test.globalrefugee.net` | GRN staging translations (used when local `TC_INSTANCE_TYPE=GRN`) |
+| `translations.test.tctalent.org` | TBB staging translations (used when local `TC_INSTANCE_TYPE=TBB`) |
+| `candidate-files.test.globalrefugee.net` | GRN staging candidate file attachments (uploaded via `S3StorageService`; TBB candidate files continue to use Google Drive and do not touch S3) |
+
+The user has no access to any production bucket. Production candidate-files / translation reads and
+writes are performed exclusively by the ECS task role.
 
 ## State and coexistence with opc-staging
 

--- a/infra/aws/terraform/opc-prod/README.md
+++ b/infra/aws/terraform/opc-prod/README.md
@@ -81,11 +81,21 @@ The application references two distinct sets of AWS credentials for S3 access:
 `AWS_CREDENTIALS_APP_ACCESSKEY` and `AWS_CREDENTIALS_APP_SECRETKEY` are **not managed by Terraform**
 and have no corresponding SSM parameters. They resolve to empty strings at runtime. When blank,
 `S3Config` falls back to the AWS default credential provider chain, which in ECS resolves to the
-**task role** (`<app>-<env>-fargate-task-role`). The task role has an S3 policy granting access to
-the configured buckets (`s3_bucket`, `translations_bucket`, and `candidate_files_bucket`).
+**task role** (`<app>-<env>-fargate-task-role`). The task role has an S3 policy that *would* grant
+access to `s3_bucket`, `translations_bucket`, and `candidate_files_bucket` — though see the note
+below on which of these buckets actually exist in this environment.
 
 This is intentional — using the task role avoids long-lived static IAM user credentials for S3
 operations performed by the newer code paths.
+
+> **Note — `candidate_files_bucket` is not provisioned in this environment.**
+> The opc-prod environment does not set `cloudfront_enable = true`, so `candidate_files_bucket`
+> is not actually created (see `s3.tf` and `cloudfront.tf`). The bucket name is also empty in
+> `main.tf`, so the ECS task role's S3 policy resolves it to no-op for this account. TBB candidate
+> files currently live on Google Drive, not S3. When the planned TBB-to-S3 migration is agreed and
+> actioned, this environment will gain a candidate-files bucket. The shared developer IAM user
+> (`tc-dev-s3-access`, documented in the [grn-staging README](../grn-staging/README.md#local-developer-access--tc-dev-s3-access-iam-user))
+> is staging-only and will not be granted access to any opc-prod bucket.
 
 ## Secret and parameter updates
 

--- a/infra/aws/terraform/opc-staging/README.md
+++ b/infra/aws/terraform/opc-staging/README.md
@@ -81,11 +81,21 @@ The application references two distinct sets of AWS credentials for S3 access:
 `AWS_CREDENTIALS_APP_ACCESSKEY` and `AWS_CREDENTIALS_APP_SECRETKEY` are **not managed by Terraform**
 and have no corresponding SSM parameters. They resolve to empty strings at runtime. When blank,
 `S3Config` falls back to the AWS default credential provider chain, which in ECS resolves to the
-**task role** (`<app>-<env>-fargate-task-role`). The task role has an S3 policy granting access to
-the configured buckets (`s3_bucket`, `translations_bucket`, and `candidate_files_bucket`).
+**task role** (`<app>-<env>-fargate-task-role`). The task role has an S3 policy that *would* grant
+access to `s3_bucket`, `translations_bucket`, and `candidate_files_bucket` — though see the note
+below on which of these buckets actually exist in this environment.
 
 This is intentional — using the task role avoids long-lived static IAM user credentials for S3
 operations performed by the newer code paths.
+
+> **Note — `candidate_files_bucket` is not provisioned in this environment.**
+> The opc-staging environment does not set `cloudfront_enable = true`, so `candidate_files_bucket`
+> is not actually created (see `s3.tf` and `cloudfront.tf`). The bucket name is also empty in
+> `main.tf`, so the ECS task role's S3 policy resolves it to no-op for this account. TBB candidate
+> files currently live on Google Drive, not S3. When the planned TBB-to-S3 migration is agreed and
+> actioned, this environment will gain a candidate-files bucket and the shared developer IAM user
+> (`tc-dev-s3-access`, documented in the [grn-staging README](../grn-staging/README.md#local-developer-access--tc-dev-s3-access-iam-user))
+> will be extended to cover it at that time.
 
 ## Secret and parameter updates
 

--- a/server/src/main/java/org/tctalent/server/configuration/properties/S3Properties.java
+++ b/server/src/main/java/org/tctalent/server/configuration/properties/S3Properties.java
@@ -57,7 +57,13 @@ public class S3Properties {
     private String region;
 
     /**
-     * S3 bucket for candidate files storage.
+     * S3 bucket for candidate files storage. Used by the GRN instance only.
+     * <p>
+     * TBB candidate files are stored on Google Drive (the legacy file-system path) and do not
+     * use this property. When the planned TBB-to-S3 migration is agreed and actioned, this
+     * field will likely be split into per-instance-type buckets mirroring the translations
+     * bucket configuration (see {@link #tbbTranslationsBucket} / {@link #grnTranslationsBucket}).
+     * <p>
      * Example: candidate-files.globalrefugee.net
      */
     private String candidateFilesBucket;


### PR DESCRIPTION
THis PR --

- Fixes TC-1224: local GRN devs can upload/download candidate attachments to candidate-files.test.globalrefugee.net after extending the tc-dev-s3-access IAM policy (manual AWS console change, not in this PR)
- Documents the tc-dev-s3-access dev IAM user and its staging bucket scope in the GRN infra READMEs
- Notes that GRN prod buckets are out of scope for the dev IAM user
- Clarifies in opc-staging/opc-prod READMEs that TBB candidate files still use Google Drive and no candidate-files bucket is provisioned there yet
- Adds JavaDoc on S3Properties.candidateFilesBucket noting GRN-only usage today and a future TBB-to-S3 migration path
