### PR TITLE
Fix bug where html stored as part of a json string was not being prop…

### DIFF
--- a/server/src/main/java/org/tctalent/server/model/db/CandidateOccupation.java
+++ b/server/src/main/java/org/tctalent/server/model/db/CandidateOccupation.java
@@ -22,6 +22,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import java.util.List;
@@ -51,6 +52,7 @@ public class CandidateOccupation extends AbstractCandidateDataDomainObject<Long>
 
     //Todo Figure out why Cascade = MERGE doesn't work. Why do we need ALL. What does this mean?
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "candidateOccupation", cascade = CascadeType.ALL)
+    @OrderBy("startDate DESC")
     private List<CandidateJobExperience> candidateJobExperiences;
 
 

--- a/server/src/main/java/org/tctalent/server/util/html/HtmlSanitizer.java
+++ b/server/src/main/java/org/tctalent/server/util/html/HtmlSanitizer.java
@@ -19,38 +19,77 @@ package org.tctalent.server.util.html;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.safety.Safelist;
+import org.springframework.lang.NonNull;
 import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
+import org.tctalent.server.util.text.TextParts;
+import org.tctalent.server.util.text.TextPartsCodec;
 
 /**
- * JSoup https://jsoup.org/ implementation of HTML Sanitization
+ * <a href="https://jsoup.org/">Jsoup</a> implementation of HTML Sanitization
  *
  * @author Tim Hill
  */
 @Service
 public class HtmlSanitizer {
+
     /**
-     * Given an untrusted HTML string, remove any tags that might contribute to a cross-site scripting (XSS) attack
-     * Ref: https://owasp.org/www-community/attacks/xss/
+     * Given an untrusted HTML string, remove any tags that might contribute to a cross-site
+     * scripting (XSS) attack
+     * Ref: <a href="https://owasp.org/www-community/attacks/xss/">OWASP website</a>
      *
-     * @param html an untrusted HTML string
-     * @return an HTML string with any potentially Cross Site Scripting tags removed, null if html
-     * was null.
+     * @param htmlOrTextPartsJson an untrusted string that could be HTML or a JSON encoded
+     *                            TextParts object containing HTML.
+     * @return a string with any potential Cross Site Scripting tags removed, null if the input
+     * string was null.
      */
     @Nullable
-    public static String sanitize(@Nullable String html) {
-        return html == null ? null :
-            StringSanitizer.removeControlCharacters(JSoupCleanNotPretty(html, Safelist.relaxed()));
+    public static String sanitize(@Nullable String htmlOrTextPartsJson) {
+        if (htmlOrTextPartsJson == null) {
+            return null;
+        }
+
+        //Check for a JSON encoded TextParts object. Try reading it as Json.
+        try {
+            TextParts parts = TextPartsCodec.readJson(htmlOrTextPartsJson);
+            // If the HTML is a valid JSON-encoded TextParts object, return its original text.
+            return TextPartsCodec.write(sanitizeTextParts(parts));
+        } catch (IllegalArgumentException e) {
+            // If the HTML is not a valid JSON-encoded TextParts object,
+            // just sanitize it as a regular HTML string.
+            return StringSanitizer.removeControlCharacters(
+                JSoupCleanNotPretty(htmlOrTextPartsJson, Safelist.relaxed()));
+        }
     }
 
     /**
-     * Same as sanitize method above, but without stripping <a> tags of 'target=' or 'rel=' to allow links to open in new tab.
-     * As adding this target attribute back can open up site to risks, also adding the attribute "rel=noopener" or
-     * "rel=noreferrer" helps avoid these issues.
-     * See here: https://developer.chrome.com/docs/lighthouse/best-practices/external-anchors-use-rel-noopener/
+     * Sanitizes the original and tidied text in the given TextParts object.
+     * @param textParts a TextParts object containing original and tidied text to be sanitized.
+     * @return a new TextParts object with the original and tidied text sanitized,
+     * but with the same keywords as the input.
+     */
+    @NonNull
+    private static TextParts sanitizeTextParts(@NonNull TextParts textParts) {
+        TextParts sanitized = new TextParts();
+        sanitized.setOriginal(sanitize(textParts.getOriginal()));
+        sanitized.setTidied(sanitize(textParts.getTidied()));
+        sanitized.setKeywords(textParts.getKeywords());
+        return sanitized;
+    }
+
+    /**
+     * Similar to the sanitize method above except that it does not process TextParts json.
+     * It is only intended for use sanitizing text in Chat posts.
+     * <p>
+     * It does not strip <a> tags of 'target=' or 'rel=' to allow links to open in a new tab.
+     * As adding this target attribute back can open up a site to risks, also adding the attribute
+     * "rel=noopener" or "rel=noreferrer" helps avoid these issues.
+     * See
+     * <a href="https://developer.chrome.com/docs/lighthouse/best-practices/external-anchors-use-rel-noopener/">
+     *     here.</a>
      * @param html an untrusted HTML string
-     * @return an HTML string with any potentially XSS tags removed but allowing links to open in new tab safely, or
-     * null if html was null
+     * @return an HTML string with any potential XSS tags removed but allowing links to open in
+     * a new tab safely, or null if input text was null
      */
     @Nullable
     public static String sanitizeWithLinksNewTab(@Nullable String html) {
@@ -63,7 +102,7 @@ public class HtmlSanitizer {
 
     /**
      * Calls JSoup.clean() with prettyPrint=false.
-     * Pretty print=true is the default but it is not needed, and it has an undesirable side effect
+     * Pretty print=true is the default, but it is unnecessary, and it has an undesirable side effect
      * of inserting newlines (which breaks the syntax of any encoded JSON strings).
      */
     private static String JSoupCleanNotPretty(String html, Safelist safelist) {

--- a/server/src/main/java/org/tctalent/server/util/text/TextPartsCodec.java
+++ b/server/src/main/java/org/tctalent/server/util/text/TextPartsCodec.java
@@ -22,8 +22,8 @@ import java.util.ArrayList;
 import java.util.List;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Component;
-
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
 /**
  * Codec (Code/Decode) for TextParts.
  * <p>
@@ -32,54 +32,88 @@ import org.springframework.stereotype.Component;
  * The stored text is usually JSON but can be plain text.
  * </p>
  *
+ * <p>
+ *     It is static so that it can be used with HtmlSanitizer which also acts statically.
+ * </p>
+ *
  * @author John Cameron
  */
-@Component
 @Slf4j
 public class TextPartsCodec {
 
-    private final ObjectMapper objectMapper;
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
-    public TextPartsCodec(ObjectMapper objectMapper) {
-        this.objectMapper = objectMapper;
+    private TextPartsCodec() {
+        throw new UnsupportedOperationException("This is a utility class and cannot be instantiated");
+    }
+
+    /**
+     * Reads the given JSON string and returns a TextParts object.
+     * @param json JSON string representing a stored TextParts object.
+     * @return TextParts object represented by the given JSON string or null if the string does
+     * not represent a valid TextParts JSON object.
+     * @throws IllegalArgumentException If the given string is not valid JSON
+     * or does not represent a valid stored TextParts JSON object.
+     */
+    public static @NonNull TextParts readJson(@NonNull String json) {
+        try {
+            StoredTextParts stored = OBJECT_MAPPER.readValue(json, StoredTextParts.class);
+
+            if (stored.getParts() != null && stored.getParts().getOriginal() != null) {
+                return normalise(stored.getParts());
+            }
+            throw new IllegalArgumentException("Missing text parts in JSON: " + json);
+        } catch (JsonProcessingException ex) {
+            throw new IllegalArgumentException(
+                "Could not parse text parts from JSON: " + json, ex);
+        }
     }
 
     /**
      * Reads the given text and returns a TextParts object.
-     * @param value Text to be read.
+     * The text can be either valid JSON representing a stored TextParts object or plain text.
+     * <p>
+     *     If the text is not valid JSON, it is assumed to be plain text, and a TextParts object
+     *     is returned with the original text set to the given value, and tidied and keywords
+     *     set to null/empty.
+     * </p>
+     * @param value Text to be read. If null or blank, an empty TextParts object is returned.
+     * @return TextParts object represented by the given text.
      */
-    public TextParts read(String value) {
+    public static @NonNull TextParts read(@Nullable String value) {
         if (value == null || value.isBlank()) {
             return new TextParts("");
         }
 
         try {
-            StoredTextParts stored = objectMapper.readValue(value, StoredTextParts.class);
-
-            if (stored.getParts() != null && stored.getParts().getOriginal() != null) {
-                return normalise(stored.getParts());
-            }
-        } catch (JsonProcessingException ex) {
-            // Legacy plain text or malformed JSON.
-            log.info("Failed to parse text parts from JSON: {}", value, ex);
+            return readJson(value);
+        } catch (IllegalArgumentException ex) {
+            // Treat as plain text. Construct a TextParts object with the original text set to the
+            // given value.
+            return new TextParts(value);
         }
-
-        return new TextParts(value);
     }
 
     /**
      * Writes the given TextParts object to a JSON string.
      * @param parts Parts to be written as a JSON string.
+     * @throws IllegalArgumentException If the parts object cannot be serialized to JSON.
      */
-    public String write(TextParts parts) {
+    public static String write(TextParts parts) {
         try {
-            return objectMapper.writeValueAsString(new StoredTextParts(normalise(parts)));
+            return OBJECT_MAPPER.writeValueAsString(new StoredTextParts(normalise(parts)));
         } catch (JsonProcessingException e) {
             throw new IllegalArgumentException("Could not serialize text parts", e);
         }
     }
 
-    private TextParts normalise(TextParts parts) {
+    /**
+     * Normalises the given TextParts object by ensuring that all properties except tidied are
+     * non-null.
+     * @param parts Parts to be normalised. If null, an empty TextParts object is returned.
+     * @return Normalised TextParts object.
+     */
+    private static TextParts normalise(@Nullable TextParts parts) {
         if (parts == null) {
             return new TextParts("");
         }
@@ -116,10 +150,6 @@ public class TextPartsCodec {
     @Data
     private static class StoredTextParts {
         private TextParts parts;
-
-        StoredTextParts() {
-        }
-
         StoredTextParts(TextParts parts) {
             this.parts = parts;
         }

--- a/server/src/main/java/org/tctalent/server/util/text/TextPartsTidiedTextService.java
+++ b/server/src/main/java/org/tctalent/server/util/text/TextPartsTidiedTextService.java
@@ -16,7 +16,6 @@
 
 package org.tctalent.server.util.text;
 
-import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
@@ -26,10 +25,7 @@ import org.springframework.util.StringUtils;
  * @author John Cameron
  */
 @Service
-@RequiredArgsConstructor
 public class TextPartsTidiedTextService {
-
-    private final TextPartsCodec textPartsCodec;
 
     public String getTidiedText(String text) {
 
@@ -37,11 +33,7 @@ public class TextPartsTidiedTextService {
             return text;
         }
 
-        TextParts parts = textPartsCodec.read(text);
-
-        if (parts == null) {
-            return text;
-        }
+        TextParts parts = TextPartsCodec.read(text);
 
         if (StringUtils.hasText(parts.getTidied())) {
             return parts.getTidied();

--- a/server/src/test/java/org/tctalent/server/util/text/TextPartsCodecTest.java
+++ b/server/src/test/java/org/tctalent/server/util/text/TextPartsCodecTest.java
@@ -18,25 +18,23 @@ package org.tctalent.server.util.text;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.tctalent.server.util.html.HtmlSanitizer;
 
 class TextPartsCodecTest {
 
     private final ObjectMapper objectMapper = new ObjectMapper();
-    private final TextPartsCodec codec = new TextPartsCodec(objectMapper);
 
     @Test
     void readsNullAsEmptyOriginalText() {
-        TextParts parts = codec.read(null);
+        TextParts parts = TextPartsCodec.read(null);
 
         assertEquals("", parts.getOriginal());
         assertNull(parts.getTidied());
@@ -45,7 +43,7 @@ class TextPartsCodecTest {
 
     @Test
     void readsBlankAsEmptyOriginalText() {
-        TextParts parts = codec.read("   ");
+        TextParts parts = TextPartsCodec.read("   ");
 
         assertEquals("", parts.getOriginal());
         assertNull(parts.getTidied());
@@ -54,7 +52,7 @@ class TextPartsCodecTest {
 
     @Test
     void readsLegacyPlainTextAsOriginal() {
-        TextParts parts = codec.read("I work electrician 5 years");
+        TextParts parts = TextPartsCodec.read("I work electrician 5 years");
 
         assertEquals("I work electrician 5 years", parts.getOriginal());
         assertNull(parts.getTidied());
@@ -63,7 +61,7 @@ class TextPartsCodecTest {
 
     @Test
     void readsLegacyHtmlAsOriginal() {
-        TextParts parts = codec.read("<p>Line 1</p><div>Line 2</div>");
+        TextParts parts = TextPartsCodec.read("<p>Line 1</p><div>Line 2</div>");
 
         assertEquals("<p>Line 1</p><div>Line 2</div>", parts.getOriginal());
         assertNull(parts.getTidied());
@@ -82,7 +80,7 @@ class TextPartsCodecTest {
             }
             """;
 
-        TextParts parts = codec.read(stored);
+        TextParts parts = TextPartsCodec.read(stored);
 
         assertEquals("i work electrician", parts.getOriginal());
         assertEquals("I worked as an electrician.", parts.getTidied());
@@ -101,11 +99,54 @@ class TextPartsCodecTest {
             }
             """;
 
-        TextParts parts = codec.read(stored);
+        TextParts parts = TextPartsCodec.read(stored);
 
         assertEquals("<p>Line 1</p><div>Line 2</div>", parts.getOriginal());
         assertEquals("<p>Line 1</p><p>Line 2</p>", parts.getTidied());
         assertEquals(List.of("html", "line"), parts.getKeywords());
+    }
+
+    @Test
+    void survivesJsonEncodedHtmlSanitization() {
+        //This is the html that we want stored in json.
+        String html = """
+        <ul type="circle"><li>John</li></ul>""";
+
+        //When the html is stored in the database as part of a JSON string, it will need the quotes
+        //around the type attribute to be escaped. So it will be stored as:
+        String htmlStored = "<ul type=\\\"circle\\\"><li>John</li></ul>";
+
+        //So the full json stored in the database will be:
+        String s = """
+            {"parts":{"original":\""""
+            + htmlStored + "\"}}";
+
+        String sanitized = HtmlSanitizer.sanitize(s);
+
+        TextParts parts = TextPartsCodec.read(sanitized);
+
+        assertEquals(html, parts.getOriginal());
+        assertNull(parts.getTidied());
+        assertEquals(List.of(), parts.getKeywords());
+    }
+
+    @Test
+    void survivesNonJsonEncodedHtmlSanitization() {
+        //For html that is stored in the database just as itself, not as part of a JSON
+        //string, it won't need any escaping of the quotes around the type attribute.
+        //So it will just be stored as:
+        String html = """
+        <ul type="circle"><li>John</li></ul>""";
+
+        String sanitized = HtmlSanitizer.sanitize(html);
+
+        TextParts parts = TextPartsCodec.read(sanitized);
+
+        //The original html is encoded into the original text part,
+        // and the tidied and keywords are left null/empty.
+        assertEquals(html, parts.getOriginal());
+        assertNull(parts.getTidied());
+        assertEquals(List.of(), parts.getKeywords());
     }
 
     @Test
@@ -119,7 +160,7 @@ class TextPartsCodecTest {
             }
             """;
 
-        TextParts parts = codec.read(stored);
+        TextParts parts = TextPartsCodec.read(stored);
 
         assertEquals("candidate text", parts.getOriginal());
         assertNull(parts.getTidied());
@@ -137,7 +178,7 @@ class TextPartsCodecTest {
             }
             """;
 
-        TextParts parts = codec.read(stored);
+        TextParts parts = TextPartsCodec.read(stored);
 
         assertEquals("candidate text", parts.getOriginal());
         assertEquals("Candidate text.", parts.getTidied());
@@ -155,7 +196,7 @@ class TextPartsCodecTest {
             }
             """;
 
-        TextParts parts = codec.read(stored);
+        TextParts parts = TextPartsCodec.read(stored);
 
         assertEquals("candidate text", parts.getOriginal());
         assertTrue(parts.getKeywords().isEmpty());
@@ -173,7 +214,7 @@ class TextPartsCodecTest {
             }
             """;
 
-        TextParts parts = codec.read(stored);
+        TextParts parts = TextPartsCodec.read(stored);
 
         assertEquals(stored, parts.getOriginal());
         assertNull(parts.getTidied());
@@ -184,7 +225,7 @@ class TextPartsCodecTest {
     void fallsBackToLegacyTextIfJsonIsNotTextParts() {
         String stored = "{\"hello\":\"world\"}";
 
-        TextParts parts = codec.read(stored);
+        TextParts parts = TextPartsCodec.read(stored);
 
         assertEquals(stored, parts.getOriginal());
         assertNull(parts.getTidied());
@@ -195,7 +236,7 @@ class TextPartsCodecTest {
     void treatsMalformedJsonAsLegacyOriginalText() {
         String malformedJson = "{\"parts\":{\"original\":\"hello\nworld\"}}";
 
-        TextParts parts = codec.read(malformedJson);
+        TextParts parts = TextPartsCodec.read(malformedJson);
 
         assertEquals(malformedJson, parts.getOriginal());
         assertNull(parts.getTidied());
@@ -210,7 +251,7 @@ class TextPartsCodecTest {
             List.of("electrician", "wiring")
         );
 
-        String stored = codec.write(parts);
+        String stored = TextPartsCodec.write(parts);
         JsonNode json = objectMapper.readTree(stored);
 
         assertEquals("i work electrician", json.at("/parts/original").asText());
@@ -227,7 +268,7 @@ class TextPartsCodecTest {
             List.of("html")
         );
 
-        String stored = codec.write(parts);
+        String stored = TextPartsCodec.write(parts);
         JsonNode json = objectMapper.readTree(stored);
 
         assertEquals("Line 1<div>Line 2</div>", json.at("/parts/original").asText());
@@ -242,7 +283,7 @@ class TextPartsCodecTest {
             List.of()
         );
 
-        String stored = codec.write(parts);
+        String stored = TextPartsCodec.write(parts);
         JsonNode json = objectMapper.readTree(stored);
 
         assertEquals("Line 1\nLine 2", json.at("/parts/original").asText());
@@ -251,7 +292,7 @@ class TextPartsCodecTest {
 
     @Test
     void writesNullPartsAsEmptyOriginal() throws Exception {
-        String stored = codec.write(null);
+        String stored = TextPartsCodec.write(null);
         JsonNode json = objectMapper.readTree(stored);
 
         assertEquals("", json.at("/parts/original").asText());
@@ -263,7 +304,7 @@ class TextPartsCodecTest {
     void writesNullOriginalAsEmptyString() throws Exception {
         TextParts parts = new TextParts(null, null, List.of("skill"));
 
-        String stored = codec.write(parts);
+        String stored = TextPartsCodec.write(parts);
         JsonNode json = objectMapper.readTree(stored);
 
         assertEquals("", json.at("/parts/original").asText());
@@ -274,7 +315,7 @@ class TextPartsCodecTest {
     void writesNullKeywordsAsEmptyArray() throws Exception {
         TextParts parts = new TextParts("text", null, null);
 
-        String stored = codec.write(parts);
+        String stored = TextPartsCodec.write(parts);
         JsonNode json = objectMapper.readTree(stored);
 
         assertEquals("text", json.at("/parts/original").asText());
@@ -290,7 +331,7 @@ class TextPartsCodecTest {
             new ArrayList<>(Arrays.asList("electrician", null, "", "   ", "wiring"))
         );
 
-        String stored = codec.write(parts);
+        String stored = TextPartsCodec.write(parts);
         JsonNode json = objectMapper.readTree(stored);
 
         assertEquals(2, json.at("/parts/keywords").size());
@@ -306,27 +347,10 @@ class TextPartsCodecTest {
             List.of("candidate", "html")
         );
 
-        TextParts result = codec.read(codec.write(original));
+        TextParts result = TextPartsCodec.read(TextPartsCodec.write(original));
 
         assertEquals(original.getOriginal(), result.getOriginal());
         assertEquals(original.getTidied(), result.getTidied());
         assertEquals(original.getKeywords(), result.getKeywords());
-    }
-
-    @Test
-    void writeThrowsIllegalArgumentExceptionIfObjectMapperCannotSerialize() {
-        ObjectMapper brokenMapper = new ObjectMapper() {
-            @Override
-            public String writeValueAsString(Object value) throws JsonProcessingException {
-                throw new JsonProcessingException("forced failure") {};
-            }
-        };
-
-        TextPartsCodec brokenCodec = new TextPartsCodec(brokenMapper);
-
-        assertThrows(
-            IllegalArgumentException.class,
-            () -> brokenCodec.write(new TextParts("text"))
-        );
     }
 }

--- a/ui/admin-portal/src/app/components/util/text-parts-view/text-parts-view.component.scss
+++ b/ui/admin-portal/src/app/components/util/text-parts-view/text-parts-view.component.scss
@@ -1,0 +1,3 @@
+.text-parts-view {
+  margin-top: 10px;
+}


### PR DESCRIPTION
…erly processed by our HtmlSantizer - messing up the json encoding.

The HtmlSanitizer now behaves differently if it detects a TextParts json string. It now extracts the html parts of the TextParts object, sanitizes them, and returns a new TextParts object containing the sanitized html.

TextPartsCodec has been converted to use static methods which allows it be used from the static HtmlSanitizer methods.