### PR TITLE
Sadat/tc 1321 improve error message for deleted or invalid candidates

### DIFF
--- a/server/src/main/java/org/tctalent/server/repository/db/CandidateRepository.java
+++ b/server/src/main/java/org/tctalent/server/repository/db/CandidateRepository.java
@@ -163,13 +163,6 @@ public interface CandidateRepository extends CacheEvictingRepository<Candidate, 
     String sourceCountryRestriction = " and c.country in (:userSourceCountries)";
     String excludeDeleted = " and c.status <> 'deleted'";
 
-    @Query(" select distinct c from Candidate c "
-            + " where lower(c.candidateNumber) like lower(:number)"
-            + excludeDeleted
-            + sourceCountryRestriction)
-    Optional<Candidate> findByCandidateNumberRestricted(@Param("number") String number,
-                                              @Param("userSourceCountries") Set<Country> userSourceCountries);
-
     @Query(" select distinct c from Candidate c left join c.user u "
             + " where lower(u.email) like lower(:candidateEmail) "
             + excludeDeleted

--- a/server/src/main/java/org/tctalent/server/service/db/CandidateService.java
+++ b/server/src/main/java/org/tctalent/server/service/db/CandidateService.java
@@ -337,7 +337,8 @@ public interface CandidateService {
      * @param candidateNumber Number of desired candidate
      * @return Candidate
      * @throws InvalidSessionException if user is not logged in
-     * @throws CountryRestrictionException if the candidate is not found
+     * @throws NoSuchObjectException if no candidate exists with the given number
+     * @throws CountryRestrictionException if candidate is outside the user's source countries
      */
     Candidate findByCandidateNumberRestricted(String candidateNumber);
 

--- a/server/src/main/java/org/tctalent/server/service/db/impl/CandidateServiceImpl.java
+++ b/server/src/main/java/org/tctalent/server/service/db/impl/CandidateServiceImpl.java
@@ -1820,12 +1820,29 @@ public class CandidateServiceImpl implements CandidateService {
         User loggedInUser = authService.getLoggedInUser()
                 .orElseThrow(() -> new InvalidSessionException("Not logged in"));
 
+        Candidate candidate = candidateRepository.findByCandidateNumber(candidateNumber);
+        if (candidate == null) {
+            throw new NoSuchObjectException("No candidate exists with number: " + candidateNumber);
+        }
+
+        // Fully erased candidates (GDPR) have their country scrubbed to null.
+        // Return a specific not-found message rather than an empty placeholder profile.
+        if (CandidateStatus.deleted.equals(candidate.getStatus())
+                && candidate.getCountry() == null) {
+            throw new NoSuchObjectException(
+                "This candidate's data has been fully deleted from the Talent Catalog.");
+        }
+
         Set<Country> sourceCountries = userService.getDefaultSourceCountries(loggedInUser);
-        Candidate candidate = candidateRepository.findByCandidateNumberRestricted(candidateNumber, sourceCountries)
-                .orElseThrow(() -> new CountryRestrictionException("You don't have access to this candidate."));
+        if (!sourceCountries.contains(candidate.getCountry())) {
+            throw new CountryRestrictionException("You don't have access to this candidate.");
+        }
 
         //TODO JC Review how this is done. Commented out for now. See issue 2989
 //        taskAssignmentService.populateTransientTaskAssignmentFields(candidate.getTaskAssignments());
+
+        // Returns candidate regardless of status — soft-deleted candidates with a country
+        // in the user's source countries are returned alongside active candidates.
         return candidate;
     }
 

--- a/server/src/test/java/org/tctalent/server/service/db/impl/CandidateServiceImplTest.java
+++ b/server/src/test/java/org/tctalent/server/service/db/impl/CandidateServiceImplTest.java
@@ -45,6 +45,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.tctalent.server.configuration.SystemAdminConfiguration;
+import org.tctalent.server.exception.CountryRestrictionException;
+import org.tctalent.server.exception.NoSuchObjectException;
 import org.tctalent.server.model.db.Candidate;
 import org.tctalent.server.model.db.CandidateStatus;
 import org.tctalent.server.model.db.Counterparty;
@@ -66,6 +68,7 @@ import org.tctalent.server.service.db.CountryService;
 import org.tctalent.server.service.db.CounterpartyService;
 import org.tctalent.server.service.db.PartnerService;
 import org.tctalent.server.service.db.SystemNotificationService;
+import org.tctalent.server.service.db.UserService;
 import org.tctalent.server.util.PersistenceContextHelper;
 
 @ExtendWith(MockitoExtension.class)
@@ -88,6 +91,7 @@ class CandidateServiceImplTest {
   @Mock private SystemNotificationService systemNotificationService;
   @Mock private CountryRepository countryRepository;
   @Mock private AuthService authService;
+  @Mock private UserService userService;
   @Mock private UserRepository userRepository;
   @Mock private User mockUser;
   @Mock private CandidateCitizenshipService candidateCitizenshipService;
@@ -442,6 +446,71 @@ class CandidateServiceImplTest {
 
     verify(counterpartyService, never()).findOrCreateByTypeAndPartner(any(), any());
     verify(agreementService, never()).recordAgreement(any(), any(), any());
+  }
+
+  @Test
+  @DisplayName("findByCandidateNumberRestricted throws not found for unknown candidate number")
+  void findByCandidateNumberRestrictedThrowsNotFoundForUnknownCandidate() {
+    String candidateNumber = "999999";
+    given(authService.getLoggedInUser()).willReturn(Optional.of(mockUser));
+    given(candidateRepository.findByCandidateNumber(candidateNumber)).willReturn(null);
+
+    NoSuchObjectException ex = assertThrows(NoSuchObjectException.class,
+        () -> candidateService.findByCandidateNumberRestricted(candidateNumber));
+
+    assertEquals("No candidate exists with number: " + candidateNumber, ex.getMessage());
+  }
+
+  @Test
+  @DisplayName("findByCandidateNumberRestricted returns deleted candidate")
+  void findByCandidateNumberRestrictedReturnsDeletedCandidate() {
+    String candidateNumber = "123456";
+    candidate.setCandidateNumber(candidateNumber);
+    candidate.setStatus(CandidateStatus.deleted);
+
+    given(authService.getLoggedInUser()).willReturn(Optional.of(mockUser));
+    given(candidateRepository.findByCandidateNumber(candidateNumber)).willReturn(candidate);
+
+    Candidate result = candidateService.findByCandidateNumberRestricted(candidateNumber);
+
+    assertEquals(candidate, result);
+  }
+
+  @Test
+  @DisplayName("findByCandidateNumberRestricted returns active candidate in source countries")
+  void findByCandidateNumberRestrictedReturnsCandidateWhenCountryAllowed() {
+    String candidateNumber = "123457";
+    candidate.setCandidateNumber(candidateNumber);
+    candidate.setStatus(CandidateStatus.active);
+    candidate.setCountry(testCountry);
+
+    given(authService.getLoggedInUser()).willReturn(Optional.of(mockUser));
+    given(candidateRepository.findByCandidateNumber(candidateNumber)).willReturn(candidate);
+    given(userService.getDefaultSourceCountries(mockUser)).willReturn(Set.of(testCountry));
+
+    Candidate result = candidateService.findByCandidateNumberRestricted(candidateNumber);
+
+    assertEquals(candidate, result);
+  }
+
+  @Test
+  @DisplayName("findByCandidateNumberRestricted throws access error for disallowed country")
+  void findByCandidateNumberRestrictedThrowsForCountryRestriction() {
+    String candidateNumber = "123458";
+    candidate.setCandidateNumber(candidateNumber);
+    candidate.setStatus(CandidateStatus.active);
+    candidate.setCountry(testCountry);
+    Country otherCountry = new Country();
+    otherCountry.setId(2L);
+
+    given(authService.getLoggedInUser()).willReturn(Optional.of(mockUser));
+    given(candidateRepository.findByCandidateNumber(candidateNumber)).willReturn(candidate);
+    given(userService.getDefaultSourceCountries(mockUser)).willReturn(Set.of(otherCountry));
+
+    CountryRestrictionException ex = assertThrows(CountryRestrictionException.class,
+        () -> candidateService.findByCandidateNumberRestricted(candidateNumber));
+
+    assertEquals("You don't have access to this candidate.", ex.getMessage());
   }
 
   @Test

--- a/server/src/test/java/org/tctalent/server/service/db/impl/CandidateServiceImplTest.java
+++ b/server/src/test/java/org/tctalent/server/service/db/impl/CandidateServiceImplTest.java
@@ -462,18 +462,56 @@ class CandidateServiceImplTest {
   }
 
   @Test
-  @DisplayName("findByCandidateNumberRestricted returns deleted candidate")
-  void findByCandidateNumberRestrictedReturnsDeletedCandidate() {
+  @DisplayName("findByCandidateNumberRestricted returns soft-deleted candidate whose country is in scope")
+  void findByCandidateNumberRestrictedReturnsSoftDeletedCandidateWhenCountryAllowed() {
     String candidateNumber = "123456";
     candidate.setCandidateNumber(candidateNumber);
     candidate.setStatus(CandidateStatus.deleted);
+    candidate.setCountry(testCountry);
 
     given(authService.getLoggedInUser()).willReturn(Optional.of(mockUser));
     given(candidateRepository.findByCandidateNumber(candidateNumber)).willReturn(candidate);
+    given(userService.getDefaultSourceCountries(mockUser)).willReturn(Set.of(testCountry));
 
     Candidate result = candidateService.findByCandidateNumberRestricted(candidateNumber);
 
     assertEquals(candidate, result);
+  }
+
+  @Test
+  @DisplayName("findByCandidateNumberRestricted throws access error for soft-deleted candidate outside source countries")
+  void findByCandidateNumberRestrictedThrowsForSoftDeletedCandidateOutsideSourceCountries() {
+    String candidateNumber = "123459";
+    candidate.setCandidateNumber(candidateNumber);
+    candidate.setStatus(CandidateStatus.deleted);
+    candidate.setCountry(testCountry);
+    Country otherCountry = new Country();
+    otherCountry.setId(99L);
+
+    given(authService.getLoggedInUser()).willReturn(Optional.of(mockUser));
+    given(candidateRepository.findByCandidateNumber(candidateNumber)).willReturn(candidate);
+    given(userService.getDefaultSourceCountries(mockUser)).willReturn(Set.of(otherCountry));
+
+    assertThrows(CountryRestrictionException.class,
+        () -> candidateService.findByCandidateNumberRestricted(candidateNumber));
+  }
+
+  @Test
+  @DisplayName("findByCandidateNumberRestricted throws not found for fully erased candidate")
+  void findByCandidateNumberRestrictedThrowsNotFoundForErasedCandidate() {
+    String candidateNumber = "123460";
+    candidate.setCandidateNumber(candidateNumber);
+    candidate.setStatus(CandidateStatus.deleted);
+    // country is null after GDPR erasure — deliberately not set
+
+    given(authService.getLoggedInUser()).willReturn(Optional.of(mockUser));
+    given(candidateRepository.findByCandidateNumber(candidateNumber)).willReturn(candidate);
+
+    NoSuchObjectException ex = assertThrows(NoSuchObjectException.class,
+        () -> candidateService.findByCandidateNumberRestricted(candidateNumber));
+
+    assertEquals("This candidate's data has been fully deleted from the Talent Catalog.",
+        ex.getMessage());
   }
 
   @Test


### PR DESCRIPTION
This PR implements the following behaviour of candidate loojkups:

Scenario | HTTP | Message / behaviour
-- | -- | --
Invalid number | 404 | "No candidate exists with number: X"
Fully erased (GDPR, country=null) | 404 | "This candidate's data has been fully deleted from the Talent Catalog."
Soft-deleted, country out of scope | 400 | "You don't have access to this candidate."
Soft-deleted, country in scope | 200 | Full profile returned, status shown as "Deleted"
Active, country out of scope | 400 | "You don't have access to this candidate."
Active, country in scope | 200 | Full profile returned
