### PR TITLE
3478 notes in chronological order from full candidate profile not in search card

### DIFF
--- a/server/src/main/java/org/tctalent/server/repository/db/read/dto/CandidateReadDto.java
+++ b/server/src/main/java/org/tctalent/server/repository/db/read/dto/CandidateReadDto.java
@@ -79,7 +79,7 @@ public class CandidateReadDto {
     private List<CandidateJobExperienceReadDto> candidateJobExperiences;
     @JsonOneToMany(joinColumn = "candidate_id")
     private List<CandidateLanguageReadDto> candidateLanguages;
-    @JsonOneToMany(joinColumn = "candidate_id")
+    @JsonOneToMany(joinColumn = "candidate_id", orderBy = "updated_date DESC")
     private List<CandidateNoteReadDto> candidateNotes;
     @JsonOneToMany(joinColumn = "candidate_id")
     private List<CandidateOccupationReadDto> candidateOccupations;

--- a/server/src/main/java/org/tctalent/server/repository/db/read/sql/SqlJsonQueryBuilder.java
+++ b/server/src/main/java/org/tctalent/server/repository/db/read/sql/SqlJsonQueryBuilder.java
@@ -292,7 +292,8 @@ public class SqlJsonQueryBuilder {
                     childTable,
                     childAlias,
                     oneToMany.joinColumn(),
-                    tableAlias
+                    tableAlias,
+                    oneToMany.orderBy()
                 );
 
                 pairs.add(new Pair(field.getName(), valueExpr));
@@ -457,19 +458,25 @@ public class SqlJsonQueryBuilder {
         SqlTable childTable,
         String childAlias,
         String joinColumnOnChild,
-        String parentAlias
+        String parentAlias,
+        String orderBy
     ) {
         BuildContext nestedCtx = new BuildContext();
         String elementJson = buildJsonExpression(elementType, childAlias, nestedCtx);
 
+        String orderByClause = (orderBy == null || orderBy.isBlank())
+            ? ""
+            : " ORDER BY " + orderBy;
+
         return ("""
             (
-              select coalesce(jsonb_agg(%s), '[]'::jsonb)
+              select coalesce(jsonb_agg(%s%s), '[]'::jsonb)
               from %s %s
               where %s.%s = %s.id
             )
             """).formatted(
             elementJson,
+            orderByClause,
             childTable.name(),
             childAlias,
             childAlias,

--- a/server/src/test/java/org/tctalent/server/repository/db/read/sql/SqlJsonQueryBuilderTest.java
+++ b/server/src/test/java/org/tctalent/server/repository/db/read/sql/SqlJsonQueryBuilderTest.java
@@ -24,6 +24,7 @@ import lombok.Getter;
 import lombok.Setter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.tctalent.server.repository.db.read.annotation.JsonOneToMany;
 import org.tctalent.server.repository.db.read.annotation.SqlColumn;
 import org.tctalent.server.repository.db.read.annotation.SqlDefaults;
 import org.tctalent.server.repository.db.read.annotation.SqlTable;
@@ -39,6 +40,23 @@ class SqlJsonQueryBuilderTest {
         @SqlColumn(transform = "to_jsonb(string_to_array(%s, ','))")
         private List<String> names;
         private String somethingElse;
+    }
+
+    @Getter
+    @Setter
+    @SqlTable(name = "tag", alias = "tg")
+    @SqlDefaults(mapUnannotatedColumns = true)
+    static class TagDto {
+        private Long id;
+        private String label;
+    }
+
+    @Getter
+    @Setter
+    @SqlTable(name = "parent", alias = "p")
+    static class ParentWithOrderedChildrenDto {
+        @JsonOneToMany(joinColumn = "parent_id", orderBy = "label ASC")
+        private List<TagDto> tags;
     }
 
 
@@ -65,6 +83,29 @@ class SqlJsonQueryBuilderTest {
             from candidate c
             where c.id in (:ids)""";
         assertEquals(expected, sql);
+    }
+
+    @Test
+    void one_to_many_with_orderBy_emits_order_by_clause() {
+        String sql = sqlJsonQueryBuilder.buildByIdsQuery(ParentWithOrderedChildrenDto.class, "ids");
+
+        assertThat(sql).contains("ORDER BY label ASC");
+    }
+
+    @Test
+    void one_to_many_without_orderBy_omits_order_by_clause() {
+        String sql = sqlJsonQueryBuilder.buildByIdsQuery(SampleDto.class, "ids");
+
+        assertThat(sql).doesNotContain("ORDER BY");
+    }
+
+    @Test
+    void candidate_notes_subquery_orders_by_updated_date_desc() {
+        String sql = sqlJsonQueryBuilder.buildByIdsQuery(CandidateReadDto.class, "ids");
+
+        assertThat(sql)
+            .contains("from candidate_note")
+            .contains("ORDER BY updated_date DESC");
     }
 
     @Test

--- a/ui/admin-portal/src/app/components/candidates/view/tab/candidate-history-tab/candidate-history-tab.component.html
+++ b/ui/admin-portal/src/app/components/candidates/view/tab/candidate-history-tab/candidate-history-tab.component.html
@@ -18,6 +18,5 @@
   [candidate]="candidate"
   [editable]="editable"
   [characterLimit]="characterLimit"
-  (onAddNote)="onAddNote($event)"
   (onResize)="resize()">
 </app-view-candidate-note>

--- a/ui/admin-portal/src/app/components/candidates/view/tab/candidate-history-tab/candidate-history-tab.component.ts
+++ b/ui/admin-portal/src/app/components/candidates/view/tab/candidate-history-tab/candidate-history-tab.component.ts
@@ -59,10 +59,6 @@ export class CandidateHistoryTabComponent implements OnInit, OnChanges {
     }
   }
 
-  onAddNote($event) {
-    // TODO
-  }
-
   resize(){
     this.onResize.emit();
   }


### PR DESCRIPTION
# Fix candidate notes ordering in search results

## What and why

`view-candidate-note` is used in two contexts: the full candidate profile (`view-candidate`) and the search card (`candidate-history-tab`). Notes appeared in the correct order in the profile but in indeterminate order in the search card.

The profile loads the candidate as a JPA entity, where Hibernate applies `@OrderBy("updatedDate DESC")` on the `candidateNotes` relationship. The search card receives its candidate from search results, which are built via `SqlJsonQueryBuilder` using native SQL — the `jsonb_agg(...)` subquery had no `ORDER BY`, so PostgreSQL returned notes in an arbitrary order.

`@JsonOneToMany` already had an `orderBy` attribute for exactly this purpose but it was never read when the SQL expression was built. This change wires it through and sets `orderBy = "updated_date DESC"` on `CandidateReadDto.candidateNotes`.

Also removes the dead `(onAddNote)` binding and no-op handler from `candidate-history-tab`.

## Changes

| File | What changed |
|---|---|
| `SqlJsonQueryBuilder.java` | Accepts and emits `ORDER BY` inside `jsonb_agg(...)` when `@JsonOneToMany.orderBy` is set |
| `CandidateReadDto.java` | Adds `orderBy = "updated_date DESC"` to `candidateNotes` |
| `candidate-history-tab.component.html` | Removes dead `(onAddNote)` binding |
| `candidate-history-tab.component.ts` | Removes empty `onAddNote` handler |

## Tests added

New tests in `SqlJsonQueryBuilderTest`:

- `one_to_many_with_orderBy_emits_order_by_clause` — verifies ORDER BY is injected for a synthetic DTO
- `one_to_many_without_orderBy_omits_order_by_clause` — verifies the empty-string guard produces no ORDER BY
- `candidate_notes_subquery_orders_by_updated_date_desc` — verifies the full `CandidateReadDto` SQL contains `ORDER BY updated_date DESC`
