### PR TITLE
Migrate from @MockBean to @MockitoBean in test classes across the ser…

### DIFF
--- a/server/src/test/java/org/tctalent/server/api/admin/ApiTestBase.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/ApiTestBase.java
@@ -19,7 +19,7 @@ package org.tctalent.server.api.admin;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.tctalent.server.model.db.Role;
 import org.tctalent.server.model.db.User;
@@ -43,13 +43,13 @@ public class ApiTestBase {
 
     protected User user;
 
-    @MockBean
+    @MockitoBean
     UserRepository userRepository;
-    @MockBean
+    @MockitoBean
     JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
-    @MockBean
+    @MockitoBean
     JwtTokenProvider jwtTokenProvider;
-    @MockBean
+    @MockitoBean
     EmailHelper emailHelper;
 
     public void configureAuthentication() {

--- a/server/src/test/java/org/tctalent/server/api/admin/AuthAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/AuthAdminApiTest.java
@@ -43,7 +43,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
@@ -87,7 +87,7 @@ class AuthAdminApiTest extends ApiTestBase {
     @Autowired MockMvc mockMvc;
     @Autowired ObjectMapper objectMapper;
 
-    @MockBean UserService userService;
+    @MockitoBean UserService userService;
 
     @BeforeEach
     public void setUp() {

--- a/server/src/test/java/org/tctalent/server/api/admin/BrandingAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/BrandingAdminApiTest.java
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.tctalent.server.model.db.BrandingInfo;
@@ -60,7 +60,7 @@ class BrandingAdminApiTest extends ApiTestBase {
     @Autowired MockMvc mockMvc;
     @Autowired ObjectMapper objectMapper;
 
-    @MockBean BrandingService brandingService;
+    @MockitoBean BrandingService brandingService;
 
     @Test
     public void testWebOnlyContextLoads() {

--- a/server/src/test/java/org/tctalent/server/api/admin/CandidateAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/CandidateAdminApiTest.java
@@ -53,7 +53,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.Resource;
 import org.springframework.data.domain.Page;
@@ -159,23 +159,23 @@ class CandidateAdminApiTest extends ApiTestBase {
 
     private final Candidate candidate = getCandidate();
 
-    @MockBean
+    @MockitoBean
     CandidateService candidateService;
-    @MockBean
+    @MockitoBean
     CandidateOpportunityService candidateOpportunityService;
-    @MockBean
+    @MockitoBean
     CandidateSavedListService candidateSavedListService;
-    @MockBean
+    @MockitoBean
     SavedListService savedListService;
-    @MockBean
+    @MockitoBean
     SavedSearchService savedSearchService;
-    @MockBean
+    @MockitoBean
     CandidateTokenProvider candidateTokenProvider;
-    @MockBean
+    @MockitoBean
     CandidateBuilderSelector candidateBuilderSelector;
-    @MockBean
+    @MockitoBean
     CandidateIntakeDataBuilderSelector candidateIntakeDataBuilderSelector;
-    @MockBean
+    @MockitoBean
     CandidateErasureService candidateErasureService;
 
     @Autowired MockMvc mockMvc;

--- a/server/src/test/java/org/tctalent/server/api/admin/CandidateAttachmentAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/CandidateAttachmentAdminApiTest.java
@@ -45,7 +45,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -91,9 +91,8 @@ class CandidateAttachmentAdminApiTest extends ApiTestBase {
                     2
             );
 
-    @MockBean CandidateAttachmentService candidateAttachmentService;
-    @MockBean
-    AuthService authService;
+    @MockitoBean CandidateAttachmentService candidateAttachmentService;
+    @MockitoBean AuthService authService;
 
     @Autowired MockMvc mockMvc;
     @Autowired ObjectMapper objectMapper;

--- a/server/src/test/java/org/tctalent/server/api/admin/CandidateCertificationAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/CandidateCertificationAdminApiTest.java
@@ -44,7 +44,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.tctalent.server.model.db.CandidateCertification;
@@ -68,7 +68,7 @@ class CandidateCertificationAdminApiTest extends ApiTestBase {
     private final List<CandidateCertification> candidateCertificationList =
         getListOfCandidateCertifications();
 
-    @MockBean CandidateCertificationService candidateCertificationService;
+    @MockitoBean CandidateCertificationService candidateCertificationService;
 
     @Autowired MockMvc mockMvc;
     @Autowired ObjectMapper objectMapper;

--- a/server/src/test/java/org/tctalent/server/api/admin/CandidateCitizenshipAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/CandidateCitizenshipAdminApiTest.java
@@ -40,7 +40,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.tctalent.server.model.db.CandidateCitizenship;
@@ -63,9 +63,9 @@ class CandidateCitizenshipAdminApiTest extends ApiTestBase {
     private final CandidateCitizenship candidateCitizenship = getCandidateCitizenship();
 
 
-    @MockBean
+    @MockitoBean
     CandidateCitizenshipService candidateCitizenshipService;
-    @MockBean
+    @MockitoBean
     CountryService countryService;
 
     @Autowired MockMvc mockMvc;

--- a/server/src/test/java/org/tctalent/server/api/admin/CandidateDependantAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/CandidateDependantAdminApiTest.java
@@ -41,7 +41,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.tctalent.server.model.db.Candidate;
@@ -64,8 +64,8 @@ class CandidateDependantAdminApiTest extends ApiTestBase {
     private final Candidate candidate = getCandidate();
     private final CandidateDependant candidateDependant = getCandidateDependant();
 
-    @MockBean CandidateDependantService candidateDependantService;
-    @MockBean CandidateService candidateService;
+    @MockitoBean CandidateDependantService candidateDependantService;
+    @MockitoBean CandidateService candidateService;
 
     @Autowired MockMvc mockMvc;
     @Autowired ObjectMapper objectMapper;

--- a/server/src/test/java/org/tctalent/server/api/admin/CandidateDestinationAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/CandidateDestinationAdminApiTest.java
@@ -40,7 +40,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.tctalent.server.model.db.CandidateDestination;
@@ -61,9 +61,8 @@ class CandidateDestinationAdminApiTest extends ApiTestBase {
 
     private final CandidateDestination candidateDestination = getCandidateDestination();
 
-    @MockBean CandidateDestinationService candidateDestinationService;
-    @MockBean
-    CountryService countryService;
+    @MockitoBean CandidateDestinationService candidateDestinationService;
+    @MockitoBean CountryService countryService;
 
     @Autowired MockMvc mockMvc;
     @Autowired ObjectMapper objectMapper;

--- a/server/src/test/java/org/tctalent/server/api/admin/CandidateEducationAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/CandidateEducationAdminApiTest.java
@@ -44,7 +44,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.tctalent.server.model.db.CandidateEducation;
@@ -68,8 +68,8 @@ class CandidateEducationAdminApiTest extends ApiTestBase {
     private final CandidateEducation candidateEducation = getCandidateEducation();
     private final List<CandidateEducation> candidateEducationList = getListOfCandidateEducations();
 
-    @MockBean CandidateEducationService candidateEducationService;
-    @MockBean CountryService countryService;
+    @MockitoBean CandidateEducationService candidateEducationService;
+    @MockitoBean CountryService countryService;
 
     @Autowired MockMvc mockMvc;
     @Autowired ObjectMapper objectMapper;

--- a/server/src/test/java/org/tctalent/server/api/admin/CandidateExamAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/CandidateExamAdminApiTest.java
@@ -39,7 +39,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.tctalent.server.model.db.CandidateExam;
@@ -60,8 +60,8 @@ class CandidateExamAdminApiTest extends ApiTestBase {
 
     private final CandidateExam candidateExam = getCandidateExam();
 
-    @MockBean CandidateExamService candidateExamService;
-    @MockBean CandidateService candidateService;
+    @MockitoBean CandidateExamService candidateExamService;
+    @MockitoBean CandidateService candidateService;
 
     @Autowired MockMvc mockMvc;
     @Autowired ObjectMapper objectMapper;

--- a/server/src/test/java/org/tctalent/server/api/admin/CandidateJobExperienceAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/CandidateJobExperienceAdminApiTest.java
@@ -42,7 +42,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -79,9 +79,9 @@ class CandidateJobExperienceAdminApiTest extends ApiTestBase {
                     1
             );
 
-    @MockBean CandidateJobExperienceService candidateJobExperienceService;
-    @MockBean CountryService countryService;
-    @MockBean OccupationService occupationService;
+    @MockitoBean CandidateJobExperienceService candidateJobExperienceService;
+    @MockitoBean CountryService countryService;
+    @MockitoBean OccupationService occupationService;
 
     @Autowired MockMvc mockMvc;
     @Autowired ObjectMapper objectMapper;

--- a/server/src/test/java/org/tctalent/server/api/admin/CandidateLanguageAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/CandidateLanguageAdminApiTest.java
@@ -44,7 +44,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.tctalent.server.model.db.CandidateLanguage;
@@ -69,7 +69,7 @@ class CandidateLanguageAdminApiTest extends ApiTestBase {
 
     private static final List<CandidateLanguage> candidateLanguageList = getListOfCandidateLanguages();
 
-    @MockBean CandidateLanguageService candidateLanguageService;
+    @MockitoBean CandidateLanguageService candidateLanguageService;
 
     @Autowired MockMvc mockMvc;
     @Autowired ObjectMapper objectMapper;

--- a/server/src/test/java/org/tctalent/server/api/admin/CandidateNoteAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/CandidateNoteAdminApiTest.java
@@ -40,7 +40,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -75,7 +75,7 @@ class CandidateNoteAdminApiTest extends ApiTestBase {
                     1
             );
 
-    @MockBean CandidateNoteService candidateNoteService;
+    @MockitoBean CandidateNoteService candidateNoteService;
 
     @Autowired MockMvc mockMvc;
     @Autowired ObjectMapper objectMapper;

--- a/server/src/test/java/org/tctalent/server/api/admin/CandidateOccupationAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/CandidateOccupationAdminApiTest.java
@@ -45,7 +45,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.tctalent.server.model.db.CandidateOccupation;
@@ -75,8 +75,8 @@ class CandidateOccupationAdminApiTest extends ApiTestBase {
     private static final CandidateOccupation candidateOccupation = getCandidateOccupation();
     private static final List<CandidateOccupation> candidateOccupationsList = getListOfCandidateOccupations();
 
-    @MockBean OccupationService occupationService;
-    @MockBean CandidateOccupationService candidateOccupationService;
+    @MockitoBean OccupationService occupationService;
+    @MockitoBean CandidateOccupationService candidateOccupationService;
 
     @Autowired MockMvc mockMvc;
     @Autowired ObjectMapper objectMapper;

--- a/server/src/test/java/org/tctalent/server/api/admin/CandidateOpportunityAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/CandidateOpportunityAdminApiTest.java
@@ -41,7 +41,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -80,9 +80,9 @@ class CandidateOpportunityAdminApiTest extends ApiTestBase {
                     1
             );
 
-    @MockBean CandidateOpportunityService candidateOpportunityService;
-    @MockBean CountryService countryService;
-    @MockBean SalesforceService salesforceService;
+    @MockitoBean CandidateOpportunityService candidateOpportunityService;
+    @MockitoBean CountryService countryService;
+    @MockitoBean SalesforceService salesforceService;
 
     @Autowired MockMvc mockMvc;
     @Autowired ObjectMapper objectMapper;

--- a/server/src/test/java/org/tctalent/server/api/admin/CandidateReviewStatusAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/CandidateReviewStatusAdminApiTest.java
@@ -40,7 +40,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.tctalent.server.model.db.CandidateReviewStatusItem;
@@ -64,7 +64,7 @@ class CandidateReviewStatusAdminApiTest extends ApiTestBase {
 
     private static final CandidateReviewStatusItem reviewStatusItem = getCandidateReviewStatusItem();
 
-    @MockBean CandidateReviewStatusService candidateReviewStatusService;
+    @MockitoBean CandidateReviewStatusService candidateReviewStatusService;
 
     @Autowired MockMvc mockMvc;
     @Autowired ObjectMapper objectMapper;

--- a/server/src/test/java/org/tctalent/server/api/admin/CandidateSavedListAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/CandidateSavedListAdminApiTest.java
@@ -41,7 +41,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
@@ -73,8 +73,8 @@ class CandidateSavedListAdminApiTest extends ApiTestBase {
 
   private static final long CANDIDATE_ID = 99L;
 
-  @MockBean CandidateSavedListService candidateSavedListService;
-  @MockBean SavedListService savedListService;
+  @MockitoBean CandidateSavedListService candidateSavedListService;
+  @MockitoBean SavedListService savedListService;
 
   @Autowired MockMvc mockMvc;
   @Autowired ObjectMapper objectMapper;

--- a/server/src/test/java/org/tctalent/server/api/admin/CandidateSkillAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/CandidateSkillAdminApiTest.java
@@ -38,7 +38,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -69,7 +69,7 @@ public class CandidateSkillAdminApiTest extends ApiTestBase {
                     1
             );
 
-    @MockBean
+    @MockitoBean
     CandidateSkillService candidateSkillService;
 
     @Autowired MockMvc mockMvc;

--- a/server/src/test/java/org/tctalent/server/api/admin/CandidateStatAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/CandidateStatAdminApiTest.java
@@ -60,7 +60,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.tctalent.server.model.db.Country;
@@ -88,13 +88,13 @@ class CandidateStatAdminApiTest extends ApiTestBase {
 
   private static final String ALL_STATS_PATH = "/all";
 
-  @MockBean CandidateService candidateService;
-  @MockBean CandidateStatsService candidateStatsService;
-  @MockBean CountryRepository countryRepository;
-  @MockBean SavedListService savedListService;
-  @MockBean SavedSearchService savedSearchService;
-  @MockBean AuthService authService;
-  @MockBean EntityManager entityManager;
+  @MockitoBean CandidateService candidateService;
+  @MockitoBean CandidateStatsService candidateStatsService;
+  @MockitoBean CountryRepository countryRepository;
+  @MockitoBean SavedListService savedListService;
+  @MockitoBean SavedSearchService savedSearchService;
+  @MockitoBean AuthService authService;
+  @MockitoBean EntityManager entityManager;
 
   @Autowired MockMvc mockMvc;
   @Autowired ObjectMapper objectMapper;

--- a/server/src/test/java/org/tctalent/server/api/admin/CandidateVisaCheckAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/CandidateVisaCheckAdminApiTest.java
@@ -42,7 +42,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.tctalent.server.model.db.CandidateVisaCheck;
@@ -68,11 +68,11 @@ public class CandidateVisaCheckAdminApiTest extends ApiTestBase {
     private static final CandidateVisaCheck candidateVisaCheck = getCandidateVisaCheck(false);
     private static final CandidateVisaCheck candidateVisaCheckComplete = getCandidateVisaCheck(true);
 
-    @MockBean
+    @MockitoBean
     CandidateVisaService candidateVisaService;
-    @MockBean
+    @MockitoBean
     CountryService countryService;
-    @MockBean
+    @MockitoBean
     OccupationService occupationService;
 
     @Autowired MockMvc mockMvc;

--- a/server/src/test/java/org/tctalent/server/api/admin/CandidateVisaJobCheckAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/CandidateVisaJobCheckAdminApiTest.java
@@ -40,7 +40,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.tctalent.server.model.db.CandidateVisaJobCheck;
@@ -62,12 +62,12 @@ public class CandidateVisaJobCheckAdminApiTest extends ApiTestBase {
     private static final CandidateVisaJobCheck candidateVisaJobCheck = getCandidateVisaJobCheck(false);
     private static final CandidateVisaJobCheck candidateVisaJobCheckComplete = getCandidateVisaJobCheck(true);
 
-    @MockBean
+    @MockitoBean
     CandidateVisaJobCheckService candidateVisaJobCheckService;
-    @MockBean
+    @MockitoBean
     OccupationService occupationService;
 
-    @MockBean
+    @MockitoBean
     SalesforceService salesforceService;
 
     @Autowired MockMvc mockMvc;

--- a/server/src/test/java/org/tctalent/server/api/admin/CountryAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/CountryAdminApiTest.java
@@ -43,7 +43,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -82,7 +82,7 @@ class CountryAdminApiTest extends ApiTestBase {
           1
       );
 
-  @MockBean CountryService countryService;
+  @MockitoBean CountryService countryService;
 
   @Autowired MockMvc mockMvc;
   @Autowired ObjectMapper objectMapper;

--- a/server/src/test/java/org/tctalent/server/api/admin/DuolingoCouponAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/DuolingoCouponAdminApiTest.java
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.MockMvc;
@@ -72,17 +72,17 @@ class DuolingoCouponAdminApiTest extends ApiTestBase {
   private static final TaskImpl task = getTask();
   private static final TaskAssignmentImpl taskAssignment = getTaskAssignment();
 
-  @MockBean
+  @MockitoBean
   AuthService authService;
-  @MockBean
+  @MockitoBean
   DuolingoCouponService couponService;
-  @MockBean
+  @MockitoBean
   SavedListService savedListService;
-  @MockBean
+  @MockitoBean
   TaskAssignmentService taskAssignmentService;
-  @MockBean
+  @MockitoBean
   TaskService taskService;
-  @MockBean
+  @MockitoBean
   CandidateService candidateService;
 
 

--- a/server/src/test/java/org/tctalent/server/api/admin/EducationLevelAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/EducationLevelAdminApiTest.java
@@ -47,7 +47,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -89,8 +89,8 @@ class EducationLevelAdminApiTest extends ApiTestBase {
           1
       );
 
-  @MockBean EducationLevelService educationLevelService;
-  @MockBean LanguageService languageService;
+  @MockitoBean EducationLevelService educationLevelService;
+  @MockitoBean LanguageService languageService;
 
   @Autowired MockMvc mockMvc;
 

--- a/server/src/test/java/org/tctalent/server/api/admin/EducationMajorAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/EducationMajorAdminApiTest.java
@@ -47,7 +47,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -90,8 +90,8 @@ class EducationMajorAdminApiTest extends ApiTestBase {
           1
       );
 
-  @MockBean EducationMajorService educationMajorService;
-  @MockBean LanguageService languageService;
+  @MockitoBean EducationMajorService educationMajorService;
+  @MockitoBean LanguageService languageService;
 
   @Autowired MockMvc mockMvc;
 

--- a/server/src/test/java/org/tctalent/server/api/admin/HelpLinkAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/HelpLinkAdminApiTest.java
@@ -43,7 +43,7 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.http.MediaType;
@@ -70,10 +70,10 @@ class HelpLinkAdminApiTest extends ApiTestBase {
 
     private static final HelpLink helpLink = getHelpLink();
 
-    @MockBean
+    @MockitoBean
     CountryService countryService;
 
-    @MockBean
+    @MockitoBean
     HelpLinkService helpLinkService;
 
     @Autowired

--- a/server/src/test/java/org/tctalent/server/api/admin/IndustryAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/IndustryAdminApiTest.java
@@ -43,7 +43,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -79,7 +79,7 @@ class IndustryAdminApiTest extends ApiTestBase {
           1
       );
 
-  @MockBean IndustryService industryService;
+  @MockitoBean IndustryService industryService;
 
   @Autowired MockMvc mockMvc;
 

--- a/server/src/test/java/org/tctalent/server/api/admin/JobAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/JobAdminApiTest.java
@@ -46,7 +46,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -102,8 +102,8 @@ class JobAdminApiTest extends ApiTestBase {
                     1
             );
 
-    @MockBean CountryService countryService;
-    @MockBean JobService jobService;
+    @MockitoBean CountryService countryService;
+    @MockitoBean JobService jobService;
 
     @Autowired MockMvc mockMvc;
     @Autowired ObjectMapper objectMapper;

--- a/server/src/test/java/org/tctalent/server/api/admin/LanguageAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/LanguageAdminApiTest.java
@@ -47,7 +47,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -90,7 +90,7 @@ class LanguageAdminApiTest extends ApiTestBase {
                     1
             );
 
-    @MockBean LanguageService languageService;
+    @MockitoBean LanguageService languageService;
 
     @Autowired MockMvc mockMvc;
     @Autowired ObjectMapper objectMapper;

--- a/server/src/test/java/org/tctalent/server/api/admin/LanguageLevelAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/LanguageLevelAdminApiTest.java
@@ -48,7 +48,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -91,8 +91,8 @@ class LanguageLevelAdminApiTest extends ApiTestBase {
                     1
             );
 
-    @MockBean LanguageLevelService languageLevelService;
-    @MockBean LanguageService languageService;
+    @MockitoBean LanguageLevelService languageLevelService;
+    @MockitoBean LanguageService languageService;
 
     @Autowired MockMvc mockMvc;
     @Autowired ObjectMapper objectMapper;

--- a/server/src/test/java/org/tctalent/server/api/admin/OccupationAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/OccupationAdminApiTest.java
@@ -48,7 +48,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -92,8 +92,8 @@ class OccupationAdminApiTest extends ApiTestBase {
                     1
             );
 
-    @MockBean OccupationService occupationService;
-    @MockBean LanguageService languageService;
+    @MockitoBean OccupationService occupationService;
+    @MockitoBean LanguageService languageService;
 
     @Autowired MockMvc mockMvc;
     @Autowired ObjectMapper objectMapper;

--- a/server/src/test/java/org/tctalent/server/api/admin/OfferToAssistAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/OfferToAssistAdminApiTest.java
@@ -38,7 +38,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -69,7 +69,7 @@ class OfferToAssistAdminApiTest extends ApiTestBase {
                     1
             );
 
-    @MockBean
+    @MockitoBean
     OfferToAssistService offerToAssistService;
 
     @Autowired

--- a/server/src/test/java/org/tctalent/server/api/admin/PartnerAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/PartnerAdminApiTest.java
@@ -46,7 +46,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -89,10 +89,10 @@ class PartnerAdminApiTest extends ApiTestBase {
           1
       );
 
-  @MockBean EmployerService employerService;
-  @MockBean PartnerService partnerService;
-  @MockBean JobService jobService;
-  @MockBean UserService userService;
+  @MockitoBean EmployerService employerService;
+  @MockitoBean PartnerService partnerService;
+  @MockitoBean JobService jobService;
+  @MockitoBean UserService userService;
 
   @Autowired MockMvc mockMvc;
   @Autowired ObjectMapper objectMapper;

--- a/server/src/test/java/org/tctalent/server/api/admin/PresetAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/PresetAdminApiTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.tctalent.server.response.preset.PresetGuestTokenResponse;
@@ -31,7 +31,7 @@ class PresetAdminApiTest extends ApiTestBase {
   @Autowired
   MockMvc mockMvc;
 
-  @MockBean
+  @MockitoBean
   PresetApiService presetApiService;
 
 

--- a/server/src/test/java/org/tctalent/server/api/admin/PublishedLinkAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/PublishedLinkAdminApiTest.java
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.tctalent.server.model.db.SavedList;
@@ -51,7 +51,7 @@ class PublishedLinkAdminApiTest extends ApiTestBase {
 
   private final SavedList savedList = new SavedList();
 
-  @MockBean SavedListService savedListService;
+  @MockitoBean SavedListService savedListService;
 
   @Autowired MockMvc mockMvc;
   @Autowired ObjectMapper objectMapper;

--- a/server/src/test/java/org/tctalent/server/api/admin/RootRouteAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/RootRouteAdminApiTest.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.tctalent.server.model.db.BrandingInfo;
@@ -51,8 +51,8 @@ class RootRouteAdminApiTest extends ApiTestBase {
 
   private BrandingInfo brandingInfo;
 
-  @MockBean BrandingService brandingService;
-  @MockBean RootRequestService rootRequestService;
+  @MockitoBean BrandingService brandingService;
+  @MockitoBean RootRequestService rootRequestService;
 
   @Autowired MockMvc mockMvc;
   @Autowired ObjectMapper objectMapper;

--- a/server/src/test/java/org/tctalent/server/api/admin/SalesforceAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/SalesforceAdminApiTest.java
@@ -38,7 +38,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.tctalent.server.configuration.SalesforceRecordTypeConfig;
@@ -64,8 +64,8 @@ class SalesforceAdminApiTest extends ApiTestBase {
 
   private final Opportunity opportunity = getOpportunityForJob();
 
-  @MockBean SalesforceService salesforceService;
-  @MockBean SalesforceRecordTypeConfig salesforceRecordTypeConfig;
+  @MockitoBean SalesforceService salesforceService;
+  @MockitoBean SalesforceRecordTypeConfig salesforceRecordTypeConfig;
 
   @Autowired MockMvc mockMvc;
   @Autowired ObjectMapper objectMapper;

--- a/server/src/test/java/org/tctalent/server/api/admin/SavedListAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/SavedListAdminApiTest.java
@@ -45,7 +45,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -102,13 +102,13 @@ class SavedListAdminApiTest extends ApiTestBase {
             1
         );
 
-    @MockBean
+    @MockitoBean
     SavedListService savedListService;
-    @MockBean
+    @MockitoBean
     CandidateService candidateService;
-    @MockBean
+    @MockitoBean
     CandidateSavedListService candidateSavedListService;
-    @MockBean
+    @MockitoBean
     SalesforceService salesforceService;
 
     @Autowired

--- a/server/src/test/java/org/tctalent/server/api/admin/SavedListCandidateAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/SavedListCandidateAdminApiTest.java
@@ -53,7 +53,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -123,19 +123,19 @@ class SavedListCandidateAdminApiTest extends ApiTestBase {
     @Autowired
     SavedListCandidateAdminApi savedListCandidateAdminApi;
 
-    @MockBean
+    @MockitoBean
     SavedListService savedListService;
-    @MockBean
+    @MockitoBean
     SavedSearchService savedSearchService;
-    @MockBean
+    @MockitoBean
     CandidateSavedListService candidateSavedListService;
-    @MockBean
+    @MockitoBean
     CandidateService candidateService;
-    @MockBean
+    @MockitoBean
     CandidateDtoService candidateDtoService;
-    @MockBean
+    @MockitoBean
     CandidateBuilderSelector candidateBuilderSelector;
-    @MockBean
+    @MockitoBean
     SavedListBuilderSelector savedListBuilderSelector;
 
 

--- a/server/src/test/java/org/tctalent/server/api/admin/SavedSearchAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/SavedSearchAdminApiTest.java
@@ -45,7 +45,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -122,13 +122,13 @@ class SavedSearchAdminApiTest extends ApiTestBase {
           1
       );
 
-  @MockBean
+  @MockitoBean
   CandidateService candidateService;
-  @MockBean
+  @MockitoBean
   CandidateSavedListService candidateSavedListService;
-  @MockBean
+  @MockitoBean
   SavedListService savedListService;
-  @MockBean
+  @MockitoBean
   SavedSearchService savedSearchService;
 
   @Autowired

--- a/server/src/test/java/org/tctalent/server/api/admin/SavedSearchCandidateAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/SavedSearchCandidateAdminApiTest.java
@@ -41,7 +41,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -87,13 +87,13 @@ class SavedSearchCandidateAdminApiTest extends ApiTestBase {
           1
       );
 
-  @MockBean
+  @MockitoBean
   SavedSearchService savedSearchService;
-  @MockBean
+  @MockitoBean
   CandidateService candidateService;
-  @MockBean
+  @MockitoBean
   CandidateDtoService candidateDtoService;
-  @MockBean
+  @MockitoBean
   CandidateBuilderSelector candidateBuilderSelector;
 
   @Autowired

--- a/server/src/test/java/org/tctalent/server/api/admin/SlackAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/SlackAdminApiTest.java
@@ -36,7 +36,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.tctalent.server.request.job.JobInfoForSlackPost;
@@ -62,9 +62,9 @@ class SlackAdminApiTest extends ApiTestBase {
     @Autowired
     SlackAdminApi slackAdminApi;
 
-    @MockBean
+    @MockitoBean
     SlackService slackService;
-    @MockBean
+    @MockitoBean
     JobService jobService;
 
     @BeforeEach

--- a/server/src/test/java/org/tctalent/server/api/admin/SurveyTypeAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/SurveyTypeAdminApiTest.java
@@ -37,7 +37,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.tctalent.server.model.db.SurveyType;
@@ -56,7 +56,7 @@ class SurveyTypeAdminApiTest extends ApiTestBase {
 
   private final List<SurveyType> surveyTypes = getSurveyTypes();
 
-  @MockBean
+  @MockitoBean
   SurveyTypeService surveyTypeService;
 
   @Autowired MockMvc mockMvc;

--- a/server/src/test/java/org/tctalent/server/api/admin/TaskAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/TaskAdminApiTest.java
@@ -41,7 +41,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -79,7 +79,7 @@ class TaskAdminApiTest extends ApiTestBase {
     @Autowired
     TaskAdminApi taskAdminApi;
 
-    @MockBean
+    @MockitoBean
     TaskService taskService;
 
     @BeforeEach

--- a/server/src/test/java/org/tctalent/server/api/admin/TaskAssignmentAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/TaskAssignmentAdminApiTest.java
@@ -48,7 +48,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.tctalent.server.model.db.Candidate;
@@ -87,11 +87,11 @@ class TaskAssignmentAdminApiTest extends ApiTestBase {
   private static final TaskAssignmentImpl completedTaskAssignment = getCompletedTaskAssignment();
   private static final List<TaskAssignmentImpl> taskAssignments = getTaskAssignments();
 
-  @MockBean AuthService authService;
-  @MockBean CandidateService candidateService;
-  @MockBean SavedListService savedListService;
-  @MockBean TaskAssignmentService taskAssignmentService;
-  @MockBean TaskService taskService;
+  @MockitoBean AuthService authService;
+  @MockitoBean CandidateService candidateService;
+  @MockitoBean SavedListService savedListService;
+  @MockitoBean TaskAssignmentService taskAssignmentService;
+  @MockitoBean TaskService taskService;
 
   @Autowired MockMvc mockMvc;
   @Autowired ObjectMapper objectMapper;

--- a/server/src/test/java/org/tctalent/server/api/admin/TranslationAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/TranslationAdminApiTest.java
@@ -53,7 +53,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -129,23 +129,23 @@ class TranslationAdminApiTest extends ApiTestBase {
   private final Page<SurveyType> surveyTypePage = new PageImpl<>(
       getSurveyTypes(), PageRequest.of(0, 10, Sort.unsorted()), 1);
 
-  @MockBean
+  @MockitoBean
   TranslationService translationService;
-  @MockBean
+  @MockitoBean
   AuthService authService;
-  @MockBean
+  @MockitoBean
   CountryService countryService;
-  @MockBean
+  @MockitoBean
   LanguageService languageService;
-  @MockBean
+  @MockitoBean
   LanguageLevelService languageLevelService;
-  @MockBean
+  @MockitoBean
   OccupationService occupationService;
-  @MockBean
+  @MockitoBean
   EducationLevelService educationLevelService;
-  @MockBean
+  @MockitoBean
   EducationMajorService educationMajorService;
-  @MockBean
+  @MockitoBean
   SurveyTypeService surveyTypeService;
 
   @Autowired

--- a/server/src/test/java/org/tctalent/server/api/admin/UserAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/UserAdminApiTest.java
@@ -46,7 +46,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -97,9 +97,9 @@ class UserAdminApiTest extends ApiTestBase {
       "notadmin@gmailcom",
       Role.limited);
 
-  @MockBean AuthService authService;
-  @MockBean CountryService countryService;
-  @MockBean UserService userService;
+  @MockitoBean AuthService authService;
+  @MockitoBean CountryService countryService;
+  @MockitoBean UserService userService;
 
   @Autowired MockMvc mockMvc;
   @Autowired ObjectMapper objectMapper;

--- a/server/src/test/java/org/tctalent/server/api/chat/ChatAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/chat/ChatAdminApiTest.java
@@ -42,7 +42,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.tctalent.server.api.admin.ApiTestBase;
@@ -90,19 +90,19 @@ class ChatAdminApiTest extends ApiTestBase {
     @Autowired
     ChatAdminApi chatAdminApi;
 
-    @MockBean
+    @MockitoBean
     JobChatServiceImpl chatService;
-    @MockBean
+    @MockitoBean
     JobChatUserService jobChatUserService;
-    @MockBean
+    @MockitoBean
     ChatPostService chatPostService;
-    @MockBean
+    @MockitoBean
     CandidateService candidateService;
-    @MockBean
+    @MockitoBean
     JobService jobService;
-    @MockBean
+    @MockitoBean
     PartnerService partnerService;
-    @MockBean
+    @MockitoBean
     UserService userService;
 
     @BeforeEach

--- a/server/src/test/java/org/tctalent/server/api/chat/ChatPostAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/chat/ChatPostAdminApiTest.java
@@ -39,7 +39,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.MockMvc;
@@ -63,10 +63,10 @@ class ChatPostAdminApiTest extends ApiTestBase {
     @Autowired
     MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     ChatPostServiceImpl chatPostService;
 
-    @MockBean
+    @MockitoBean
     ChatUploadFileServiceImpl chatUploadFileService;
 
     @BeforeEach

--- a/server/src/test/java/org/tctalent/server/api/chatbot/ChatbotApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/chatbot/ChatbotApiTest.java
@@ -39,7 +39,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.tctalent.server.model.db.chatbot.ChatbotMessage;
@@ -57,8 +57,8 @@ class ChatbotApiTest {
 
   @Autowired private ObjectMapper objectMapper;
 
-  @MockBean private ChatbotService chatbotService;
-  @MockBean private EmailHelper emailHelper;
+  @MockitoBean private ChatbotService chatbotService;
+  @MockitoBean private EmailHelper emailHelper;
 
   private ChatbotMessage chatbotMessage;
 

--- a/server/src/test/java/org/tctalent/server/casi/api/ServicesAdminControllerTest.java
+++ b/server/src/test/java/org/tctalent/server/casi/api/ServicesAdminControllerTest.java
@@ -48,7 +48,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.MockMvc;
@@ -90,11 +90,11 @@ class ServicesAdminControllerTest extends ApiTestBase {
   private static final String RESOURCE_CODE = "COUPON123";
   private static final String CANDIDATE_NUMBER = "12345";
 
-  @MockBean private AuthService authService;
-  @MockBean private CandidateServiceRegistry candidateServiceRegistry;
-  @MockBean private CandidateServicesQueryService queryService;
-  @MockBean private CandidateAssistanceService candidateAssistanceService;
-  @MockBean private ServiceListRepository serviceListRepository;
+  @MockitoBean private AuthService authService;
+  @MockitoBean private CandidateServiceRegistry candidateServiceRegistry;
+  @MockitoBean private CandidateServicesQueryService queryService;
+  @MockitoBean private CandidateAssistanceService candidateAssistanceService;
+  @MockitoBean private ServiceListRepository serviceListRepository;
 
   @Autowired private MockMvc mockMvc;
   @Autowired private ObjectMapper objectMapper;

--- a/server/src/test/java/org/tctalent/server/casi/api/ServicesPortalControllerTest.java
+++ b/server/src/test/java/org/tctalent/server/casi/api/ServicesPortalControllerTest.java
@@ -40,7 +40,7 @@ import org.mockito.ArgumentMatchers;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.tctalent.server.api.admin.ApiTestBase;
@@ -79,15 +79,15 @@ class ServicesPortalControllerTest extends ApiTestBase {
   private static final String TERMS_ID = "ReferenceServiceTermsV1";
   private static final String OPC_DPA_TERMS_ID = "OpcDataProcessingAgreementV1";
 
-  @MockBean private AuthService authService;
-  @MockBean private UserService userService;
-  @MockBean private CandidateServiceRegistry candidateServiceRegistry;
-  @MockBean private EligibilityPolicyRegistry eligibilityPolicyRegistry;
-  @MockBean private CandidateAssistanceService candidateAssistanceService;
-  @MockBean private AgreementService agreementService;
-  @MockBean private CounterpartyService counterpartyService;
-  @MockBean private CandidateService candidateService;
-  @MockBean private TermsInfoService termsInfoService;
+  @MockitoBean private AuthService authService;
+  @MockitoBean private UserService userService;
+  @MockitoBean private CandidateServiceRegistry candidateServiceRegistry;
+  @MockitoBean private EligibilityPolicyRegistry eligibilityPolicyRegistry;
+  @MockitoBean private CandidateAssistanceService candidateAssistanceService;
+  @MockitoBean private AgreementService agreementService;
+  @MockitoBean private CounterpartyService counterpartyService;
+  @MockitoBean private CandidateService candidateService;
+  @MockitoBean private TermsInfoService termsInfoService;
 
   @Autowired private MockMvc mockMvc;
   @Autowired private ObjectMapper objectMapper;

--- a/server/src/test/java/org/tctalent/server/integration/api/portal/PrivacyPolicyAgreementIntegrationTest.java
+++ b/server/src/test/java/org/tctalent/server/integration/api/portal/PrivacyPolicyAgreementIntegrationTest.java
@@ -34,7 +34,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -70,9 +70,9 @@ public class PrivacyPolicyAgreementIntegrationTest extends BaseDBIntegrationTest
   @Autowired private TcUserDetailsService tcUserDetailsService;
   @Autowired private JwtTokenProvider jwtTokenProvider;
 
-  @MockBean
+  @MockitoBean
   private SavedSearchService savedSearchService;
-  @MockBean
+  @MockitoBean
   private CandidateRedisCache candidateRedisCache;
   private Candidate candidate;
   private SavedList pendingTermsList;


### PR DESCRIPTION
This PR touches a lot of files but the change is straightforward and simply moves from the deprecated MockBean in server tests to MockitoBean. 

The latter is the intended replacement for MockBean since Spring Boot 3.4. 

We are running Spring Boot 3.5.13.