### PR TITLE
TC-1335: Remove duplicate red triangle from erase candidate modal

### DIFF
--- a/ui/admin-portal/src/app/components/candidates/view/erase/erase-candidate-data.component.html
+++ b/ui/admin-portal/src/app/components/candidates/view/erase/erase-candidate-data.component.html
@@ -1,6 +1,7 @@
 <tc-modal
   [heading]="'Erase candidate data'"
   [icon]="'fas fa-triangle-exclamation'"
+  [iconSize]="'xl'"
   [isError]="true"
   [showClose]="!erasing"
   [showCancel]="!erasing && step === 1"
@@ -18,12 +19,6 @@
 
   <!-- STEP 1: WARNING -->
   <div *ngIf="step === 1 && !erasing">
-    <div class="erase-warning-icon">
-      <tc-icon size="xl" color="error" ariaLabel="Warning">
-        <i class="fas fa-triangle-exclamation"></i>
-      </tc-icon>
-    </div>
-
     <h5 class="mb-3">This is a permanent erasure action</h5>
 
     <p>

--- a/ui/admin-portal/src/app/components/candidates/view/erase/erase-candidate-data.component.scss
+++ b/ui/admin-portal/src/app/components/candidates/view/erase/erase-candidate-data.component.scss
@@ -1,3 +1,0 @@
-.erase-warning-icon {
-  margin-bottom: 1rem;
-}

--- a/ui/admin-portal/src/app/shared/components/icon-component/tc-icon.component.scss
+++ b/ui/admin-portal/src/app/shared/components/icon-component/tc-icon.component.scss
@@ -14,7 +14,7 @@
     font-size: 1.25rem;
   }
 
-  &.icon-xl, &.icon-lg::ng-deep > i {
+  &.icon-xl, &.icon-xl::ng-deep > i {
     font-size: 1.5rem;
   }
 

--- a/ui/admin-portal/src/app/shared/components/modal/tc-modal.component.html
+++ b/ui/admin-portal/src/app/shared/components/modal/tc-modal.component.html
@@ -10,7 +10,9 @@
     <i class="fa-solid fa-xmark"></i>
   </tc-icon>
 
-  <tc-icon *ngIf="icon" [color]="isError ? 'error' : 'primary'">
+  <tc-icon *ngIf="icon"
+           [color]="isError ? 'error' : 'primary'"
+           [size]="iconSize">
     <i [class]="icon"></i>
   </tc-icon>
 

--- a/ui/admin-portal/src/app/shared/components/modal/tc-modal.component.spec.ts
+++ b/ui/admin-portal/src/app/shared/components/modal/tc-modal.component.spec.ts
@@ -5,6 +5,7 @@ import {NgbActiveModal} from "@ng-bootstrap/ng-bootstrap";
 import {By} from "@angular/platform-browser";
 import {ButtonComponent} from "../button/button.component";
 import {Component} from "@angular/core";
+import {TcIconComponent} from "../icon-component/tc-icon.component";
 
 @Component({
   template: `
@@ -14,6 +15,7 @@ import {Component} from "@angular/core";
       [disableAction]="disableAction"
       [showCancel]="showCancel"
       [icon]="icon"
+      [iconSize]="iconSize"
       (onAction)="onAction()"
     >
       <p>Modal body content</p>
@@ -26,6 +28,7 @@ class TestHostComponent {
   disableAction = false;
   showCancel = true;
   icon?: string;
+  iconSize: 'sm' | 'md' | 'lg' | 'xl' | 'inherit' = 'inherit';
 
   actionCalled = false;
   onAction() {
@@ -40,7 +43,7 @@ describe('TcModalComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [TcModalComponent, TestHostComponent, ButtonComponent],
+      declarations: [TcModalComponent, TestHostComponent, ButtonComponent, TcIconComponent],
       providers: [NgbActiveModal],
     }).compileComponents();
 
@@ -71,6 +74,15 @@ describe('TcModalComponent', () => {
 
     const modalDiv = fixture.debugElement.query(By.css('.tc-modal'));
     expect(modalDiv.nativeElement.className).toContain('has-icon');
+  });
+
+  it('should pass icon size to tc-icon', () => {
+    host.icon = 'fas fa-bell';
+    host.iconSize = 'xl';
+    fixture.detectChanges();
+
+    const icon = fixture.debugElement.query(By.directive(TcIconComponent));
+    expect(icon.componentInstance.size).toBe('xl');
   });
 
   it('should not show icon if not provided', () => {

--- a/ui/admin-portal/src/app/shared/components/modal/tc-modal.component.ts
+++ b/ui/admin-portal/src/app/shared/components/modal/tc-modal.component.ts
@@ -22,6 +22,7 @@ import {NgbActiveModal} from "@ng-bootstrap/ng-bootstrap";
  *  - `disableAction: boolean` — disables the action button
  *  - `showCancel: boolean` — toggles the cancel button visibility
  *  - `icon: string` — optional FontAwesome icon class
+ *  - `iconSize: 'sm' | 'md' | 'lg' | 'xl' | 'inherit'` — optional icon size
  *  - `isError: boolean = false` — switches the modal to an error style (red header + red icon)
  *  - `cancelText: string = 'Cancel'` — label for the cancel button
  *  - `showClose: boolean = false` — toggles the top-right close “X”
@@ -101,6 +102,7 @@ export class TcModalComponent {
   @Input() disableAction: boolean = false;
   @Input() showCancel: boolean = true;
   @Input() icon: string;
+  @Input() iconSize: 'sm' | 'md' | 'lg' | 'xl' | 'inherit' = 'inherit';
   @Input() isError: boolean = false;
   @Input() cancelText: string = 'Cancel';
   /**


### PR DESCRIPTION
Removes the duplicate red warning triangle from the erase candidate data modal. 
Update the TC modal to support TC-icon size. 
<img width="907" height="566" alt="Screenshot 2026-06-24 at 3 54 21 PM" src="https://github.com/user-attachments/assets/faedab33-dd59-49fa-ab85-6fd693f29c39" />
<img width="848" height="572" alt="Screenshot 2026-06-24 at 3 54 25 PM" src="https://github.com/user-attachments/assets/eea14d40-11ab-40ee-ab74-54e27e41be24" />
