### PR TITLE
TC-1336 Add Mark All as Yes button for destinations step in candidate portal registration

### DIFF
--- a/ui/admin-portal/src/app/components/settings/translations/general/general-translations.component.ts
+++ b/ui/admin-portal/src/app/components/settings/translations/general/general-translations.component.ts
@@ -488,6 +488,9 @@ const ALL_FIELDS = {
           "INTEREST": null,
           "NOTES": null,
         },
+        "BUTTON": {
+          "MARK_ALL_YES": null
+        },
       },
       "CERTIFICATIONS": {
         "LABEL": {

--- a/ui/candidate-portal/src/app/components/register/destinations/registration-destinations.component.html
+++ b/ui/candidate-portal/src/app/components/register/destinations/registration-destinations.component.html
@@ -22,6 +22,14 @@
 
     <app-error [error]="error"></app-error>
 
+    <div class="destination-actions">
+      <tc-button type="outline"
+                 [disabled]="saving"
+                 (onClick)="setAllDestinationsToInterested()">
+        Mark all as Yes
+      </tc-button>
+    </div>
+
     <div class="destination-card" *ngFor="let destination of destinations; let i = index;">
       <div class="card">
         <app-destination

--- a/ui/candidate-portal/src/app/components/register/destinations/registration-destinations.component.html
+++ b/ui/candidate-portal/src/app/components/register/destinations/registration-destinations.component.html
@@ -26,7 +26,7 @@
       <tc-button type="outline"
                  [disabled]="saving"
                  (onClick)="setAllDestinationsToInterested()">
-        Mark all as Yes
+        {{ 'REGISTRATION.DESTINATIONS.BUTTON.MARK_ALL_YES' | translate }}
       </tc-button>
     </div>
 

--- a/ui/candidate-portal/src/app/components/register/destinations/registration-destinations.component.scss
+++ b/ui/candidate-portal/src/app/components/register/destinations/registration-destinations.component.scss
@@ -17,3 +17,9 @@
 .destination-card:last-child hr {
   display: none;
 }
+
+.destination-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 1rem;
+}

--- a/ui/candidate-portal/src/app/components/register/destinations/registration-destinations.component.spec.ts
+++ b/ui/candidate-portal/src/app/components/register/destinations/registration-destinations.component.spec.ts
@@ -18,7 +18,7 @@ import {Component, EventEmitter, Input, Output, QueryList} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {UntypedFormControl, UntypedFormGroup} from '@angular/forms';
 import {By} from '@angular/platform-browser';
-import {TranslateModule} from '@ngx-translate/core';
+import {TranslateModule, TranslateService} from '@ngx-translate/core';
 import {of, throwError} from 'rxjs';
 
 import {RegistrationDestinationsComponent} from './registration-destinations.component';
@@ -111,6 +111,7 @@ describe('RegistrationDestinationsComponent', () => {
   let countryServiceSpy: jasmine.SpyObj<CountryService>;
   let candidateDestinationServiceSpy: jasmine.SpyObj<CandidateDestinationService>;
   let registrationServiceSpy: jasmine.SpyObj<RegistrationService>;
+  let translateService: TranslateService;
 
   async function configureAndCreate(options?: {
     destinations?: Country[];
@@ -175,6 +176,18 @@ describe('RegistrationDestinationsComponent', () => {
         {provide: RegistrationService, useValue: registrationServiceSpy}
       ]
     }).compileComponents();
+
+    translateService = TestBed.inject(TranslateService);
+    translateService.setTranslation('en', {
+      REGISTRATION: {
+        DESTINATIONS: {
+          BUTTON: {
+            MARK_ALL_YES: 'Mark all as Yes'
+          }
+        }
+      }
+    });
+    translateService.use('en');
 
     fixture = TestBed.createComponent(RegistrationDestinationsComponent);
     component = fixture.componentInstance;

--- a/ui/candidate-portal/src/app/components/register/destinations/registration-destinations.component.spec.ts
+++ b/ui/candidate-portal/src/app/components/register/destinations/registration-destinations.component.spec.ts
@@ -16,6 +16,7 @@
 
 import {Component, EventEmitter, Input, Output, QueryList} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {UntypedFormControl, UntypedFormGroup} from '@angular/forms';
 import {By} from '@angular/platform-browser';
 import {TranslateModule} from '@ngx-translate/core';
 import {of, throwError} from 'rxjs';
@@ -54,6 +55,16 @@ class RegistrationFooterStubComponent {
   @Input() type?: string;
   @Output() backClicked = new EventEmitter<void>();
   @Output() nextClicked = new EventEmitter<void>();
+}
+
+@Component({
+  selector: 'tc-button',
+  template: '<button type="button" [disabled]="disabled" (click)="onClick.emit()"><ng-content></ng-content></button>'
+})
+class TcButtonStubComponent {
+  @Input() disabled?: boolean;
+  @Input() type?: string;
+  @Output() onClick = new EventEmitter<void>();
 }
 
 @Component({
@@ -153,6 +164,7 @@ describe('RegistrationDestinationsComponent', () => {
         TcLoadingStubComponent,
         ErrorStubComponent,
         RegistrationFooterStubComponent,
+        TcButtonStubComponent,
         DestinationStubComponent
       ],
       imports: [TranslateModule.forRoot()],
@@ -221,6 +233,22 @@ describe('RegistrationDestinationsComponent', () => {
       expect(destinationEls.length).toBe(2);
     });
 
+    it('should render a mark all as Yes button', () => {
+      const button = fixture.debugElement.query(By.directive(TcButtonStubComponent));
+
+      expect(button).toBeTruthy();
+      expect(button.nativeElement.textContent).toContain('Mark all as Yes');
+      expect(button.componentInstance.disabled).toBeFalse();
+    });
+
+    it('should disable the mark all as Yes button while saving', () => {
+      component.saving = true;
+      fixture.detectChanges();
+      const button = fixture.debugElement.query(By.directive(TcButtonStubComponent));
+
+      expect(button.componentInstance.disabled).toBeTrue();
+    });
+
     it('should pass the registration footer type based on edit mode', async () => {
       TestBed.resetTestingModule();
       await configureAndCreate({edit: true});
@@ -245,6 +273,62 @@ describe('RegistrationDestinationsComponent', () => {
       setDestinationForms([{invalid: false}, {invalid: true}]);
 
       expect(component.validationPassed).toBeFalse();
+    });
+  });
+
+  describe('setAllDestinationsToInterested', () => {
+    beforeEach(async () => configureAndCreate());
+
+    it('should set every destination interest to Yes and mark changed forms dirty', () => {
+      const yesForm = new UntypedFormGroup({
+        interest: new UntypedFormControl(YesNoUnsureLearn.Yes)
+      });
+      const noForm = new UntypedFormGroup({
+        interest: new UntypedFormControl(YesNoUnsureLearn.No)
+      });
+      const emptyForm = new UntypedFormGroup({
+        interest: new UntypedFormControl(null)
+      });
+      setDestinationForms([yesForm, noForm, emptyForm]);
+
+      component.setAllDestinationsToInterested();
+
+      expect(yesForm.value.interest).toBe(YesNoUnsureLearn.Yes);
+      expect(noForm.value.interest).toBe(YesNoUnsureLearn.Yes);
+      expect(emptyForm.value.interest).toBe(YesNoUnsureLearn.Yes);
+      expect(yesForm.dirty).toBeFalse();
+      expect(noForm.dirty).toBeTrue();
+      expect(emptyForm.dirty).toBeTrue();
+      expect(yesForm.get('interest').dirty).toBeFalse();
+      expect(noForm.get('interest').dirty).toBeTrue();
+      expect(emptyForm.get('interest').dirty).toBeTrue();
+    });
+
+    it('should not emit value changes when setting interests in bulk', () => {
+      const noForm = new UntypedFormGroup({
+        interest: new UntypedFormControl(YesNoUnsureLearn.No)
+      });
+      const valueChangesSpy = jasmine.createSpy('valueChanges');
+      noForm.get('interest').valueChanges.subscribe(valueChangesSpy);
+      setDestinationForms([noForm]);
+
+      component.setAllDestinationsToInterested();
+
+      expect(valueChangesSpy).not.toHaveBeenCalled();
+    });
+
+    it('should set all interests to Yes when the button is clicked', () => {
+      const noForm = new UntypedFormGroup({
+        interest: new UntypedFormControl(YesNoUnsureLearn.No)
+      });
+      setDestinationForms([noForm]);
+      const button = fixture.debugElement.query(By.directive(TcButtonStubComponent));
+
+      button.triggerEventHandler('onClick', null);
+
+      expect(noForm.value.interest).toBe(YesNoUnsureLearn.Yes);
+      expect(noForm.dirty).toBeTrue();
+      expect(noForm.get('interest').dirty).toBeTrue();
     });
   });
 

--- a/ui/candidate-portal/src/app/components/register/destinations/registration-destinations.component.ts
+++ b/ui/candidate-portal/src/app/components/register/destinations/registration-destinations.component.ts
@@ -24,7 +24,7 @@ import {
   ViewChildren
 } from '@angular/core';
 import {UntypedFormBuilder, UntypedFormGroup} from "@angular/forms";
-import {Candidate, CandidateDestination} from "../../../model/candidate";
+import {Candidate, CandidateDestination, YesNoUnsureLearn} from "../../../model/candidate";
 import {CandidateService} from "../../../services/candidate.service";
 import {RegistrationService} from "../../../services/registration.service";
 import {CountryService} from "../../../services/country.service";
@@ -91,6 +91,16 @@ export class RegistrationDestinationsComponent implements OnInit {
 
   fetchDestination(countryId: number) {
      return this.candidateDestinations?.find(d => d.country.id === countryId)
+  }
+
+  setAllDestinationsToInterested() {
+    this.destinationFormComponents?.forEach(destination => {
+      const interestControl = destination.form?.get('interest');
+      if (interestControl && interestControl.value !== YesNoUnsureLearn.Yes) {
+        interestControl.setValue(YesNoUnsureLearn.Yes, {emitEvent: false});
+        interestControl.markAsDirty();
+      }
+    });
   }
 
   save(dir: string) {


### PR DESCRIPTION
Adds a bulk action to the candidate registration Destinations step so candidates can mark all destination interest fields as `Yes` with one click. 
<img width="405" height="598" alt="Screenshot 2026-06-24 at 7 22 07 PM" src="https://github.com/user-attachments/assets/937eab03-6329-49b4-824f-b3288cecd667" />
