### PR TITLE
3460 Add SalesforceServiceImpl unit tests

### DIFF
--- a/server/src/test/java/org/tctalent/server/service/db/impl/SalesforceServiceImplTest.java
+++ b/server/src/test/java/org/tctalent/server/service/db/impl/SalesforceServiceImplTest.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2026 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.service.db.impl;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.BDDMockito.given;
+import static org.tctalent.server.data.CandidateTestData.getCandidate;
+import static org.tctalent.server.data.CountryTestData.CANADA;
+import static org.tctalent.server.data.CountryTestData.UNITED_KINGDOM;
+import static org.tctalent.server.data.SalesforceJobOppTestData.getSalesforceJobOppMinimal;
+
+import java.time.LocalDate;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.tctalent.server.configuration.SalesforceConfig;
+import org.tctalent.server.configuration.SalesforceRecordTypeConfig;
+import org.tctalent.server.configuration.SalesforceTbbAccountsConfig;
+import org.tctalent.server.model.db.Candidate;
+import org.tctalent.server.model.db.SalesforceJobOpp;
+import org.tctalent.server.service.db.CandidateDependantService;
+import org.tctalent.server.service.db.NextStepProcessingService;
+import org.tctalent.server.service.db.email.EmailHelper;
+
+@ExtendWith(MockitoExtension.class)
+class SalesforceServiceImplTest {
+
+    @Mock private EmailHelper emailHelper;
+    @Mock private SalesforceConfig salesforceConfig;
+    @Mock private SalesforceRecordTypeConfig salesforceRecordTypeConfig;
+    @Mock private SalesforceTbbAccountsConfig salesforceTbbAccountsConfig;
+    @Mock private CandidateDependantService candidateDependantService;
+    @Mock private NextStepProcessingService nextStepProcessingService;
+
+    private SalesforceServiceImpl salesforceService;
+
+    @BeforeEach
+    void setUp() {
+        given(salesforceConfig.getBaseClassicUrl())
+            .willReturn("https://talentbeyondboundaries.my.salesforce.com/");
+
+        salesforceService = new SalesforceServiceImpl(
+            emailHelper,
+            salesforceConfig,
+            salesforceRecordTypeConfig,
+            salesforceTbbAccountsConfig,
+            candidateDependantService,
+            nextStepProcessingService
+        );
+    }
+
+    @Test
+    @DisplayName("should make candidate opportunity external id from candidate and job ids")
+    void makeExternalId_shouldJoinCandidateAndJobIds() {
+        assertEquals("123-006Uu00000IGDAEIA5",
+            SalesforceServiceImpl.makeExternalId("123", "006Uu00000IGDAEIA5"));
+    }
+
+    @Test
+    @DisplayName("should truncate generated candidate opportunity names to Salesforce limit")
+    void generateCandidateOppName_shouldTruncateLongNamesToSalesforceLimit() {
+        Candidate candidate = getCandidate();
+        candidate.setCandidateNumber("123456");
+
+        SalesforceJobOpp job = getSalesforceJobOppMinimal();
+        job.setName("A".repeat(130));
+
+        String result = salesforceService.generateCandidateOppName(candidate, job);
+
+        assertAll(
+            () -> assertEquals(120, result.length()),
+            () -> assertEquals("test(123456)-" + "A".repeat(104) + "...", result)
+        );
+    }
+
+    @Test
+    @DisplayName("should choose Canada candidate opportunity record type for Canadian jobs")
+    void getCandidateOpportunityRecordType_shouldUseCanadaRecordTypeForCanadianJobs() {
+        SalesforceJobOpp job = getSalesforceJobOppMinimal();
+        job.setCountry(CANADA);
+
+        String result = ReflectionTestUtils.invokeMethod(
+            salesforceService, "getCandidateOpportunityRecordType", job);
+
+        assertEquals("Candidate recruitment (CAN)", result);
+    }
+
+    @Test
+    @DisplayName("should choose default candidate opportunity record type for non-Canadian jobs")
+    void getCandidateOpportunityRecordType_shouldUseDefaultRecordTypeForNonCanadianJobs() {
+        SalesforceJobOpp job = getSalesforceJobOppMinimal();
+        job.setCountry(UNITED_KINGDOM);
+
+        String result = ReflectionTestUtils.invokeMethod(
+            salesforceService, "getCandidateOpportunityRecordType", job);
+
+        assertEquals("Candidate recruitment", result);
+    }
+
+    @Test
+    @DisplayName("should build create candidate opportunity request with required Salesforce fields")
+    void candidateOpportunityRecordComposite_shouldIncludeCreateOnlyFields_whenCreating() {
+        Candidate candidate = getCandidate();
+        candidate.setSflink(
+            "https://talentbeyondboundaries.lightning.force.com/lightning/r/Contact/003Uu00000IGDAEIA5/view");
+        SalesforceJobOpp job = getSalesforceJobOppMinimal();
+        job.setOwnerId("005Uu00000IGDAEIA5");
+
+        SalesforceServiceImpl.CandidateOpportunityRecordComposite request =
+            salesforceService.new CandidateOpportunityRecordComposite(
+                "Candidate recruitment", candidate, job, true);
+
+        SalesforceServiceImpl.RecordTypeField recordType =
+            (SalesforceServiceImpl.RecordTypeField) request.get("RecordType");
+        SalesforceServiceImpl.CompositeAttributes attributes =
+            (SalesforceServiceImpl.CompositeAttributes) request.get("attributes");
+
+        assertAll(
+            () -> assertNotNull(attributes),
+            () -> assertEquals("Opportunity", attributes.type),
+            () -> assertEquals("Candidate recruitment", recordType.Name),
+            () -> assertEquals("99-sales-force-job-opp-id",
+                request.get("TBBCandidateExternalId__c")),
+            () -> assertEquals("test(99)-Test Job", request.get("Name")),
+            () -> assertEquals(job.getAccountId(), request.get("AccountId")),
+            () -> assertEquals("003Uu00000IGDAEIA5", request.get("Candidate_Contact__c")),
+            () -> assertEquals(job.getSfId(), request.get("Parent_Opportunity__c")),
+            () -> assertEquals(job.getOwnerId(), request.get("OwnerId")),
+            () -> assertNotNull(LocalDate.parse((String) request.get("CloseDate")))
+        );
+    }
+
+    @Test
+    @DisplayName("should build update candidate opportunity request without create-only fields")
+    void candidateOpportunityRecordComposite_shouldOmitCreateOnlyFields_whenUpdating() {
+        Candidate candidate = getCandidate();
+        SalesforceJobOpp job = getSalesforceJobOppMinimal();
+
+        SalesforceServiceImpl.CandidateOpportunityRecordComposite request =
+            salesforceService.new CandidateOpportunityRecordComposite(
+                "Candidate recruitment", candidate, job, false);
+
+        assertAll(
+            () -> assertEquals("99-sales-force-job-opp-id",
+                request.get("TBBCandidateExternalId__c")),
+            () -> assertNull(request.get("Name")),
+            () -> assertFalse(request.containsKey("AccountId")),
+            () -> assertFalse(request.containsKey("Candidate_Contact__c")),
+            () -> assertFalse(request.containsKey("Parent_Opportunity__c")),
+            () -> assertFalse(request.containsKey("CloseDate"))
+        );
+    }
+
+}

--- a/server/src/test/java/org/tctalent/server/service/db/impl/SalesforceServiceImplTest.java
+++ b/server/src/test/java/org/tctalent/server/service/db/impl/SalesforceServiceImplTest.java
@@ -18,6 +18,8 @@ package org.tctalent.server.service.db.impl;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -312,6 +314,77 @@ class SalesforceServiceImplTest {
         () -> assertEquals("https://drive.example/jd", result.Job_Description_Folder__c),
         () -> assertEquals("https://tc.example/list", result.Talent_Catalog_List__c),
         () -> assertEquals(123L, result.TCid__c)
+    );
+  }
+
+  @Test
+  void candidateOpportunityRecordCompositeIncludesCreateOnlyFieldsWhenCreating() {
+    Candidate candidate = mock(Candidate.class);
+    User user = new User();
+    user.setFirstName("John");
+
+    SalesforceJobOpp job = mock(SalesforceJobOpp.class);
+
+    when(candidate.getUser()).thenReturn(user);
+    when(candidate.getCandidateNumber()).thenReturn("99");
+    when(candidate.getSfId()).thenReturn("003Uu00000IGDAEIA5");
+    when(job.getSfId()).thenReturn("sales-force-job-opp-id");
+    when(job.getName()).thenReturn("Test Job");
+    when(job.getAccountId()).thenReturn("123456");
+    when(job.getOwnerId()).thenReturn("005Uu00000IGDAEIA5");
+
+    SalesforceServiceImpl.CandidateOpportunityRecordComposite request =
+        service.new CandidateOpportunityRecordComposite(
+            "Candidate recruitment", candidate, job, true);
+
+    SalesforceServiceImpl.RecordTypeField recordType =
+        (SalesforceServiceImpl.RecordTypeField) request.get("RecordType");
+    SalesforceServiceImpl.CompositeAttributes attributes =
+        (SalesforceServiceImpl.CompositeAttributes) request.get("attributes");
+
+    assertAll(
+        () -> assertNotNull(attributes),
+        () -> assertEquals("Opportunity", attributes.getType()),
+        () -> assertEquals("Candidate recruitment", recordType.Name),
+        () -> assertEquals(
+            candidate.getCandidateNumber() + "-" + job.getSfId(),
+            request.get("TBBCandidateExternalId__c")),
+        () -> assertEquals(
+            candidate.getUser().getFirstName()
+                + "(" + candidate.getCandidateNumber() + ")-" + job.getName(),
+            request.get("Name")),
+        () -> assertEquals(job.getAccountId(), request.get("AccountId")),
+        () -> assertEquals(candidate.getSfId(), request.get("Candidate_Contact__c")),
+        () -> assertEquals(job.getSfId(), request.get("Parent_Opportunity__c")),
+        () -> assertEquals(job.getOwnerId(), request.get("OwnerId")),
+        () -> assertNotNull(LocalDate.parse((String) request.get("CloseDate")))
+    );
+  }
+
+  @Test
+  void candidateOpportunityRecordCompositeOmitsCreateOnlyFieldsWhenUpdating() {
+    Candidate candidate = mock(Candidate.class);
+    User user = new User();
+    SalesforceJobOpp job = mock(SalesforceJobOpp.class);
+
+    when(candidate.getUser()).thenReturn(user);
+    when(candidate.getCandidateNumber()).thenReturn("99");
+    when(job.getSfId()).thenReturn("sales-force-job-opp-id");
+
+    SalesforceServiceImpl.CandidateOpportunityRecordComposite request =
+        service.new CandidateOpportunityRecordComposite(
+            "Candidate recruitment", candidate, job, false);
+
+    assertAll(
+        () -> assertEquals(
+            candidate.getCandidateNumber() + "-" + job.getSfId(),
+            request.get("TBBCandidateExternalId__c")),
+        () -> assertFalse(request.containsKey("Name")),
+        () -> assertFalse(request.containsKey("AccountId")),
+        () -> assertFalse(request.containsKey("Candidate_Contact__c")),
+        () -> assertFalse(request.containsKey("Parent_Opportunity__c")),
+        () -> assertFalse(request.containsKey("OwnerId")),
+        () -> assertFalse(request.containsKey("CloseDate"))
     );
   }
 


### PR DESCRIPTION
## Summary

Closes #3460.

This PR completes the remaining `SalesforceServiceImpl` item in the external integration helper test coverage issue. The issue checklist already had coverage for `LinkPreviewServiceImpl`, `SlackServiceImpl`, `S3ResourceHelper`, `EmailHelper`, and `GoogleSheetPublisherServiceImpl`; `SalesforceServiceImpl` was the only unchecked helper left.

The added coverage focuses on Salesforce payload-building and helper logic that can be tested safely without live Salesforce credentials or network calls.

## What changed

- Added `SalesforceServiceImplTest` under the existing `server/src/test/java/org/tctalent/server/service/db/impl` test package.
- Instantiated `SalesforceServiceImpl` with Mockito mocks for its external collaborators and configuration objects.
- Covered candidate opportunity external ID generation.
- Covered candidate opportunity name truncation to Salesforce's 120-character opportunity-name limit.
- Covered Canada-specific versus default candidate opportunity record type selection.
- Covered create candidate-opportunity request payload fields, including Salesforce record type, composite attributes, external ID, candidate contact ID, parent opportunity ID, owner ID, account ID, name, and close date.
- Covered update candidate-opportunity request payloads to confirm create-only fields are omitted.

No production code, database migrations, API contracts, UI code, permissions, or runtime Salesforce behavior changed.

## Why this issue was chosen

This was a low-risk, high-signal follow-up while the other PRs are awaiting review:

- It is test-only.
- It adds a new test file rather than modifying files currently touched by open PRs.
- It completes the one remaining unchecked item in #3460.
- It avoids the broader `@MockBean` cleanup issue for now because the open OAuth PRs touch many of the same API test files and would likely cause merge conflicts.

## Contribution guideline notes

- This branch was created from the upstream `staging` branch.
- The change is submitted through the fork-and-pull workflow from `devamchakrabarty:3460-salesforce-service-tests` into `Talent-Catalog/talentcatalog:staging`.
- The branch name includes the issue number and a short description.
- The implementation follows the existing server unit-test style using JUnit 5 and Mockito.
- The change is narrowly scoped to server tests and does not touch Flyway migrations, schema, frontend files, or runtime application code.

## Testing

- `git diff --cached --check`
  - Passed before commit with no whitespace errors.
- `./gradlew server:test --tests org.tctalent.server.service.db.impl.SalesforceServiceImplTest`
  - Initial local attempt failed before Gradle could run tests because the macOS Java launcher could not locate a Java runtime.
- `JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home PATH=/opt/homebrew/opt/openjdk@17/bin:$PATH ./gradlew server:test --tests org.tctalent.server.service.db.impl.SalesforceServiceImplTest`
  - Passed.
  - Result: `BUILD SUCCESSFUL in 1m 1s`.
  - Gradle reported `17 actionable tasks: 9 executed, 8 up-to-date`.
  - The focused `SalesforceServiceImplTest` class completed with zero failures.

The Gradle run also produced existing npm audit, Angular CommonJS/budget, and unused TypeScript warnings while building the UI bundles required by the Gradle task. Local `npm_install` touched the three UI `package-lock.json` files during verification; those generated changes were restored before commit and push.
