### PR TITLE
Add DB specification unit tests

### DIFF
--- a/server/src/test/java/org/tctalent/server/repository/db/CandidateOpportunitySpecificationTest.java
+++ b/server/src/test/java/org/tctalent/server/repository/db/CandidateOpportunitySpecificationTest.java
@@ -1,0 +1,760 @@
+/*
+ * Copyright (c) 2026 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free
+ *  Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.repository.db;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.Order;
+import jakarta.persistence.criteria.Path;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import jakarta.persistence.criteria.Subquery;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
+import org.tctalent.server.model.db.CandidateOpportunity;
+import org.tctalent.server.model.db.CandidateOpportunityStage;
+import org.tctalent.server.model.db.PartnerImpl;
+import org.tctalent.server.model.db.User;
+import org.tctalent.server.request.candidate.opportunity.SearchCandidateOpportunityRequest;
+import org.tctalent.server.request.opportunity.OpportunityOwnershipType;
+import org.tctalent.server.util.SpecificationHelper;
+
+@ExtendWith(MockitoExtension.class)
+class CandidateOpportunitySpecificationTest {
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private Root<CandidateOpportunity> opp;
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private CriteriaQuery<CandidateOpportunity> query;
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private CriteriaQuery<Long> countQuery;
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private CriteriaBuilder cb;
+
+  @Mock private Predicate conjunction;
+  @Mock private Path<Object> idPath;
+  @Mock private Order idOrder;
+
+  @Mock private Path<Object> sortNamePath;
+  @Mock private Order sortNameOrder;
+
+  @Mock private Path<String> keywordNamePath;
+  @Mock private Expression<String> lowerNamePath;
+  @Mock private Predicate keywordPredicate;
+  @Mock private Predicate keywordConjunction;
+
+  @Mock private Path<CandidateOpportunityStage> stagePath;
+  @Mock private Predicate stageInPredicate;
+  @Mock private Predicate stagePredicate;
+  @Mock private Predicate stageConjunction;
+
+  @Mock private Path<Integer> stageOrderPath;
+  @Mock private Predicate activeStagesPredicate;
+  @Mock private Predicate activeStagesConjunction;
+
+  @Mock private Path<Boolean> closedPath;
+  @Mock private Predicate closedPredicate;
+  @Mock private Predicate activeOrClosedPredicate;
+  @Mock private Predicate activeOrClosedConjunction;
+  @Mock private Predicate notClosedConjunction;
+
+  @Mock private Path<LocalDate> nextStepDueDatePath;
+  @Mock private Predicate hasDueDatePredicate;
+  @Mock private Predicate overduePredicate;
+  @Mock private Predicate overdueConjunction;
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private Join<Object, Object> jobOppJoin;
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private Join<Object, Object> candidateJoin;
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private Join<Object, Object> userJoin;
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private Join<Object, Object> partnerJoin;
+
+  @Mock private Predicate ownedPredicate;
+  @Mock private Predicate ownedConjunction;
+  @Mock private Predicate matchContactUserPredicate;
+  @Mock private Predicate matchCreatedByPredicate;
+  @Mock private Predicate ownerDisjunction;
+
+  @Mock private Predicate emptyDisjunction;
+  @Mock private Predicate nonEmptyDisjunction;
+  @Mock private Expression<Boolean> disjunctionExpression;
+
+  @Test
+  @DisplayName("should cover default constructor")
+  void constructor_shouldCreateInstance() {
+    assertNotNull(new CandidateOpportunitySpecification());
+  }
+
+  @Test
+  @DisplayName("should throw when criteria query is null")
+  void buildSearchQuery_shouldThrow_whenCriteriaQueryIsNull() {
+    SearchCandidateOpportunityRequest request = new SearchCandidateOpportunityRequest();
+
+    Specification<CandidateOpportunity> specification =
+        CandidateOpportunitySpecification.buildSearchQuery(request, null);
+
+    assertThrows(IllegalArgumentException.class,
+        () -> specification.toPredicate(opp, null, cb));
+  }
+
+  @Test
+  @DisplayName("should apply stable id sort when sort is not requested")
+  void buildSearchQuery_shouldApplyStableIdSort_whenSortNotRequested() {
+    stubNonCountQuery();
+
+    Predicate result = toPredicate(new SearchCandidateOpportunityRequest(), null);
+
+    assertEquals(conjunction, result);
+    verify(query).orderBy(List.of(idOrder));
+  }
+
+  @Test
+  @DisplayName("should apply requested ASC sort and stable id sort")
+  void buildSearchQuery_shouldApplyRequestedAscSortAndStableIdSort() {
+    stubNonCountQuery();
+
+    SearchCandidateOpportunityRequest request = new SearchCandidateOpportunityRequest();
+    request.setSortDirection(Sort.Direction.ASC);
+    request.setSortFields(new String[] {"name"});
+
+    when(opp.get("name")).thenReturn(sortNamePath);
+    when(cb.asc(sortNamePath)).thenReturn(sortNameOrder);
+
+    Predicate result = toPredicate(request, null);
+
+    assertEquals(conjunction, result);
+    verify(query).orderBy(List.of(sortNameOrder, idOrder));
+  }
+
+  @Test
+  @DisplayName("should apply requested id DESC sort without extra stable id sort")
+  void buildSearchQuery_shouldApplyRequestedIdDescSortWithoutExtraStableIdSort() {
+    stubNonCountQuery();
+
+    SearchCandidateOpportunityRequest request = new SearchCandidateOpportunityRequest();
+    request.setSortDirection(Sort.Direction.DESC);
+    request.setSortFields(new String[] {"id"});
+
+    Predicate result = toPredicate(request, null);
+
+    assertEquals(conjunction, result);
+    verify(query).orderBy(List.of(idOrder));
+  }
+
+  @Test
+  @DisplayName("should not apply ordering for count query")
+  void buildSearchQuery_shouldNotApplyOrdering_forCountQuery() {
+    when(countQuery.getResultType()).thenReturn(Long.class);
+    when(cb.conjunction()).thenReturn(conjunction);
+
+    Specification<CandidateOpportunity> specification =
+        CandidateOpportunitySpecification.buildSearchQuery(
+            new SearchCandidateOpportunityRequest(), null);
+
+    Predicate result = specification.toPredicate(opp, countQuery, cb);
+
+    assertEquals(conjunction, result);
+    verify(countQuery, never()).orderBy(anyList());
+    verify(opp, never()).get("id");
+  }
+
+  @Test
+  @DisplayName("should apply lowercase keyword filter")
+  void buildSearchQuery_shouldApplyLowercaseKeywordFilter() {
+    stubNonCountQuery();
+
+    SearchCandidateOpportunityRequest request = new SearchCandidateOpportunityRequest();
+    request.setKeyword("Case Name");
+
+    when(opp.<String>get("name")).thenReturn(keywordNamePath);
+    when(cb.lower(keywordNamePath)).thenReturn(lowerNamePath);
+    when(cb.like(lowerNamePath, "%case name%")).thenReturn(keywordPredicate);
+    when(cb.and(conjunction, keywordPredicate)).thenReturn(keywordConjunction);
+
+    Predicate result = toPredicate(request, null);
+
+    assertEquals(keywordConjunction, result);
+  }
+
+  @Test
+  @DisplayName("should apply stage filter and ignore active and closed filters")
+  void buildSearchQuery_shouldApplyStageFilterAndIgnoreActiveAndClosedFilters() {
+    stubNonCountQuery();
+
+    List<CandidateOpportunityStage> stages = List.of(
+        CandidateOpportunityStage.prospect,
+        CandidateOpportunityStage.jobOfferRetracted
+    );
+
+    SearchCandidateOpportunityRequest request = new SearchCandidateOpportunityRequest();
+    request.setStages(stages);
+    request.setActiveStages(true);
+    request.setSfOppClosed(false);
+
+    when(opp.<CandidateOpportunityStage>get("stage")).thenReturn(stagePath);
+    when(stagePath.in(stages)).thenReturn(stageInPredicate);
+    when(cb.isTrue(stageInPredicate)).thenReturn(stagePredicate);
+    when(cb.and(conjunction, stagePredicate)).thenReturn(stageConjunction);
+
+    Predicate result = toPredicate(request, null);
+
+    assertEquals(stageConjunction, result);
+    verify(opp, never()).get("stageOrder");
+    verify(opp, never()).get("closed");
+  }
+
+  @Test
+  @DisplayName("should apply active stages only")
+  void buildSearchQuery_shouldApplyActiveStagesOnly() {
+    stubNonCountQuery();
+
+    SearchCandidateOpportunityRequest request = new SearchCandidateOpportunityRequest();
+    request.setActiveStages(true);
+
+    when(opp.<Integer>get("stageOrder")).thenReturn(stageOrderPath);
+    when(cb.between(
+        stageOrderPath,
+        CandidateOpportunityStage.prospect.ordinal(),
+        CandidateOpportunityStage.relocating.ordinal()
+    )).thenReturn(activeStagesPredicate);
+    when(cb.and(conjunction, activeStagesPredicate)).thenReturn(activeStagesConjunction);
+
+    Predicate result = toPredicate(request, null);
+
+    assertEquals(activeStagesConjunction, result);
+  }
+
+  @Test
+  @DisplayName("should include active stages or closed opportunities when both are requested")
+  void buildSearchQuery_shouldIncludeActiveStagesOrClosedOpportunities() {
+    stubNonCountQuery();
+
+    SearchCandidateOpportunityRequest request = new SearchCandidateOpportunityRequest();
+    request.setActiveStages(true);
+    request.setSfOppClosed(true);
+
+    when(opp.<Integer>get("stageOrder")).thenReturn(stageOrderPath);
+    when(cb.between(
+        stageOrderPath,
+        CandidateOpportunityStage.prospect.ordinal(),
+        CandidateOpportunityStage.relocating.ordinal()
+    )).thenReturn(activeStagesPredicate);
+
+    when(opp.<Boolean>get("closed")).thenReturn(closedPath);
+    when(cb.equal(closedPath, true)).thenReturn(closedPredicate);
+    when(cb.or(activeStagesPredicate, closedPredicate)).thenReturn(activeOrClosedPredicate);
+    when(cb.and(conjunction, activeOrClosedPredicate)).thenReturn(activeOrClosedConjunction);
+
+    Predicate result = toPredicate(request, null);
+
+    assertEquals(activeOrClosedConjunction, result);
+  }
+
+  @Test
+  @DisplayName("should skip active filtering when active stages is false")
+  void buildSearchQuery_shouldSkipActiveFiltering_whenActiveStagesFalse() {
+    stubNonCountQuery();
+
+    SearchCandidateOpportunityRequest request = new SearchCandidateOpportunityRequest();
+    request.setActiveStages(false);
+
+    Predicate result = toPredicate(request, null);
+
+    assertEquals(conjunction, result);
+    verify(opp, never()).get("stageOrder");
+  }
+
+  @Test
+  @DisplayName("should skip closed filtering when closed is true and active is not requested")
+  void buildSearchQuery_shouldSkipClosedFiltering_whenClosedTrue() {
+    stubNonCountQuery();
+
+    SearchCandidateOpportunityRequest request = new SearchCandidateOpportunityRequest();
+    request.setSfOppClosed(true);
+
+    Predicate result = toPredicate(request, null);
+
+    assertEquals(conjunction, result);
+  }
+
+  @Test
+  @DisplayName("should exclude closed opportunities when closed is false")
+  void buildSearchQuery_shouldExcludeClosedOpportunities_whenClosedFalse() {
+    stubNonCountQuery();
+
+    SearchCandidateOpportunityRequest request = new SearchCandidateOpportunityRequest();
+    request.setSfOppClosed(false);
+
+    when(opp.<Boolean>get("closed")).thenReturn(closedPath);
+    when(cb.equal(closedPath, false)).thenReturn(closedPredicate);
+    when(cb.and(conjunction, closedPredicate)).thenReturn(notClosedConjunction);
+
+    Predicate result = toPredicate(request, null);
+
+    assertEquals(notClosedConjunction, result);
+  }
+
+  @Test
+  @DisplayName("should apply overdue filter")
+  void buildSearchQuery_shouldApplyOverdueFilter() {
+    stubNonCountQuery();
+
+    SearchCandidateOpportunityRequest request = new SearchCandidateOpportunityRequest();
+    request.setOverdue(true);
+
+    when(opp.<LocalDate>get("nextStepDueDate")).thenReturn(nextStepDueDatePath);
+    when(cb.isNotNull(nextStepDueDatePath)).thenReturn(hasDueDatePredicate);
+    when(cb.lessThan(nextStepDueDatePath, LocalDate.now())).thenReturn(overduePredicate);
+    when(cb.and(conjunction, hasDueDatePredicate, overduePredicate))
+        .thenReturn(overdueConjunction);
+
+    Predicate result = toPredicate(request, null);
+
+    assertEquals(overdueConjunction, result);
+  }
+
+  @Test
+  @DisplayName("should skip overdue filter when overdue is false")
+  void buildSearchQuery_shouldSkipOverdueFilter_whenOverdueFalse() {
+    stubNonCountQuery();
+
+    SearchCandidateOpportunityRequest request = new SearchCandidateOpportunityRequest();
+    request.setOverdue(false);
+
+    Predicate result = toPredicate(request, null);
+
+    assertEquals(conjunction, result);
+    verify(opp, never()).get("nextStepDueDate");
+  }
+
+  @Test
+  @DisplayName("should apply unread messages filter")
+  void buildSearchQuery_shouldApplyUnreadMessagesFilter() {
+    stubNonCountQuery();
+
+    SearchCandidateOpportunityRequest request = new SearchCandidateOpportunityRequest();
+    request.setWithUnreadMessages(true);
+
+    User loggedInUser = mock(User.class);
+    Predicate unreadPredicate = mock(Predicate.class);
+    Predicate unreadConjunction = mock(Predicate.class);
+
+    when(cb.and(any(Predicate.class), any(Predicate.class))).thenReturn(conjunction);
+    when(cb.and(conjunction, unreadPredicate)).thenReturn(unreadConjunction);
+
+    try (MockedStatic<SpecificationHelper> mockedHelper = mockStatic(SpecificationHelper.class)) {
+      mockedHelper.when(() -> SpecificationHelper.hasUnreadChats(
+          any(User.class),
+          any(CriteriaQuery.class),
+          any(CriteriaBuilder.class),
+          any(Subquery.class),
+          any(Root.class),
+          any(Predicate.class)
+      )).thenReturn(unreadPredicate);
+
+      Predicate result = toPredicate(request, loggedInUser);
+
+      assertEquals(unreadConjunction, result);
+    }
+  }
+
+  @Test
+  @DisplayName("should skip unread messages filter when unread is false")
+  void buildSearchQuery_shouldSkipUnreadMessagesFilter_whenUnreadFalse() {
+    stubNonCountQuery();
+
+    SearchCandidateOpportunityRequest request = new SearchCandidateOpportunityRequest();
+    request.setWithUnreadMessages(false);
+
+    Predicate result = toPredicate(request, null);
+
+    assertEquals(conjunction, result);
+    verify(query, never()).subquery(Long.class);
+  }
+
+  @Test
+  @DisplayName("should skip ownership when ownership type is null")
+  void buildSearchQuery_shouldSkipOwnership_whenOwnershipTypeIsNull() {
+    stubNonCountQuery();
+
+    SearchCandidateOpportunityRequest request = new SearchCandidateOpportunityRequest();
+    request.setOwnedByMe(true);
+    request.setOwnedByMyPartner(true);
+
+    Predicate result = toPredicate(request, null);
+
+    assertEquals(conjunction, result);
+    verify(opp, never()).join("jobOpp");
+    verify(opp, never()).join("candidate");
+  }
+
+  @Test
+  @DisplayName("should skip ownership when logged in user is null")
+  void buildSearchQuery_shouldSkipOwnership_whenLoggedInUserIsNull() {
+    stubNonCountQuery();
+
+    SearchCandidateOpportunityRequest request = new SearchCandidateOpportunityRequest();
+    request.setOwnershipType(OpportunityOwnershipType.AS_JOB_CREATOR);
+    request.setOwnedByMe(true);
+
+    Predicate result = toPredicate(request, null);
+
+    assertEquals(conjunction, result);
+    verify(opp, never()).join("jobOpp");
+  }
+
+  @Test
+  @DisplayName("should skip ownership when logged in user has no partner")
+  void buildSearchQuery_shouldSkipOwnership_whenLoggedInUserHasNoPartner() {
+    stubNonCountQuery();
+
+    SearchCandidateOpportunityRequest request = new SearchCandidateOpportunityRequest();
+    request.setOwnershipType(OpportunityOwnershipType.AS_JOB_CREATOR);
+    request.setOwnedByMe(true);
+
+    User loggedInUser = mock(User.class);
+    when(loggedInUser.getPartner()).thenReturn(null);
+
+    Predicate result = toPredicate(request, loggedInUser);
+
+    assertEquals(conjunction, result);
+    verify(opp, never()).join("jobOpp");
+  }
+
+  @Test
+  @DisplayName("should filter job creator ownership by my partner")
+  void buildSearchQuery_shouldFilterJobCreatorOwnershipByMyPartner() {
+    stubNonCountQuery();
+
+    SearchCandidateOpportunityRequest request = new SearchCandidateOpportunityRequest();
+    request.setOwnershipType(OpportunityOwnershipType.AS_JOB_CREATOR);
+    request.setOwnedByMyPartner(true);
+
+    User loggedInUser = mock(User.class);
+    PartnerImpl loggedInUserPartner = mock(PartnerImpl.class);
+
+    when(loggedInUser.getPartner()).thenReturn(loggedInUserPartner);
+    when(loggedInUserPartner.getId()).thenReturn(99L);
+
+    doReturn(jobOppJoin).when(opp).join("jobOpp");
+
+    when(cb.equal(jobOppJoin.get("jobCreator").get("id"), 99L)).thenReturn(ownedPredicate);
+    when(cb.and(conjunction, ownedPredicate)).thenReturn(ownedConjunction);
+
+    Predicate result = toPredicate(request, loggedInUser);
+
+    assertEquals(ownedConjunction, result);
+  }
+
+  @Test
+  @DisplayName("should filter job creator ownership by logged in user")
+  void buildSearchQuery_shouldFilterJobCreatorOwnershipByLoggedInUser() {
+    stubNonCountQuery();
+
+    SearchCandidateOpportunityRequest request = new SearchCandidateOpportunityRequest();
+    request.setOwnershipType(OpportunityOwnershipType.AS_JOB_CREATOR);
+    request.setOwnedByMe(true);
+
+    User loggedInUser = mock(User.class);
+    PartnerImpl loggedInUserPartner = mock(PartnerImpl.class);
+
+    when(loggedInUser.getPartner()).thenReturn(loggedInUserPartner);
+    when(loggedInUser.getId()).thenReturn(42L);
+
+    doReturn(jobOppJoin).when(opp).join("jobOpp");
+
+    when(cb.and(any(Predicate.class), any(Predicate.class)))
+        .thenReturn(matchContactUserPredicate, matchCreatedByPredicate, ownedConjunction);
+    when(cb.or(matchContactUserPredicate, matchCreatedByPredicate)).thenReturn(ownerDisjunction);
+
+    Predicate result = toPredicate(request, loggedInUser);
+
+    assertEquals(ownedConjunction, result);
+  }
+
+  @Test
+  @DisplayName("should skip job creator owned by me when flag is false")
+  void buildSearchQuery_shouldSkipJobCreatorOwnedByMe_whenFlagFalse() {
+    stubNonCountQuery();
+
+    SearchCandidateOpportunityRequest request = new SearchCandidateOpportunityRequest();
+    request.setOwnershipType(OpportunityOwnershipType.AS_JOB_CREATOR);
+    request.setOwnedByMyPartner(false);
+    request.setOwnedByMe(false);
+
+    User loggedInUser = mock(User.class);
+    PartnerImpl loggedInUserPartner = mock(PartnerImpl.class);
+
+    when(loggedInUser.getPartner()).thenReturn(loggedInUserPartner);
+
+    Predicate result = toPredicate(request, loggedInUser);
+
+    assertEquals(conjunction, result);
+    verify(opp, never()).join("jobOpp");
+  }
+
+  @Test
+  @DisplayName("should filter source partner ownership by candidate partner")
+  void buildSearchQuery_shouldFilterSourcePartnerOwnershipByCandidatePartner() {
+    stubNonCountQuery();
+
+    SearchCandidateOpportunityRequest request = new SearchCandidateOpportunityRequest();
+    request.setOwnershipType(OpportunityOwnershipType.AS_SOURCE_PARTNER);
+    request.setOwnedByMyPartner(true);
+
+    User loggedInUser = mock(User.class);
+    PartnerImpl loggedInUserPartner = mock(PartnerImpl.class);
+
+    when(loggedInUser.getPartner()).thenReturn(loggedInUserPartner);
+    when(loggedInUserPartner.isSourcePartner()).thenReturn(true);
+    when(loggedInUserPartner.getId()).thenReturn(123L);
+
+    stubCandidatePartnerJoin();
+
+    when(cb.equal(partnerJoin.get("id"), 123L)).thenReturn(ownedPredicate);
+    when(cb.and(conjunction, ownedPredicate)).thenReturn(ownedConjunction);
+
+    Predicate result = toPredicate(request, loggedInUser);
+
+    assertEquals(ownedConjunction, result);
+  }
+
+  @Test
+  @DisplayName("should skip source partner ownership when logged in partner is not source partner")
+  void buildSearchQuery_shouldSkipSourcePartnerOwnership_whenPartnerIsNotSourcePartner() {
+    stubNonCountQuery();
+
+    SearchCandidateOpportunityRequest request = new SearchCandidateOpportunityRequest();
+    request.setOwnershipType(OpportunityOwnershipType.AS_SOURCE_PARTNER);
+    request.setOwnedByMyPartner(true);
+
+    User loggedInUser = mock(User.class);
+    PartnerImpl loggedInUserPartner = mock(PartnerImpl.class);
+
+    when(loggedInUser.getPartner()).thenReturn(loggedInUserPartner);
+    when(loggedInUserPartner.isSourcePartner()).thenReturn(false);
+
+    Predicate result = toPredicate(request, loggedInUser);
+
+    assertEquals(conjunction, result);
+    verify(opp, never()).join("candidate");
+  }
+
+  @Test
+  @DisplayName("should filter source partner owned by me without default contact")
+  void buildSearchQuery_shouldFilterSourcePartnerOwnedByMeWithoutDefaultContact() {
+    stubNonCountQuery();
+
+    SearchCandidateOpportunityRequest request = new SearchCandidateOpportunityRequest();
+    request.setOwnershipType(OpportunityOwnershipType.AS_SOURCE_PARTNER);
+    request.setOwnedByMe(true);
+
+    User loggedInUser = mock(User.class);
+    PartnerImpl loggedInUserPartner = mock(PartnerImpl.class);
+
+    when(loggedInUser.getPartner()).thenReturn(loggedInUserPartner);
+    when(loggedInUserPartner.isSourcePartner()).thenReturn(true);
+    when(loggedInUserPartner.getId()).thenReturn(123L);
+    when(loggedInUser.getId()).thenReturn(42L);
+    when(loggedInUserPartner.getDefaultContact()).thenReturn(null);
+
+    stubCandidatePartnerJoin();
+    doReturn(jobOppJoin).when(opp).join("jobOpp");
+
+    when(cb.disjunction()).thenReturn(emptyDisjunction);
+    when(cb.or(any(Predicate.class), any(Predicate.class))).thenReturn(nonEmptyDisjunction);
+    when(nonEmptyDisjunction.getExpressions()).thenReturn(List.of(disjunctionExpression));
+    when(cb.and(any(Predicate.class), any(Predicate.class))).thenReturn(conjunction);
+
+    Predicate result = toPredicate(request, loggedInUser);
+
+    assertEquals(conjunction, result);
+  }
+
+  @Test
+  @DisplayName("should filter source partner owned by me when default contact does not match")
+  void buildSearchQuery_shouldFilterSourcePartnerOwnedByMeWhenDefaultContactDoesNotMatch() {
+    stubNonCountQuery();
+
+    SearchCandidateOpportunityRequest request = new SearchCandidateOpportunityRequest();
+    request.setOwnershipType(OpportunityOwnershipType.AS_SOURCE_PARTNER);
+    request.setOwnedByMe(true);
+
+    User loggedInUser = mock(User.class);
+    User defaultContact = mock(User.class);
+    PartnerImpl loggedInUserPartner = mock(PartnerImpl.class);
+
+    when(loggedInUser.getPartner()).thenReturn(loggedInUserPartner);
+    when(loggedInUserPartner.isSourcePartner()).thenReturn(true);
+    when(loggedInUserPartner.getId()).thenReturn(123L);
+    when(loggedInUser.getId()).thenReturn(42L);
+    when(loggedInUserPartner.getDefaultContact()).thenReturn(defaultContact);
+    when(defaultContact.getId()).thenReturn(99L);
+
+    stubCandidatePartnerJoin();
+    doReturn(jobOppJoin).when(opp).join("jobOpp");
+
+    when(cb.disjunction()).thenReturn(emptyDisjunction);
+    when(cb.or(any(Predicate.class), any(Predicate.class))).thenReturn(nonEmptyDisjunction);
+    when(nonEmptyDisjunction.getExpressions()).thenReturn(List.of(disjunctionExpression));
+    when(cb.and(any(Predicate.class), any(Predicate.class))).thenReturn(conjunction);
+
+    Predicate result = toPredicate(request, loggedInUser);
+
+    assertEquals(conjunction, result);
+  }
+
+  @Test
+  @DisplayName("should filter source partner owned by me when logged in user is default contact")
+  void buildSearchQuery_shouldFilterSourcePartnerOwnedByMeWhenLoggedInUserIsDefaultContact() {
+    stubNonCountQuery();
+
+    SearchCandidateOpportunityRequest request = new SearchCandidateOpportunityRequest();
+    request.setOwnershipType(OpportunityOwnershipType.AS_SOURCE_PARTNER);
+    request.setOwnedByMe(true);
+
+    User loggedInUser = mock(User.class);
+    User defaultContact = mock(User.class);
+    PartnerImpl loggedInUserPartner = mock(PartnerImpl.class);
+
+    when(loggedInUser.getPartner()).thenReturn(loggedInUserPartner);
+    when(loggedInUserPartner.isSourcePartner()).thenReturn(true);
+    when(loggedInUserPartner.getId()).thenReturn(123L);
+    when(loggedInUser.getId()).thenReturn(42L);
+    when(loggedInUserPartner.getDefaultContact()).thenReturn(defaultContact);
+    when(defaultContact.getId()).thenReturn(42L);
+
+    stubCandidatePartnerJoin();
+    doReturn(jobOppJoin).when(opp).join("jobOpp");
+
+    when(cb.disjunction()).thenReturn(emptyDisjunction);
+    when(cb.or(any(Predicate.class), any(Predicate.class))).thenReturn(nonEmptyDisjunction);
+    when(nonEmptyDisjunction.getExpressions()).thenReturn(List.of(disjunctionExpression));
+    when(cb.and(any(Predicate.class), any(Predicate.class))).thenReturn(conjunction);
+
+    Predicate result = toPredicate(request, loggedInUser);
+
+    assertEquals(conjunction, result);
+    verify(query).subquery(User.class);
+  }
+
+  @Test
+  @DisplayName("should skip source partner owned by me final disjunction when it is empty")
+  void buildSearchQuery_shouldSkipSourcePartnerOwnedByMeFinalDisjunctionWhenEmpty() {
+    stubNonCountQuery();
+
+    SearchCandidateOpportunityRequest request = new SearchCandidateOpportunityRequest();
+    request.setOwnershipType(OpportunityOwnershipType.AS_SOURCE_PARTNER);
+    request.setOwnedByMe(true);
+
+    User loggedInUser = mock(User.class);
+    PartnerImpl loggedInUserPartner = mock(PartnerImpl.class);
+
+    when(loggedInUser.getPartner()).thenReturn(loggedInUserPartner);
+    when(loggedInUserPartner.isSourcePartner()).thenReturn(true);
+    when(loggedInUserPartner.getId()).thenReturn(123L);
+    when(loggedInUser.getId()).thenReturn(42L);
+    when(loggedInUserPartner.getDefaultContact()).thenReturn(null);
+
+    stubCandidatePartnerJoin();
+    doReturn(jobOppJoin).when(opp).join("jobOpp");
+
+    when(cb.disjunction()).thenReturn(emptyDisjunction);
+    when(cb.or(any(Predicate.class), any(Predicate.class))).thenReturn(emptyDisjunction);
+    when(emptyDisjunction.getExpressions()).thenReturn(List.of());
+    when(cb.and(any(Predicate.class), any(Predicate.class))).thenReturn(conjunction);
+
+    Predicate result = toPredicate(request, loggedInUser);
+
+    assertEquals(conjunction, result);
+  }
+
+  @Test
+  @DisplayName("should skip source partner owned by me when flag is false")
+  void buildSearchQuery_shouldSkipSourcePartnerOwnedByMe_whenFlagFalse() {
+    stubNonCountQuery();
+
+    SearchCandidateOpportunityRequest request = new SearchCandidateOpportunityRequest();
+    request.setOwnershipType(OpportunityOwnershipType.AS_SOURCE_PARTNER);
+    request.setOwnedByMyPartner(false);
+    request.setOwnedByMe(false);
+
+    User loggedInUser = mock(User.class);
+    PartnerImpl loggedInUserPartner = mock(PartnerImpl.class);
+
+    when(loggedInUser.getPartner()).thenReturn(loggedInUserPartner);
+    when(loggedInUserPartner.isSourcePartner()).thenReturn(true);
+
+    Predicate result = toPredicate(request, loggedInUser);
+
+    assertEquals(conjunction, result);
+    verify(opp, never()).join("candidate");
+  }
+
+  private Predicate toPredicate(SearchCandidateOpportunityRequest request, User loggedInUser) {
+    Specification<CandidateOpportunity> specification =
+        CandidateOpportunitySpecification.buildSearchQuery(request, loggedInUser);
+
+    return specification.toPredicate(opp, query, cb);
+  }
+
+  private void stubNonCountQuery() {
+    when(query.getResultType()).thenReturn(CandidateOpportunity.class);
+    when(cb.conjunction()).thenReturn(conjunction);
+    when(opp.get("id")).thenReturn(idPath);
+    when(cb.desc(idPath)).thenReturn(idOrder);
+    when(query.orderBy(anyList())).thenReturn(query);
+  }
+
+  private void stubCandidatePartnerJoin() {
+    doReturn(candidateJoin).when(opp).join("candidate");
+    doReturn(userJoin).when(candidateJoin).join("user");
+    doReturn(partnerJoin).when(userJoin).join("partner");
+  }
+}

--- a/server/src/test/java/org/tctalent/server/repository/db/CandidateSpecificationTest.java
+++ b/server/src/test/java/org/tctalent/server/repository/db/CandidateSpecificationTest.java
@@ -16,31 +16,11 @@
 
 package org.tctalent.server.repository.db;
 
-/*
- * Copyright (c) 2026 Talent Catalog.
- *
- * This program is free software: you can redistribute it and/or modify it under
- * the terms of the GNU General Public License as published by the Free
- * Software Foundation, either version 3 of the License, or any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
- * for more details.
- *
- * You should have received a copy of the GNU General Public License.
- * If not, see https://www.gnu.org/licenses/.
- */
-
-
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.withSettings;
 
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
@@ -55,6 +35,10 @@ import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.tctalent.server.model.db.Candidate;
 import org.tctalent.server.model.db.CandidateFilterByOpps;
 import org.tctalent.server.model.db.CandidateStatus;
@@ -65,7 +49,47 @@ import org.tctalent.server.model.db.UnhcrStatus;
 import org.tctalent.server.model.db.User;
 import org.tctalent.server.request.candidate.SearchCandidateRequest;
 
+@ExtendWith(MockitoExtension.class)
 class CandidateSpecificationTest {
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private Root<Candidate> candidate;
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private CriteriaQuery<Candidate> query;
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private CriteriaQuery<Long> countQuery;
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private CriteriaBuilder cb;
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private JoinFetch userFetch;
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private JoinFetch partnerFetch;
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private JoinFetch nationalityFetch;
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private JoinFetch countryFetch;
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private JoinFetch maxEducationLevelFetch;
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private Predicate conjunction;
+
+  @Mock
+  private Candidate excludedCandidate;
+
+  @Mock
+  private User loggedInUser;
+
+  @Mock
+  private Country sourceCountry;
 
   @Test
   @DisplayName("should cover default constructor")
@@ -78,9 +102,11 @@ class CandidateSpecificationTest {
   void buildSearchQuery_shouldThrow_whenCriteriaQueryIsNull() {
     SearchCandidateRequest request = new SearchCandidateRequest();
 
+    when(cb.conjunction()).thenReturn(conjunction);
+
     assertThrows(IllegalArgumentException.class,
         () -> CandidateSpecification.buildSearchQuery(request, null, null)
-            .toPredicate(mockCandidateRoot(), null, mockCriteriaBuilder()));
+            .toPredicate(candidate, null, cb));
   }
 
   @Test
@@ -124,8 +150,6 @@ class CandidateSpecificationTest {
     request.setListAllIds(List.of(9L, 10L));
     request.setCandidateFilterByOpps(CandidateFilterByOpps.someOpps);
 
-    Candidate excludedCandidate = mock(Candidate.class);
-
     assertNotNull(runNonCount(request, null, List.of(excludedCandidate)));
   }
 
@@ -134,7 +158,7 @@ class CandidateSpecificationTest {
   void buildSearchQuery_shouldBuildCountQuery() {
     SearchCandidateRequest request = new SearchCandidateRequest();
 
-    assertNotNull(runCount(request, null, null));
+    assertNotNull(runCount(request));
   }
 
   @Test
@@ -164,8 +188,7 @@ class CandidateSpecificationTest {
   void buildSearchQuery_shouldLimitByLoggedInUserSourceCountries() {
     SearchCandidateRequest request = new SearchCandidateRequest();
 
-    User loggedInUser = mock(User.class);
-    when(loggedInUser.getSourceCountries()).thenReturn(Set.of(mock(Country.class)));
+    when(loggedInUser.getSourceCountries()).thenReturn(Set.of(sourceCountry));
 
     assertNotNull(runNonCount(request, loggedInUser, null));
   }
@@ -175,7 +198,6 @@ class CandidateSpecificationTest {
   void buildSearchQuery_shouldIgnoreSourceCountryLimitation_whenLoggedInUserHasNoSourceCountries() {
     SearchCandidateRequest request = new SearchCandidateRequest();
 
-    User loggedInUser = mock(User.class);
     when(loggedInUser.getSourceCountries()).thenReturn(Set.of());
 
     assertNotNull(runNonCount(request, loggedInUser, null));
@@ -342,73 +364,37 @@ class CandidateSpecificationTest {
         .toPredicate(context.candidate, context.query, context.cb);
   }
 
-  private Predicate runCount(
-      SearchCandidateRequest request,
-      User loggedInUser,
-      Collection<Candidate> excludedCandidates
-  ) {
+  private Predicate runCount(SearchCandidateRequest request) {
     CriteriaContext context = countContext();
 
-    return CandidateSpecification.buildSearchQuery(request, loggedInUser, excludedCandidates)
+    return CandidateSpecification.buildSearchQuery(request, null, null)
         .toPredicate(context.candidate, context.query, context.cb);
   }
 
   private CriteriaContext nonCountContext() {
-    Root<Candidate> candidate = mockCandidateRoot();
-    CriteriaQuery<Candidate> query = mock(CriteriaQuery.class, RETURNS_DEEP_STUBS);
-    CriteriaBuilder cb = mockCriteriaBuilder();
-
     when(query.getResultType()).thenReturn(Candidate.class);
-    stubFetchJoins(candidate);
+    when(cb.conjunction()).thenReturn(conjunction);
+    stubFetchJoins();
 
     return new CriteriaContext(candidate, query, cb);
   }
 
   private CriteriaContext countContext() {
-    Root<Candidate> candidate = mockCandidateRoot();
-    CriteriaQuery<Long> query = mock(CriteriaQuery.class, RETURNS_DEEP_STUBS);
-    CriteriaBuilder cb = mockCriteriaBuilder();
+    when(countQuery.getResultType()).thenReturn(Long.class);
+    when(cb.conjunction()).thenReturn(conjunction);
 
-    when(query.getResultType()).thenReturn(Long.class);
-
-    return new CriteriaContext(candidate, query, cb);
+    return new CriteriaContext(candidate, countQuery, cb);
   }
 
-  private CriteriaBuilder mockCriteriaBuilder() {
-    CriteriaBuilder cb = mock(CriteriaBuilder.class, RETURNS_DEEP_STUBS);
-    when(cb.conjunction()).thenReturn(mock(Predicate.class, RETURNS_DEEP_STUBS));
-    return cb;
+  private void stubFetchJoins() {
+    doReturn(userFetch).when(candidate).fetch("user", JoinType.INNER);
+    doReturn(partnerFetch).when(userFetch).fetch("partner", JoinType.INNER);
+    doReturn(nationalityFetch).when(candidate).fetch("nationality");
+    doReturn(countryFetch).when(candidate).fetch("country");
+    doReturn(maxEducationLevelFetch).when(candidate).fetch("maxEducationLevel");
   }
 
-  private Root<Candidate> mockCandidateRoot() {
-    return mock(Root.class, RETURNS_DEEP_STUBS);
-  }
-
-  private void stubFetchJoins(Root<Candidate> candidate) {
-    Join<Object, Object> user = mockJoinFetch();
-    Join<Object, Object> partner = mockJoinFetch();
-    Join<Object, Object> nationality = mockJoinFetch();
-    Join<Object, Object> country = mockJoinFetch();
-    Join<Object, Object> maxEducationLevel = mockJoinFetch();
-
-    doReturn(asFetch(user)).when(candidate).fetch("user", JoinType.INNER);
-    doReturn(asFetch(partner)).when(user).fetch("partner", JoinType.INNER);
-    doReturn(asFetch(nationality)).when(candidate).fetch("nationality");
-    doReturn(asFetch(country)).when(candidate).fetch("country");
-    doReturn(asFetch(maxEducationLevel)).when(candidate).fetch("maxEducationLevel");
-  }
-
-  private Join<Object, Object> mockJoinFetch() {
-    return mock(
-        Join.class,
-        withSettings()
-            .extraInterfaces(Fetch.class)
-            .defaultAnswer(RETURNS_DEEP_STUBS)
-    );
-  }
-
-  private Fetch<Object, Object> asFetch(Join<Object, Object> join) {
-    return (Fetch<Object, Object>) join;
+  private interface JoinFetch extends Join<Object, Object>, Fetch<Object, Object> {
   }
 
   private record CriteriaContext(

--- a/server/src/test/java/org/tctalent/server/repository/db/CandidateSpecificationTest.java
+++ b/server/src/test/java/org/tctalent/server/repository/db/CandidateSpecificationTest.java
@@ -1,0 +1,420 @@
+/*
+ * Copyright (c) 2026 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free
+ *  Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.repository.db;
+
+/*
+ * Copyright (c) 2026 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License.
+ * If not, see https://www.gnu.org/licenses/.
+ */
+
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Fetch;
+import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.JoinType;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import java.time.LocalDate;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.tctalent.server.model.db.Candidate;
+import org.tctalent.server.model.db.CandidateFilterByOpps;
+import org.tctalent.server.model.db.CandidateStatus;
+import org.tctalent.server.model.db.Country;
+import org.tctalent.server.model.db.Gender;
+import org.tctalent.server.model.db.SearchType;
+import org.tctalent.server.model.db.UnhcrStatus;
+import org.tctalent.server.model.db.User;
+import org.tctalent.server.request.candidate.SearchCandidateRequest;
+
+class CandidateSpecificationTest {
+
+  @Test
+  @DisplayName("should cover default constructor")
+  void constructor_shouldCreateInstance() {
+    assertNotNull(new CandidateSpecification());
+  }
+
+  @Test
+  @DisplayName("should throw when criteria query is null")
+  void buildSearchQuery_shouldThrow_whenCriteriaQueryIsNull() {
+    SearchCandidateRequest request = new SearchCandidateRequest();
+
+    assertThrows(IllegalArgumentException.class,
+        () -> CandidateSpecification.buildSearchQuery(request, null, null)
+            .toPredicate(mockCandidateRoot(), null, mockCriteriaBuilder()));
+  }
+
+  @Test
+  @DisplayName("should build non-count query with many positive filters")
+  void buildSearchQuery_shouldBuildNonCountQuery_withManyPositiveFilters() {
+    SearchCandidateRequest request = new SearchCandidateRequest();
+    request.setKeyword("Ehsan Developer");
+    request.setStatuses(List.of(CandidateStatus.active));
+    request.setOccupationIds(List.of(10L, 20L));
+    request.setMinYrs(2);
+    request.setMaxYrs(8);
+    request.setNationalityIds(List.of(1L));
+    request.setNationalitySearchType(SearchType.or);
+    request.setCountryIds(List.of(2L));
+    request.setCountrySearchType(SearchType.or);
+    request.setPartnerIds(List.of(3L));
+    request.setSurveyTypeIds(List.of(4L));
+    request.setRegoReferrerParam("referrer");
+    request.setRegoUtmCampaign("campaign");
+    request.setRegoUtmSource("source");
+    request.setRegoUtmMedium("medium");
+    request.setGender(Gender.male);
+    request.setTimezone("UTC");
+    request.setLastModifiedFrom(LocalDate.of(2026, 1, 1));
+    request.setLastModifiedTo(LocalDate.of(2026, 1, 31));
+    request.setMinAge(18);
+    request.setMaxAge(45);
+    request.setUnhcrStatuses(List.of(UnhcrStatus.RegisteredAsylum));
+    request.setMinEducationLevel(2);
+    request.setMaxEducationLevel(5);
+    request.setMiniIntakeCompleted(true);
+    request.setFullIntakeCompleted(true);
+    request.setPotentialDuplicate(true);
+    request.setEducationMajorIds(List.of(5L));
+    request.setEnglishMinWrittenLevel(3);
+    request.setEnglishMinSpokenLevel(4);
+    request.setOtherLanguageId(6L);
+    request.setOtherMinWrittenLevel(2);
+    request.setOtherMinSpokenLevel(3);
+    request.setListAnyIds(List.of(7L, 8L));
+    request.setListAllIds(List.of(9L, 10L));
+    request.setCandidateFilterByOpps(CandidateFilterByOpps.someOpps);
+
+    Candidate excludedCandidate = mock(Candidate.class);
+
+    assertNotNull(runNonCount(request, null, List.of(excludedCandidate)));
+  }
+
+  @Test
+  @DisplayName("should build count query")
+  void buildSearchQuery_shouldBuildCountQuery() {
+    SearchCandidateRequest request = new SearchCandidateRequest();
+
+    assertNotNull(runCount(request, null, null));
+  }
+
+  @Test
+  @DisplayName("should apply nationality and country default OR search when search type is null")
+  void buildSearchQuery_shouldApplyDefaultOrSearchTypes_whenSearchTypeNull() {
+    SearchCandidateRequest request = new SearchCandidateRequest();
+    request.setNationalityIds(List.of(1L));
+    request.setCountryIds(List.of(2L));
+
+    assertNotNull(runNonCount(request, null, null));
+  }
+
+  @Test
+  @DisplayName("should apply nationality and country NOT search")
+  void buildSearchQuery_shouldApplyNotSearchTypes() {
+    SearchCandidateRequest request = new SearchCandidateRequest();
+    request.setNationalityIds(List.of(1L));
+    request.setNationalitySearchType(SearchType.not);
+    request.setCountryIds(List.of(2L));
+    request.setCountrySearchType(SearchType.not);
+
+    assertNotNull(runNonCount(request, null, null));
+  }
+
+  @Test
+  @DisplayName("should limit country by logged-in user's source countries when no country ids are requested")
+  void buildSearchQuery_shouldLimitByLoggedInUserSourceCountries() {
+    SearchCandidateRequest request = new SearchCandidateRequest();
+
+    User loggedInUser = mock(User.class);
+    when(loggedInUser.getSourceCountries()).thenReturn(Set.of(mock(Country.class)));
+
+    assertNotNull(runNonCount(request, loggedInUser, null));
+  }
+
+  @Test
+  @DisplayName("should ignore source country limitation when logged-in user has no source countries")
+  void buildSearchQuery_shouldIgnoreSourceCountryLimitation_whenLoggedInUserHasNoSourceCountries() {
+    SearchCandidateRequest request = new SearchCandidateRequest();
+
+    User loggedInUser = mock(User.class);
+    when(loggedInUser.getSourceCountries()).thenReturn(Set.of());
+
+    assertNotNull(runNonCount(request, loggedInUser, null));
+  }
+
+  @Test
+  @DisplayName("should apply occupation filter without year bounds")
+  void buildSearchQuery_shouldApplyOccupationFilter_withoutYearBounds() {
+    SearchCandidateRequest request = new SearchCandidateRequest();
+    request.setOccupationIds(List.of(1L));
+
+    assertNotNull(runNonCount(request, null, null));
+  }
+
+  @Test
+  @DisplayName("should ignore blank registration tracking fields")
+  void buildSearchQuery_shouldIgnoreBlankRegistrationTrackingFields() {
+    SearchCandidateRequest request = new SearchCandidateRequest();
+    request.setRegoReferrerParam("   ");
+    request.setRegoUtmCampaign("   ");
+    request.setRegoUtmSource("   ");
+    request.setRegoUtmMedium("   ");
+
+    assertNotNull(runNonCount(request, null, null));
+  }
+
+  @Test
+  @DisplayName("should apply false intake completion filters")
+  void buildSearchQuery_shouldApplyFalseIntakeCompletionFilters() {
+    SearchCandidateRequest request = new SearchCandidateRequest();
+    request.setMiniIntakeCompleted(false);
+    request.setFullIntakeCompleted(false);
+
+    assertNotNull(runNonCount(request, null, null));
+  }
+
+  @Test
+  @DisplayName("should apply min education level only")
+  void buildSearchQuery_shouldApplyMinEducationLevelOnly() {
+    SearchCandidateRequest request = new SearchCandidateRequest();
+    request.setMinEducationLevel(3);
+
+    assertNotNull(runNonCount(request, null, null));
+  }
+
+  @Test
+  @DisplayName("should apply max education level only")
+  void buildSearchQuery_shouldApplyMaxEducationLevelOnly() {
+    SearchCandidateRequest request = new SearchCandidateRequest();
+    request.setMaxEducationLevel(5);
+
+    assertNotNull(runNonCount(request, null, null));
+  }
+
+  @Test
+  @DisplayName("should apply English written level only")
+  void buildSearchQuery_shouldApplyEnglishWrittenLevelOnly() {
+    SearchCandidateRequest request = new SearchCandidateRequest();
+    request.setEnglishMinWrittenLevel(3);
+
+    assertNotNull(runNonCount(request, null, null));
+  }
+
+  @Test
+  @DisplayName("should apply English spoken level only")
+  void buildSearchQuery_shouldApplyEnglishSpokenLevelOnly() {
+    SearchCandidateRequest request = new SearchCandidateRequest();
+    request.setEnglishMinSpokenLevel(3);
+
+    assertNotNull(runNonCount(request, null, null));
+  }
+
+  @Test
+  @DisplayName("should apply other language id only")
+  void buildSearchQuery_shouldApplyOtherLanguageIdOnly() {
+    SearchCandidateRequest request = new SearchCandidateRequest();
+    request.setOtherLanguageId(11L);
+
+    assertNotNull(runNonCount(request, null, null));
+  }
+
+  @Test
+  @DisplayName("should apply other language spoken level only")
+  void buildSearchQuery_shouldApplyOtherLanguageSpokenLevelOnly() {
+    SearchCandidateRequest request = new SearchCandidateRequest();
+    request.setOtherLanguageId(11L);
+    request.setOtherMinSpokenLevel(3);
+
+    assertNotNull(runNonCount(request, null, null));
+  }
+
+  @Test
+  @DisplayName("should apply other language written level only")
+  void buildSearchQuery_shouldApplyOtherLanguageWrittenLevelOnly() {
+    SearchCandidateRequest request = new SearchCandidateRequest();
+    request.setOtherLanguageId(11L);
+    request.setOtherMinWrittenLevel(3);
+
+    assertNotNull(runNonCount(request, null, null));
+  }
+
+  @Test
+  @DisplayName("should evaluate other spoken language condition without other language id")
+  void buildSearchQuery_shouldEvaluateOtherSpokenCondition_withoutOtherLanguageId() {
+    SearchCandidateRequest request = new SearchCandidateRequest();
+    request.setOtherMinSpokenLevel(3);
+
+    assertNotNull(runNonCount(request, null, null));
+  }
+
+  @Test
+  @DisplayName("should evaluate other written language condition without other language id")
+  void buildSearchQuery_shouldEvaluateOtherWrittenCondition_withoutOtherLanguageId() {
+    SearchCandidateRequest request = new SearchCandidateRequest();
+    request.setOtherMinWrittenLevel(3);
+
+    assertNotNull(runNonCount(request, null, null));
+  }
+
+  @Test
+  @DisplayName("should apply NOT list searches")
+  void buildSearchQuery_shouldApplyNotListSearches() {
+    SearchCandidateRequest request = new SearchCandidateRequest();
+    request.setListAnyIds(List.of(1L));
+    request.setListAnySearchType(SearchType.not);
+    request.setListAllIds(List.of(2L));
+    request.setListAllSearchType(SearchType.not);
+
+    assertNotNull(runNonCount(request, null, null));
+  }
+
+  @Test
+  @DisplayName("should apply all candidate opportunity filters")
+  void buildSearchQuery_shouldApplyAllCandidateOpportunityFilters() {
+    for (CandidateFilterByOpps filter : CandidateFilterByOpps.values()) {
+      SearchCandidateRequest request = new SearchCandidateRequest();
+      request.setCandidateFilterByOpps(filter);
+
+      assertNotNull(runNonCount(request, null, null));
+    }
+  }
+
+  @Test
+  @DisplayName("should mark query as distinct")
+  void buildSearchQuery_shouldMarkQueryAsDistinct() {
+    SearchCandidateRequest request = new SearchCandidateRequest();
+
+    CriteriaContext context = nonCountContext();
+
+    CandidateSpecification.buildSearchQuery(request, null, null)
+        .toPredicate(context.candidate, context.query, context.cb);
+
+    verify(context.query).distinct(true);
+  }
+
+  private Predicate runNonCount(
+      SearchCandidateRequest request,
+      User loggedInUser,
+      Collection<Candidate> excludedCandidates
+  ) {
+    CriteriaContext context = nonCountContext();
+
+    return CandidateSpecification.buildSearchQuery(request, loggedInUser, excludedCandidates)
+        .toPredicate(context.candidate, context.query, context.cb);
+  }
+
+  private Predicate runCount(
+      SearchCandidateRequest request,
+      User loggedInUser,
+      Collection<Candidate> excludedCandidates
+  ) {
+    CriteriaContext context = countContext();
+
+    return CandidateSpecification.buildSearchQuery(request, loggedInUser, excludedCandidates)
+        .toPredicate(context.candidate, context.query, context.cb);
+  }
+
+  private CriteriaContext nonCountContext() {
+    Root<Candidate> candidate = mockCandidateRoot();
+    CriteriaQuery<Candidate> query = mock(CriteriaQuery.class, RETURNS_DEEP_STUBS);
+    CriteriaBuilder cb = mockCriteriaBuilder();
+
+    when(query.getResultType()).thenReturn(Candidate.class);
+    stubFetchJoins(candidate);
+
+    return new CriteriaContext(candidate, query, cb);
+  }
+
+  private CriteriaContext countContext() {
+    Root<Candidate> candidate = mockCandidateRoot();
+    CriteriaQuery<Long> query = mock(CriteriaQuery.class, RETURNS_DEEP_STUBS);
+    CriteriaBuilder cb = mockCriteriaBuilder();
+
+    when(query.getResultType()).thenReturn(Long.class);
+
+    return new CriteriaContext(candidate, query, cb);
+  }
+
+  private CriteriaBuilder mockCriteriaBuilder() {
+    CriteriaBuilder cb = mock(CriteriaBuilder.class, RETURNS_DEEP_STUBS);
+    when(cb.conjunction()).thenReturn(mock(Predicate.class, RETURNS_DEEP_STUBS));
+    return cb;
+  }
+
+  private Root<Candidate> mockCandidateRoot() {
+    return mock(Root.class, RETURNS_DEEP_STUBS);
+  }
+
+  private void stubFetchJoins(Root<Candidate> candidate) {
+    Join<Object, Object> user = mockJoinFetch();
+    Join<Object, Object> partner = mockJoinFetch();
+    Join<Object, Object> nationality = mockJoinFetch();
+    Join<Object, Object> country = mockJoinFetch();
+    Join<Object, Object> maxEducationLevel = mockJoinFetch();
+
+    doReturn(asFetch(user)).when(candidate).fetch("user", JoinType.INNER);
+    doReturn(asFetch(partner)).when(user).fetch("partner", JoinType.INNER);
+    doReturn(asFetch(nationality)).when(candidate).fetch("nationality");
+    doReturn(asFetch(country)).when(candidate).fetch("country");
+    doReturn(asFetch(maxEducationLevel)).when(candidate).fetch("maxEducationLevel");
+  }
+
+  private Join<Object, Object> mockJoinFetch() {
+    return mock(
+        Join.class,
+        withSettings()
+            .extraInterfaces(Fetch.class)
+            .defaultAnswer(RETURNS_DEEP_STUBS)
+    );
+  }
+
+  private Fetch<Object, Object> asFetch(Join<Object, Object> join) {
+    return (Fetch<Object, Object>) join;
+  }
+
+  private record CriteriaContext(
+      Root<Candidate> candidate,
+      CriteriaQuery<?> query,
+      CriteriaBuilder cb
+  ) {
+  }
+}

--- a/server/src/test/java/org/tctalent/server/repository/db/CandidateSpecificationUtilTest.java
+++ b/server/src/test/java/org/tctalent/server/repository/db/CandidateSpecificationUtilTest.java
@@ -1,0 +1,408 @@
+/*
+ * Copyright (c) 2026 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free
+ *  Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.repository.db;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.Order;
+import jakarta.persistence.criteria.Path;
+import jakarta.persistence.criteria.Root;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Sort;
+import org.tctalent.server.model.db.Candidate;
+import org.tctalent.server.request.PagedSearchRequest;
+
+@ExtendWith(MockitoExtension.class)
+class CandidateSpecificationUtilTest {
+
+  @Mock private Root<Candidate> candidate;
+  @Mock private CriteriaBuilder cb;
+
+  @Mock private Join<Object, Object> user;
+  @Mock private Join<Object, Object> partner;
+  @Mock private Join<Object, Object> nationality;
+  @Mock private Join<Object, Object> country;
+  @Mock private Join<Object, Object> educationLevel;
+
+  @Mock private Path<Object> candidateIdPath;
+  @Mock private Path<Object> candidateNamePath;
+  @Mock private Path<Object> partnerNamePath;
+  @Mock private Path<Object> userFirstNamePath;
+  @Mock private Path<Object> nationalityNamePath;
+  @Mock private Path<Object> countryNamePath;
+  @Mock private Path<Object> educationLevelNamePath;
+
+  @Mock private Order candidateIdDescOrder;
+  @Mock private Order candidateNameAscOrder;
+  @Mock private Order partnerNameAscOrder;
+  @Mock private Order userFirstNameAscOrder;
+  @Mock private Order nationalityNameAscOrder;
+  @Mock private Order countryNameAscOrder;
+  @Mock private Order educationLevelNameAscOrder;
+  @Mock private Order candidateNameDescOrder;
+
+  @Test
+  @DisplayName("should cover default constructor")
+  void constructor_shouldCreateInstance() {
+    assertNotNull(new CandidateSpecificationUtil());
+  }
+
+  @Test
+  @DisplayName("should add stable id sort when sort fields are null")
+  void getOrderByOrders_shouldAddStableIdSort_whenSortFieldsAreNull() {
+    PagedSearchRequest request = new PagedSearchRequest();
+
+    when(candidate.<Object>get("id")).thenReturn(candidateIdPath);
+    when(cb.desc(candidateIdPath)).thenReturn(candidateIdDescOrder);
+
+    List<Order> result = CandidateSpecificationUtil.getOrderByOrders(
+        request,
+        candidate,
+        cb,
+        user,
+        partner,
+        nationality,
+        country,
+        educationLevel
+    );
+
+    assertEquals(List.of(candidateIdDescOrder), result);
+
+    verify(candidate).get("id");
+    verify(cb).desc(candidateIdPath);
+  }
+
+  @Test
+  @DisplayName("should sort candidate direct field ascending and add stable id sort")
+  void getOrderByOrders_shouldSortCandidateDirectFieldAscendingAndAddStableIdSort() {
+    PagedSearchRequest request = new PagedSearchRequest(
+        Sort.Direction.ASC,
+        new String[] {"name"}
+    );
+
+    when(candidate.<Object>get("name")).thenReturn(candidateNamePath);
+    when(cb.asc(candidateNamePath)).thenReturn(candidateNameAscOrder);
+
+    when(candidate.<Object>get("id")).thenReturn(candidateIdPath);
+    when(cb.desc(candidateIdPath)).thenReturn(candidateIdDescOrder);
+
+    List<Order> result = CandidateSpecificationUtil.getOrderByOrders(
+        request,
+        candidate,
+        cb,
+        user,
+        partner,
+        nationality,
+        country,
+        educationLevel
+    );
+
+    assertEquals(List.of(candidateNameAscOrder, candidateIdDescOrder), result);
+
+    verify(candidate).get("name");
+    verify(cb).asc(candidateNamePath);
+    verify(candidate).get("id");
+    verify(cb).desc(candidateIdPath);
+  }
+
+  @Test
+  @DisplayName("should sort candidate direct field descending and add stable id sort")
+  void getOrderByOrders_shouldSortCandidateDirectFieldDescendingAndAddStableIdSort() {
+    PagedSearchRequest request = new PagedSearchRequest(
+        Sort.Direction.DESC,
+        new String[] {"name"}
+    );
+
+    when(candidate.<Object>get("name")).thenReturn(candidateNamePath);
+    when(cb.desc(candidateNamePath)).thenReturn(candidateNameDescOrder);
+
+    when(candidate.<Object>get("id")).thenReturn(candidateIdPath);
+    when(cb.desc(candidateIdPath)).thenReturn(candidateIdDescOrder);
+
+    List<Order> result = CandidateSpecificationUtil.getOrderByOrders(
+        request,
+        candidate,
+        cb,
+        user,
+        partner,
+        nationality,
+        country,
+        educationLevel
+    );
+
+    assertEquals(List.of(candidateNameDescOrder, candidateIdDescOrder), result);
+
+    verify(candidate).get("name");
+    verify(cb).desc(candidateNamePath);
+    verify(candidate).get("id");
+    verify(cb).desc(candidateIdPath);
+  }
+
+  @Test
+  @DisplayName("should sort by id without adding extra stable id sort")
+  void getOrderByOrders_shouldSortByIdWithoutAddingExtraStableIdSort() {
+    PagedSearchRequest request = new PagedSearchRequest(
+        Sort.Direction.DESC,
+        new String[] {"id"}
+    );
+
+    when(candidate.<Object>get("id")).thenReturn(candidateIdPath);
+    when(cb.desc(candidateIdPath)).thenReturn(candidateIdDescOrder);
+
+    List<Order> result = CandidateSpecificationUtil.getOrderByOrders(
+        request,
+        candidate,
+        cb,
+        user,
+        partner,
+        nationality,
+        country,
+        educationLevel
+    );
+
+    assertEquals(List.of(candidateIdDescOrder), result);
+
+    verify(candidate).get("id");
+    verify(cb).desc(candidateIdPath);
+  }
+
+  @Test
+  @DisplayName("should sort using partner join for user partner field")
+  void getOrderByOrders_shouldSortUsingPartnerJoin() {
+    PagedSearchRequest request = new PagedSearchRequest(
+        Sort.Direction.ASC,
+        new String[] {"user.partner.name"}
+    );
+
+    when(partner.get("name")).thenReturn(partnerNamePath);
+    when(cb.asc(partnerNamePath)).thenReturn(partnerNameAscOrder);
+
+    when(candidate.<Object>get("id")).thenReturn(candidateIdPath);
+    when(cb.desc(candidateIdPath)).thenReturn(candidateIdDescOrder);
+
+    List<Order> result = CandidateSpecificationUtil.getOrderByOrders(
+        request,
+        candidate,
+        cb,
+        user,
+        partner,
+        nationality,
+        country,
+        educationLevel
+    );
+
+    assertEquals(List.of(partnerNameAscOrder, candidateIdDescOrder), result);
+
+    verify(partner).get("name");
+    verify(cb).asc(partnerNamePath);
+  }
+
+  @Test
+  @DisplayName("should sort using user join for user field")
+  void getOrderByOrders_shouldSortUsingUserJoin() {
+    PagedSearchRequest request = new PagedSearchRequest(
+        Sort.Direction.ASC,
+        new String[] {"user.firstName"}
+    );
+
+    when(user.get("firstName")).thenReturn(userFirstNamePath);
+    when(cb.asc(userFirstNamePath)).thenReturn(userFirstNameAscOrder);
+
+    when(candidate.<Object>get("id")).thenReturn(candidateIdPath);
+    when(cb.desc(candidateIdPath)).thenReturn(candidateIdDescOrder);
+
+    List<Order> result = CandidateSpecificationUtil.getOrderByOrders(
+        request,
+        candidate,
+        cb,
+        user,
+        partner,
+        nationality,
+        country,
+        educationLevel
+    );
+
+    assertEquals(List.of(userFirstNameAscOrder, candidateIdDescOrder), result);
+
+    verify(user).get("firstName");
+    verify(cb).asc(userFirstNamePath);
+  }
+
+  @Test
+  @DisplayName("should sort using nationality join")
+  void getOrderByOrders_shouldSortUsingNationalityJoin() {
+    PagedSearchRequest request = new PagedSearchRequest(
+        Sort.Direction.ASC,
+        new String[] {"nationality.name"}
+    );
+
+    when(nationality.get("name")).thenReturn(nationalityNamePath);
+    when(cb.asc(nationalityNamePath)).thenReturn(nationalityNameAscOrder);
+
+    when(candidate.<Object>get("id")).thenReturn(candidateIdPath);
+    when(cb.desc(candidateIdPath)).thenReturn(candidateIdDescOrder);
+
+    List<Order> result = CandidateSpecificationUtil.getOrderByOrders(
+        request,
+        candidate,
+        cb,
+        user,
+        partner,
+        nationality,
+        country,
+        educationLevel
+    );
+
+    assertEquals(List.of(nationalityNameAscOrder, candidateIdDescOrder), result);
+
+    verify(nationality).get("name");
+    verify(cb).asc(nationalityNamePath);
+  }
+
+  @Test
+  @DisplayName("should sort using country join")
+  void getOrderByOrders_shouldSortUsingCountryJoin() {
+    PagedSearchRequest request = new PagedSearchRequest(
+        Sort.Direction.ASC,
+        new String[] {"country.name"}
+    );
+
+    when(country.get("name")).thenReturn(countryNamePath);
+    when(cb.asc(countryNamePath)).thenReturn(countryNameAscOrder);
+
+    when(candidate.<Object>get("id")).thenReturn(candidateIdPath);
+    when(cb.desc(candidateIdPath)).thenReturn(candidateIdDescOrder);
+
+    List<Order> result = CandidateSpecificationUtil.getOrderByOrders(
+        request,
+        candidate,
+        cb,
+        user,
+        partner,
+        nationality,
+        country,
+        educationLevel
+    );
+
+    assertEquals(List.of(countryNameAscOrder, candidateIdDescOrder), result);
+
+    verify(country).get("name");
+    verify(cb).asc(countryNamePath);
+  }
+
+  @Test
+  @DisplayName("should sort using max education level join")
+  void getOrderByOrders_shouldSortUsingMaxEducationLevelJoin() {
+    PagedSearchRequest request = new PagedSearchRequest(
+        Sort.Direction.ASC,
+        new String[] {"maxEducationLevel.name"}
+    );
+
+    when(educationLevel.get("name")).thenReturn(educationLevelNamePath);
+    when(cb.asc(educationLevelNamePath)).thenReturn(educationLevelNameAscOrder);
+
+    when(candidate.<Object>get("id")).thenReturn(candidateIdPath);
+    when(cb.desc(candidateIdPath)).thenReturn(candidateIdDescOrder);
+
+    List<Order> result = CandidateSpecificationUtil.getOrderByOrders(
+        request,
+        candidate,
+        cb,
+        user,
+        partner,
+        nationality,
+        country,
+        educationLevel
+    );
+
+    assertEquals(List.of(educationLevelNameAscOrder, candidateIdDescOrder), result);
+
+    verify(educationLevel).get("name");
+    verify(cb).asc(educationLevelNamePath);
+  }
+
+  @Test
+  @DisplayName("should sort multiple fields and add stable id sort once")
+  void getOrderByOrders_shouldSortMultipleFieldsAndAddStableIdSortOnce() {
+    PagedSearchRequest request = new PagedSearchRequest(
+        Sort.Direction.ASC,
+        new String[] {
+            "user.partner.name",
+            "user.firstName",
+            "nationality.name",
+            "country.name",
+            "maxEducationLevel.name",
+            "name"
+        }
+    );
+
+    when(partner.get("name")).thenReturn(partnerNamePath);
+    when(cb.asc(partnerNamePath)).thenReturn(partnerNameAscOrder);
+
+    when(user.get("firstName")).thenReturn(userFirstNamePath);
+    when(cb.asc(userFirstNamePath)).thenReturn(userFirstNameAscOrder);
+
+    when(nationality.get("name")).thenReturn(nationalityNamePath);
+    when(cb.asc(nationalityNamePath)).thenReturn(nationalityNameAscOrder);
+
+    when(country.get("name")).thenReturn(countryNamePath);
+    when(cb.asc(countryNamePath)).thenReturn(countryNameAscOrder);
+
+    when(educationLevel.get("name")).thenReturn(educationLevelNamePath);
+    when(cb.asc(educationLevelNamePath)).thenReturn(educationLevelNameAscOrder);
+
+    when(candidate.<Object>get("name")).thenReturn(candidateNamePath);
+    when(cb.asc(candidateNamePath)).thenReturn(candidateNameAscOrder);
+
+    when(candidate.<Object>get("id")).thenReturn(candidateIdPath);
+    when(cb.desc(candidateIdPath)).thenReturn(candidateIdDescOrder);
+
+    List<Order> result = CandidateSpecificationUtil.getOrderByOrders(
+        request,
+        candidate,
+        cb,
+        user,
+        partner,
+        nationality,
+        country,
+        educationLevel
+    );
+
+    assertEquals(
+        List.of(
+            partnerNameAscOrder,
+            userFirstNameAscOrder,
+            nationalityNameAscOrder,
+            countryNameAscOrder,
+            educationLevelNameAscOrder,
+            candidateNameAscOrder,
+            candidateIdDescOrder
+        ),
+        result
+    );
+  }
+}

--- a/server/src/test/java/org/tctalent/server/repository/db/CountrySpecificationTest.java
+++ b/server/src/test/java/org/tctalent/server/repository/db/CountrySpecificationTest.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2026 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free
+ *  Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.repository.db;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.Path;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tctalent.server.model.db.Country;
+import org.tctalent.server.model.db.Status;
+import org.tctalent.server.request.country.SearchCountryRequest;
+
+@ExtendWith(MockitoExtension.class)
+class CountrySpecificationTest {
+
+  @Mock private Root<Country> country;
+  @Mock private CriteriaQuery<?> query;
+  @Mock private CriteriaBuilder cb;
+
+  @Mock private Predicate conjunction;
+  @Mock private Predicate combinedPredicate;
+
+  @Mock private Path<String> namePath;
+  @Mock private Expression<String> lowerNamePath;
+  @Mock private Predicate nameLikePredicate;
+
+  @Mock private Path<Status> statusPath;
+  @Mock private Predicate statusPredicate;
+
+  @Test
+  @DisplayName("should cover default constructor")
+  void constructor_shouldCreateInstance() {
+    assertNotNull(new CountrySpecification());
+  }
+
+  @Test
+  @DisplayName("should throw when criteria query is null")
+  void buildSearchQuery_shouldThrow_whenCriteriaQueryIsNull() {
+    SearchCountryRequest request = new SearchCountryRequest();
+
+    assertThrows(IllegalArgumentException.class,
+        () -> CountrySpecification.buildSearchQuery(request)
+            .toPredicate(country, null, cb));
+  }
+
+  @Test
+  @DisplayName("should build base query when keyword and status are null")
+  void buildSearchQuery_shouldBuildBaseQuery_whenKeywordAndStatusAreNull() {
+    SearchCountryRequest request = new SearchCountryRequest();
+
+    when(cb.conjunction()).thenReturn(conjunction);
+
+    Predicate result = CountrySpecification.buildSearchQuery(request)
+        .toPredicate(country, query, cb);
+
+    assertEquals(conjunction, result);
+
+    verify(query).distinct(true);
+    verify(cb).conjunction();
+  }
+
+  @Test
+  @DisplayName("should build base query when keyword is blank")
+  void buildSearchQuery_shouldBuildBaseQuery_whenKeywordIsBlank() {
+    SearchCountryRequest request = new SearchCountryRequest();
+    request.setKeyword("   ");
+
+    when(cb.conjunction()).thenReturn(conjunction);
+
+    Predicate result = CountrySpecification.buildSearchQuery(request)
+        .toPredicate(country, query, cb);
+
+    assertEquals(conjunction, result);
+
+    verify(query).distinct(true);
+    verify(cb).conjunction();
+  }
+
+  @Test
+  @DisplayName("should apply keyword filter")
+  void buildSearchQuery_shouldApplyKeywordFilter() {
+    SearchCountryRequest request = new SearchCountryRequest();
+    request.setKeyword("Afghanistan");
+
+    stubBaseAnd();
+    stubKeyword("afghanistan");
+
+    Predicate result = CountrySpecification.buildSearchQuery(request)
+        .toPredicate(country, query, cb);
+
+    assertEquals(combinedPredicate, result);
+
+    verify(query).distinct(true);
+    verify(cb).like(lowerNamePath, "%afghanistan%");
+  }
+
+  @Test
+  @DisplayName("should apply status filter")
+  void buildSearchQuery_shouldApplyStatusFilter() {
+    SearchCountryRequest request = new SearchCountryRequest();
+    request.setStatus(Status.active);
+
+    stubBaseAnd();
+    stubStatus();
+
+    Predicate result = CountrySpecification.buildSearchQuery(request)
+        .toPredicate(country, query, cb);
+
+    assertEquals(combinedPredicate, result);
+
+    verify(query).distinct(true);
+    verify(cb).equal(statusPath, Status.active);
+  }
+
+  @Test
+  @DisplayName("should apply keyword and status filters")
+  void buildSearchQuery_shouldApplyKeywordAndStatusFilters() {
+    SearchCountryRequest request = new SearchCountryRequest();
+    request.setKeyword("Australia");
+    request.setStatus(Status.active);
+
+    stubBaseAnd();
+    stubKeyword("australia");
+    stubStatus();
+
+    Predicate result = CountrySpecification.buildSearchQuery(request)
+        .toPredicate(country, query, cb);
+
+    assertEquals(combinedPredicate, result);
+
+    verify(query).distinct(true);
+    verify(cb).like(lowerNamePath, "%australia%");
+    verify(cb).equal(statusPath, Status.active);
+  }
+
+  private void stubBaseAnd() {
+    when(cb.conjunction()).thenReturn(conjunction);
+    when(cb.and(any(Predicate.class), any(Predicate.class))).thenReturn(combinedPredicate);
+  }
+
+  private void stubKeyword(String lowerCaseKeyword) {
+    when(country.<String>get("name")).thenReturn(namePath);
+    when(cb.lower(namePath)).thenReturn(lowerNamePath);
+    when(cb.like(lowerNamePath, "%" + lowerCaseKeyword + "%"))
+        .thenReturn(nameLikePredicate);
+  }
+
+  private void stubStatus() {
+    when(country.<Status>get("status")).thenReturn(statusPath);
+    when(cb.equal(statusPath, Status.active)).thenReturn(statusPredicate);
+  }
+}

--- a/server/src/test/java/org/tctalent/server/repository/db/EducationLevelSpecificationTest.java
+++ b/server/src/test/java/org/tctalent/server/repository/db/EducationLevelSpecificationTest.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2026 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free
+ *  Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.repository.db;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.Path;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tctalent.server.model.db.EducationLevel;
+import org.tctalent.server.model.db.Status;
+import org.tctalent.server.request.education.level.SearchEducationLevelRequest;
+
+@ExtendWith(MockitoExtension.class)
+class EducationLevelSpecificationTest {
+
+  @Mock private Root<EducationLevel> educationLevel;
+  @Mock private CriteriaQuery<?> query;
+  @Mock private CriteriaBuilder cb;
+
+  @Mock private Predicate conjunction;
+  @Mock private Predicate combinedPredicate;
+
+  @Mock private Path<String> namePath;
+  @Mock private Expression<String> lowerNamePath;
+  @Mock private Predicate nameLikePredicate;
+
+  @Mock private Path<Status> statusPath;
+  @Mock private Predicate statusPredicate;
+
+  @Test
+  @DisplayName("should cover default constructor")
+  void constructor_shouldCreateInstance() {
+    assertNotNull(new EducationLevelSpecification());
+  }
+
+  @Test
+  @DisplayName("should throw when criteria query is null")
+  void buildSearchQuery_shouldThrow_whenCriteriaQueryIsNull() {
+    SearchEducationLevelRequest request = new SearchEducationLevelRequest();
+
+    // In this spec, cb.conjunction() is called before the null query check.
+    when(cb.conjunction()).thenReturn(conjunction);
+
+    assertThrows(IllegalArgumentException.class,
+        () -> EducationLevelSpecification.buildSearchQuery(request)
+            .toPredicate(educationLevel, null, cb));
+  }
+
+  @Test
+  @DisplayName("should build base query when keyword and status are null")
+  void buildSearchQuery_shouldBuildBaseQuery_whenKeywordAndStatusAreNull() {
+    SearchEducationLevelRequest request = new SearchEducationLevelRequest();
+
+    when(cb.conjunction()).thenReturn(conjunction);
+
+    Predicate result = EducationLevelSpecification.buildSearchQuery(request)
+        .toPredicate(educationLevel, query, cb);
+
+    assertEquals(conjunction, result);
+
+    verify(query).distinct(true);
+    verify(cb).conjunction();
+  }
+
+  @Test
+  @DisplayName("should build base query when keyword is blank")
+  void buildSearchQuery_shouldBuildBaseQuery_whenKeywordIsBlank() {
+    SearchEducationLevelRequest request = new SearchEducationLevelRequest();
+    request.setKeyword("   ");
+
+    when(cb.conjunction()).thenReturn(conjunction);
+
+    Predicate result = EducationLevelSpecification.buildSearchQuery(request)
+        .toPredicate(educationLevel, query, cb);
+
+    assertEquals(conjunction, result);
+
+    verify(query).distinct(true);
+    verify(cb).conjunction();
+  }
+
+  @Test
+  @DisplayName("should apply keyword filter")
+  void buildSearchQuery_shouldApplyKeywordFilter() {
+    SearchEducationLevelRequest request = new SearchEducationLevelRequest();
+    request.setKeyword("Bachelor Degree");
+
+    stubBaseAnd();
+    stubKeyword("bachelor degree");
+
+    Predicate result = EducationLevelSpecification.buildSearchQuery(request)
+        .toPredicate(educationLevel, query, cb);
+
+    assertEquals(combinedPredicate, result);
+
+    verify(query).distinct(true);
+    verify(cb).like(lowerNamePath, "%bachelor degree%");
+  }
+
+  @Test
+  @DisplayName("should apply status filter")
+  void buildSearchQuery_shouldApplyStatusFilter() {
+    SearchEducationLevelRequest request = new SearchEducationLevelRequest();
+    request.setStatus(Status.active);
+
+    stubBaseAnd();
+    stubStatus();
+
+    Predicate result = EducationLevelSpecification.buildSearchQuery(request)
+        .toPredicate(educationLevel, query, cb);
+
+    assertEquals(combinedPredicate, result);
+
+    verify(query).distinct(true);
+    verify(cb).equal(statusPath, Status.active);
+  }
+
+  @Test
+  @DisplayName("should apply keyword and status filters")
+  void buildSearchQuery_shouldApplyKeywordAndStatusFilters() {
+    SearchEducationLevelRequest request = new SearchEducationLevelRequest();
+    request.setKeyword("Master Degree");
+    request.setStatus(Status.active);
+
+    stubBaseAnd();
+    stubKeyword("master degree");
+    stubStatus();
+
+    Predicate result = EducationLevelSpecification.buildSearchQuery(request)
+        .toPredicate(educationLevel, query, cb);
+
+    assertEquals(combinedPredicate, result);
+
+    verify(query).distinct(true);
+    verify(cb).like(lowerNamePath, "%master degree%");
+    verify(cb).equal(statusPath, Status.active);
+  }
+
+  private void stubBaseAnd() {
+    when(cb.conjunction()).thenReturn(conjunction);
+    when(cb.and(any(Predicate.class), any(Predicate.class))).thenReturn(combinedPredicate);
+  }
+
+  private void stubKeyword(String lowerCaseKeyword) {
+    when(educationLevel.<String>get("name")).thenReturn(namePath);
+    when(cb.lower(namePath)).thenReturn(lowerNamePath);
+    when(cb.like(lowerNamePath, "%" + lowerCaseKeyword + "%"))
+        .thenReturn(nameLikePredicate);
+  }
+
+  private void stubStatus() {
+    when(educationLevel.<Status>get("status")).thenReturn(statusPath);
+    when(cb.equal(statusPath, Status.active)).thenReturn(statusPredicate);
+  }
+}

--- a/server/src/test/java/org/tctalent/server/repository/db/EducationMajorSpecificationTest.java
+++ b/server/src/test/java/org/tctalent/server/repository/db/EducationMajorSpecificationTest.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2026 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free
+ *  Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.repository.db;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.Path;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tctalent.server.model.db.EducationMajor;
+import org.tctalent.server.model.db.Status;
+import org.tctalent.server.request.education.major.SearchEducationMajorRequest;
+
+@ExtendWith(MockitoExtension.class)
+class EducationMajorSpecificationTest {
+
+  @Mock private Root<EducationMajor> educationMajor;
+  @Mock private CriteriaQuery<?> query;
+  @Mock private CriteriaBuilder cb;
+
+  @Mock private Predicate conjunction;
+  @Mock private Predicate combinedPredicate;
+
+  @Mock private Path<String> namePath;
+  @Mock private Expression<String> lowerNamePath;
+  @Mock private Predicate nameLikePredicate;
+
+  @Mock private Path<Status> statusPath;
+  @Mock private Predicate statusPredicate;
+
+  @Test
+  @DisplayName("should cover default constructor")
+  void constructor_shouldCreateInstance() {
+    assertNotNull(new EducationMajorSpecification());
+  }
+
+  @Test
+  @DisplayName("should throw when criteria query is null")
+  void buildSearchQuery_shouldThrow_whenCriteriaQueryIsNull() {
+    SearchEducationMajorRequest request = new SearchEducationMajorRequest();
+
+    when(cb.conjunction()).thenReturn(conjunction);
+
+    assertThrows(IllegalArgumentException.class,
+        () -> EducationMajorSpecification.buildSearchQuery(request)
+            .toPredicate(educationMajor, null, cb));
+  }
+
+  @Test
+  @DisplayName("should build base query when keyword and status are null")
+  void buildSearchQuery_shouldBuildBaseQuery_whenKeywordAndStatusAreNull() {
+    SearchEducationMajorRequest request = new SearchEducationMajorRequest();
+
+    when(cb.conjunction()).thenReturn(conjunction);
+
+    Predicate result = EducationMajorSpecification.buildSearchQuery(request)
+        .toPredicate(educationMajor, query, cb);
+
+    assertEquals(conjunction, result);
+
+    verify(query).distinct(true);
+    verify(cb).conjunction();
+  }
+
+  @Test
+  @DisplayName("should build base query when keyword is blank")
+  void buildSearchQuery_shouldBuildBaseQuery_whenKeywordIsBlank() {
+    SearchEducationMajorRequest request = new SearchEducationMajorRequest();
+    request.setKeyword("   ");
+
+    when(cb.conjunction()).thenReturn(conjunction);
+
+    Predicate result = EducationMajorSpecification.buildSearchQuery(request)
+        .toPredicate(educationMajor, query, cb);
+
+    assertEquals(conjunction, result);
+
+    verify(query).distinct(true);
+    verify(cb).conjunction();
+  }
+
+  @Test
+  @DisplayName("should apply keyword filter")
+  void buildSearchQuery_shouldApplyKeywordFilter() {
+    SearchEducationMajorRequest request = new SearchEducationMajorRequest();
+    request.setKeyword("Computer Science");
+
+    stubBaseAnd();
+    stubKeyword("computer science");
+
+    Predicate result = EducationMajorSpecification.buildSearchQuery(request)
+        .toPredicate(educationMajor, query, cb);
+
+    assertEquals(combinedPredicate, result);
+
+    verify(query).distinct(true);
+    verify(cb).like(lowerNamePath, "%computer science%");
+  }
+
+  @Test
+  @DisplayName("should apply status filter")
+  void buildSearchQuery_shouldApplyStatusFilter() {
+    SearchEducationMajorRequest request = new SearchEducationMajorRequest();
+    request.setStatus(Status.active);
+
+    stubBaseAnd();
+    stubStatus();
+
+    Predicate result = EducationMajorSpecification.buildSearchQuery(request)
+        .toPredicate(educationMajor, query, cb);
+
+    assertEquals(combinedPredicate, result);
+
+    verify(query).distinct(true);
+    verify(cb).equal(statusPath, Status.active);
+  }
+
+  @Test
+  @DisplayName("should apply keyword and status filters")
+  void buildSearchQuery_shouldApplyKeywordAndStatusFilters() {
+    SearchEducationMajorRequest request = new SearchEducationMajorRequest();
+    request.setKeyword("Software Engineering");
+    request.setStatus(Status.active);
+
+    stubBaseAnd();
+    stubKeyword("software engineering");
+    stubStatus();
+
+    Predicate result = EducationMajorSpecification.buildSearchQuery(request)
+        .toPredicate(educationMajor, query, cb);
+
+    assertEquals(combinedPredicate, result);
+
+    verify(query).distinct(true);
+    verify(cb).like(lowerNamePath, "%software engineering%");
+    verify(cb).equal(statusPath, Status.active);
+  }
+
+  private void stubBaseAnd() {
+    when(cb.conjunction()).thenReturn(conjunction);
+    when(cb.and(any(Predicate.class), any(Predicate.class))).thenReturn(combinedPredicate);
+  }
+
+  private void stubKeyword(String lowerCaseKeyword) {
+    when(educationMajor.<String>get("name")).thenReturn(namePath);
+    when(cb.lower(namePath)).thenReturn(lowerNamePath);
+    when(cb.like(lowerNamePath, "%" + lowerCaseKeyword + "%"))
+        .thenReturn(nameLikePredicate);
+  }
+
+  private void stubStatus() {
+    when(educationMajor.<Status>get("status")).thenReturn(statusPath);
+    when(cb.equal(statusPath, Status.active)).thenReturn(statusPredicate);
+  }
+}

--- a/server/src/test/java/org/tctalent/server/repository/db/GetCandidateSavedListsQueryTest.java
+++ b/server/src/test/java/org/tctalent/server/repository/db/GetCandidateSavedListsQueryTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2026 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free
+ *  Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.repository.db;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Path;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import jakarta.persistence.criteria.Subquery;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tctalent.server.model.db.CandidateSavedList;
+import org.tctalent.server.model.db.SavedList;
+
+@ExtendWith(MockitoExtension.class)
+class GetCandidateSavedListsQueryTest {
+
+  @Mock private Root<SavedList> savedList;
+  @Mock private CriteriaQuery<?> query;
+  @Mock private CriteriaBuilder cb;
+
+  @Mock private Subquery<SavedList> subquery;
+  @Mock private Root<CandidateSavedList> candidateSavedList;
+
+  @Mock private Path<SavedList> savedListPath;
+  @Mock private Path<Object> candidatePath;
+  @Mock private Path<Long> candidateIdPath;
+
+  @Mock private Predicate candidateIdPredicate;
+  @Mock private CriteriaBuilder.In<SavedList> inPredicate;
+
+  @Test
+  @DisplayName("should build subquery for saved lists belonging to candidate")
+  void toPredicate_shouldBuildSubqueryForCandidateSavedLists() {
+    long candidateId = 123L;
+
+    when(query.subquery(SavedList.class)).thenReturn(subquery);
+    when(subquery.from(CandidateSavedList.class)).thenReturn(candidateSavedList);
+
+    when(candidateSavedList.<SavedList>get("savedList")).thenReturn(savedListPath);
+    when(candidateSavedList.<Object>get("candidate")).thenReturn(candidatePath);
+    when(candidatePath.<Long>get("id")).thenReturn(candidateIdPath);
+
+    when(cb.equal(candidateIdPath, candidateId)).thenReturn(candidateIdPredicate);
+    when(subquery.select(savedListPath)).thenReturn(subquery);
+    when(subquery.where(candidateIdPredicate)).thenReturn(subquery);
+
+    when(cb.in(savedList)).thenReturn(inPredicate);
+    when(inPredicate.value(subquery)).thenReturn(inPredicate);
+
+    Predicate result = new GetCandidateSavedListsQuery(candidateId)
+        .toPredicate(savedList, query, cb);
+
+    assertEquals(inPredicate, result);
+
+    verify(query).subquery(SavedList.class);
+    verify(subquery).from(CandidateSavedList.class);
+    verify(subquery).select(savedListPath);
+    verify(subquery).where(candidateIdPredicate);
+    verify(cb).equal(candidateIdPath, candidateId);
+    verify(cb).in(savedList);
+    verify(inPredicate).value(subquery);
+  }
+}

--- a/server/src/test/java/org/tctalent/server/repository/db/GetSavedListCandidatesQueryTest.java
+++ b/server/src/test/java/org/tctalent/server/repository/db/GetSavedListCandidatesQueryTest.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright (c) 2026 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free
+ *  Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.repository.db;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Fetch;
+import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.JoinType;
+import jakarta.persistence.criteria.Root;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tctalent.server.model.db.Candidate;
+import org.tctalent.server.model.db.CandidateOpportunity;
+import org.tctalent.server.model.db.CandidateSavedList;
+import org.tctalent.server.model.db.SalesforceJobOpp;
+import org.tctalent.server.model.db.SavedList;
+import org.tctalent.server.request.candidate.SavedListGetRequest;
+
+@ExtendWith(MockitoExtension.class)
+class GetSavedListCandidatesQueryTest {
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private Root<Candidate> candidate;
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private CriteriaQuery<Candidate> query;
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private CriteriaQuery<Long> countQuery;
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private CriteriaBuilder cb;
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private Root<CandidateSavedList> candidateSavedList;
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private Join<Candidate, CandidateOpportunity> candidateOpportunity;
+
+  @Mock
+  private SavedList savedList;
+
+  @Mock
+  private SalesforceJobOpp sfJobOpp;
+
+  @Mock
+  private JoinFetch userFetch;
+
+  @Mock
+  private JoinFetch partnerFetch;
+
+  @Mock
+  private JoinFetch nationalityFetch;
+
+  @Mock
+  private JoinFetch countryFetch;
+
+  @Mock
+  private JoinFetch educationLevelFetch;
+
+  @Test
+  @DisplayName("should throw when criteria query is null")
+  void toPredicate_shouldThrow_whenCriteriaQueryIsNull() {
+    SavedListGetRequest request = new SavedListGetRequest();
+
+    assertThrows(IllegalArgumentException.class,
+        () -> new GetSavedListCandidatesQuery(savedList, request)
+            .toPredicate(candidate, null, cb));
+  }
+
+  @Test
+  @DisplayName("should build non-count query and apply fetches and ordering")
+  void toPredicate_shouldBuildNonCountQueryAndApplyFetchesAndOrdering() {
+    SavedListGetRequest request = new SavedListGetRequest();
+
+    stubNonCountQuery();
+
+    assertNotNull(new GetSavedListCandidatesQuery(savedList, request)
+        .toPredicate(candidate, query, cb));
+
+    verify(candidate).fetch("user", JoinType.LEFT);
+    verify(userFetch).fetch("partner", JoinType.LEFT);
+    verify(candidate).fetch("nationality", JoinType.LEFT);
+    verify(candidate).fetch("country", JoinType.LEFT);
+    verify(candidate).fetch("maxEducationLevel", JoinType.LEFT);
+    verify(query).orderBy(anyList());
+  }
+
+  @Test
+  @DisplayName("should build count query without fetches and ordering")
+  void toPredicate_shouldBuildCountQueryWithoutFetchesAndOrdering() {
+    SavedListGetRequest request = new SavedListGetRequest();
+
+    when(countQuery.getResultType()).thenReturn(Long.class);
+    when(countQuery.subquery(Candidate.class).from(CandidateSavedList.class))
+        .thenReturn(candidateSavedList);
+
+    assertNotNull(new GetSavedListCandidatesQuery(savedList, request)
+        .toPredicate(candidate, countQuery, cb));
+
+    verify(candidate, never()).fetch("user", JoinType.LEFT);
+    verify(countQuery, never()).orderBy(anyList());
+  }
+
+  @Test
+  @DisplayName("should apply keyword filter")
+  void toPredicate_shouldApplyKeywordFilter() {
+    SavedListGetRequest request = new SavedListGetRequest();
+    request.setKeyword("Ehsan Candidate");
+
+    stubNonCountQuery();
+
+    assertNotNull(new GetSavedListCandidatesQuery(savedList, request)
+        .toPredicate(candidate, query, cb));
+
+    verify(cb).like(
+        cb.lower(candidate.get("candidateNumber")),
+        "%ehsan candidate%"
+    );
+    verify(cb).like(
+        cb.lower(candidate.get("user").get("firstName")),
+        "%ehsan candidate%"
+    );
+    verify(cb).like(
+        cb.lower(candidate.get("user").get("lastName")),
+        "%ehsan candidate%"
+    );
+  }
+
+  @Test
+  @DisplayName("should skip keyword filter when keyword is blank")
+  void toPredicate_shouldSkipKeywordFilterWhenKeywordIsBlank() {
+    SavedListGetRequest request = new SavedListGetRequest();
+    request.setKeyword("   ");
+
+    stubNonCountQuery();
+
+    assertNotNull(new GetSavedListCandidatesQuery(savedList, request)
+        .toPredicate(candidate, query, cb));
+
+    verify(candidate, never()).get("candidateNumber");
+  }
+
+  @Test
+  @DisplayName("should apply job filter and default open or won opportunity filter when show closed is null")
+  void toPredicate_shouldApplyJobFilterAndDefaultOppFilterWhenShowClosedIsNull() {
+    SavedListGetRequest request = new SavedListGetRequest();
+
+    stubNonCountQuery();
+    stubSavedListWithJob();
+
+    assertNotNull(new GetSavedListCandidatesQuery(savedList, request)
+        .toPredicate(candidate, query, cb));
+
+    verify(candidate).join("candidateOpportunities", JoinType.LEFT);
+    verify(candidateOpportunity).get("jobOpp");
+    verify(candidateOpportunity).get("closed");
+    verify(candidateOpportunity).get("won");
+  }
+
+  @Test
+  @DisplayName("should apply job filter and open or won opportunity filter when show closed is false")
+  void toPredicate_shouldApplyJobFilterAndDefaultOppFilterWhenShowClosedIsFalse() {
+    SavedListGetRequest request = new SavedListGetRequest();
+    request.setShowClosedOpps(false);
+
+    stubNonCountQuery();
+    stubSavedListWithJob();
+
+    assertNotNull(new GetSavedListCandidatesQuery(savedList, request)
+        .toPredicate(candidate, query, cb));
+
+    verify(candidate).join("candidateOpportunities", JoinType.LEFT);
+    verify(candidateOpportunity).get("jobOpp");
+    verify(candidateOpportunity).get("closed");
+    verify(candidateOpportunity).get("won");
+  }
+
+  @Test
+  @DisplayName("should apply job filter but skip closed opportunity filter when show closed is true")
+  void toPredicate_shouldApplyJobFilterButSkipClosedOppFilterWhenShowClosedIsTrue() {
+    SavedListGetRequest request = new SavedListGetRequest();
+    request.setShowClosedOpps(true);
+
+    stubNonCountQuery();
+    stubSavedListWithJob();
+
+    assertNotNull(new GetSavedListCandidatesQuery(savedList, request)
+        .toPredicate(candidate, query, cb));
+
+    verify(candidate).join("candidateOpportunities", JoinType.LEFT);
+    verify(candidateOpportunity).get("jobOpp");
+    verify(candidateOpportunity, never()).get("closed");
+    verify(candidateOpportunity, never()).get("won");
+  }
+
+  @Test
+  @DisplayName("should skip job opportunity filtering when saved list has no job")
+  void toPredicate_shouldSkipJobOpportunityFilteringWhenSavedListHasNoJob() {
+    SavedListGetRequest request = new SavedListGetRequest();
+
+    stubNonCountQuery();
+
+    assertNotNull(new GetSavedListCandidatesQuery(savedList, request)
+        .toPredicate(candidate, query, cb));
+
+    verify(candidate, never()).join("candidateOpportunities", JoinType.LEFT);
+  }
+
+  private void stubNonCountQuery() {
+    when(query.getResultType()).thenReturn(Candidate.class);
+    when(query.subquery(Candidate.class).from(CandidateSavedList.class))
+        .thenReturn(candidateSavedList);
+
+    doReturn(userFetch).when(candidate).fetch("user", JoinType.LEFT);
+    doReturn(partnerFetch).when(userFetch).fetch("partner", JoinType.LEFT);
+    doReturn(nationalityFetch).when(candidate).fetch("nationality", JoinType.LEFT);
+    doReturn(countryFetch).when(candidate).fetch("country", JoinType.LEFT);
+    doReturn(educationLevelFetch).when(candidate).fetch("maxEducationLevel", JoinType.LEFT);
+  }
+
+  private void stubSavedListWithJob() {
+    when(savedList.getSfJobOpp()).thenReturn(sfJobOpp);
+    when(sfJobOpp.getId()).thenReturn(55L);
+    doReturn(candidateOpportunity)
+        .when(candidate).join("candidateOpportunities", JoinType.LEFT);
+  }
+
+  private interface JoinFetch extends Join<Object, Object>, Fetch<Object, Object> {
+  }
+}

--- a/server/src/test/java/org/tctalent/server/repository/db/GetSavedListsQueryTest.java
+++ b/server/src/test/java/org/tctalent/server/repository/db/GetSavedListsQueryTest.java
@@ -16,22 +16,6 @@
 
 package org.tctalent.server.repository.db;
 
-/*
- * Copyright (c) 2026 Talent Catalog.
- *
- * This program is free software: you can redistribute it and/or modify it under
- * the terms of the GNU General Public License as published by the Free
- * Software Foundation, either version 3 of the License, or any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
- * for more details.
- *
- * You should have received a copy of the GNU General Public License.
- * If not, see https://www.gnu.org/licenses/.
- */
-
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;

--- a/server/src/test/java/org/tctalent/server/repository/db/GetSavedListsQueryTest.java
+++ b/server/src/test/java/org/tctalent/server/repository/db/GetSavedListsQueryTest.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright (c) 2026 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free
+ *  Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.repository.db;
+
+/*
+ * Copyright (c) 2026 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License.
+ * If not, see https://www.gnu.org/licenses/.
+ */
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.JoinType;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tctalent.server.model.db.PartnerImpl;
+import org.tctalent.server.model.db.SavedList;
+import org.tctalent.server.model.db.User;
+import org.tctalent.server.request.list.SearchSavedListRequest;
+
+@ExtendWith(MockitoExtension.class)
+class GetSavedListsQueryTest {
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS) private Root<SavedList> savedList;
+  @Mock private CriteriaQuery<?> query;
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS) private CriteriaBuilder cb;
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS) private Join<Object, Object> jobOpp;
+
+  @Mock private Predicate disjunction;
+  @Mock private Expression<Boolean> disjunctionExpression;
+
+  @Mock private User loggedInUser;
+  @Mock private PartnerImpl loggedInUserPartner;
+  @Mock private SavedList sharedListOne;
+  @Mock private SavedList sharedListTwo;
+
+  @Test
+  @DisplayName("should throw when criteria query is null")
+  void toPredicate_shouldThrow_whenCriteriaQueryIsNull() {
+    SearchSavedListRequest request = new SearchSavedListRequest();
+
+    assertThrows(IllegalArgumentException.class,
+        () -> new GetSavedListsQuery(request, null)
+            .toPredicate(savedList, null, cb));
+  }
+
+  @Test
+  @DisplayName("should build base query for non-selection saved lists")
+  void toPredicate_shouldBuildBaseQueryForNonSelectionSavedLists() {
+    SearchSavedListRequest request = new SearchSavedListRequest();
+    stubBaseQueryWithEmptyDisjunction();
+
+    assertNotNull(new GetSavedListsQuery(request, null)
+        .toPredicate(savedList, query, cb));
+
+    verify(query).distinct(true);
+    verify(savedList).join("sfJobOpp", JoinType.LEFT);
+  }
+
+  @Test
+  @DisplayName("should apply keyword and all true filters")
+  void toPredicate_shouldApplyKeywordAndAllTrueFilters() {
+    SearchSavedListRequest request = new SearchSavedListRequest();
+    request.setKeyword("Developer List");
+    request.setFixed(true);
+    request.setRegisteredJob(true);
+    request.setSfOppClosed(true);
+    request.setShortName(true);
+    request.setGlobal(true);
+    request.setShared(true);
+    request.setOwnedByMyPartner(true);
+    request.setOwned(true);
+
+    when(loggedInUser.getSharedLists()).thenReturn(Set.of(sharedListOne, sharedListTwo));
+    when(sharedListOne.getId()).thenReturn(11L);
+    when(sharedListTwo.getId()).thenReturn(22L);
+
+    when(loggedInUser.getPartner()).thenReturn(loggedInUserPartner);
+    when(loggedInUserPartner.getId()).thenReturn(99L);
+    when(loggedInUser.getId()).thenReturn(42L);
+
+    stubBaseQueryWithNonEmptyDisjunction();
+
+    assertNotNull(new GetSavedListsQuery(request, loggedInUser)
+        .toPredicate(savedList, query, cb));
+
+    verify(query).distinct(true);
+    verify(savedList).join("sfJobOpp", JoinType.LEFT);
+    verify(loggedInUser).getSharedLists();
+    verify(loggedInUser).getPartner();
+    verify(loggedInUser).getId();
+    verify(loggedInUserPartner).getId();
+  }
+
+  @Test
+  @DisplayName("should apply false filters and short name false")
+  void toPredicate_shouldApplyFalseFiltersAndShortNameFalse() {
+    SearchSavedListRequest request = new SearchSavedListRequest();
+    request.setFixed(false);
+    request.setRegisteredJob(false);
+    request.setSfOppClosed(false);
+    request.setShortName(false);
+    request.setGlobal(false);
+    request.setShared(false);
+    request.setOwnedByMyPartner(false);
+    request.setOwned(false);
+
+    stubBaseQueryWithEmptyDisjunction();
+
+    assertNotNull(new GetSavedListsQuery(request, loggedInUser)
+        .toPredicate(savedList, query, cb));
+
+    verify(query).distinct(true);
+    verify(savedList).join("sfJobOpp", JoinType.LEFT);
+  }
+
+  @Test
+  @DisplayName("should skip shared owned and partner filters when user is null")
+  void toPredicate_shouldSkipUserFilters_whenLoggedInUserIsNull() {
+    SearchSavedListRequest request = new SearchSavedListRequest();
+    request.setShared(true);
+    request.setOwnedByMyPartner(true);
+    request.setOwned(true);
+
+    stubBaseQueryWithEmptyDisjunction();
+
+    assertNotNull(new GetSavedListsQuery(request, null)
+        .toPredicate(savedList, query, cb));
+
+    verify(query).distinct(true);
+    verify(savedList).join("sfJobOpp", JoinType.LEFT);
+  }
+
+  @Test
+  @DisplayName("should apply shared filter with empty shared lists")
+  void toPredicate_shouldApplySharedFilterWithEmptySharedLists() {
+    SearchSavedListRequest request = new SearchSavedListRequest();
+    request.setShared(true);
+
+    when(loggedInUser.getSharedLists()).thenReturn(Set.of());
+
+    stubBaseQueryWithNonEmptyDisjunction();
+
+    assertNotNull(new GetSavedListsQuery(request, loggedInUser)
+        .toPredicate(savedList, query, cb));
+
+    verify(loggedInUser).getSharedLists();
+  }
+
+  private void stubBaseQueryWithEmptyDisjunction() {
+    doReturn(jobOpp).when(savedList).join("sfJobOpp", JoinType.LEFT);
+    when(cb.disjunction()).thenReturn(disjunction);
+    when(disjunction.getExpressions()).thenReturn(List.of());
+  }
+
+  private void stubBaseQueryWithNonEmptyDisjunction() {
+    doReturn(jobOpp).when(savedList).join("sfJobOpp", JoinType.LEFT);
+    when(cb.disjunction()).thenReturn(disjunction);
+    when(cb.or(any(Predicate.class), any(Predicate.class))).thenReturn(disjunction);
+    when(disjunction.getExpressions()).thenReturn(List.of(disjunctionExpression));
+  }
+}

--- a/server/src/test/java/org/tctalent/server/repository/db/HelpLinkFetchSpecificationTest.java
+++ b/server/src/test/java/org/tctalent/server/repository/db/HelpLinkFetchSpecificationTest.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright (c) 2026 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free
+ *  Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.repository.db;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Path;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tctalent.server.model.db.CandidateOpportunityStage;
+import org.tctalent.server.model.db.HelpFocus;
+import org.tctalent.server.model.db.HelpLink;
+import org.tctalent.server.model.db.JobOpportunityStage;
+import org.tctalent.server.request.helplink.SearchHelpLinkRequest;
+
+@ExtendWith(MockitoExtension.class)
+class HelpLinkFetchSpecificationTest {
+
+  @Mock private Root<HelpLink> helpLink;
+  @Mock private CriteriaQuery<?> query;
+  @Mock private CriteriaBuilder cb;
+
+  @Mock private Predicate conjunction;
+  @Mock private Predicate combinedPredicate;
+
+  @Mock private Path<Object> countryPath;
+  @Mock private Path<Long> countryIdPath;
+  @Mock private Predicate countryPredicate;
+
+  @Mock private Path<CandidateOpportunityStage> caseStagePath;
+  @Mock private Predicate caseStagePredicate;
+
+  @Mock private Path<HelpFocus> focusPath;
+  @Mock private Predicate focusPredicate;
+
+  @Mock private Path<JobOpportunityStage> jobStagePath;
+  @Mock private Predicate jobStagePredicate;
+
+  @Mock private Path<Object> nextStepInfoPath;
+  @Mock private Path<String> nextStepNamePath;
+  @Mock private Predicate nextStepPredicate;
+
+  @Test
+  @DisplayName("should cover default constructor")
+  void constructor_shouldCreateInstance() {
+    assertNotNull(new HelpLinkFetchSpecification());
+  }
+
+  @Test
+  @DisplayName("should throw when criteria query is null")
+  void buildSearchQuery_shouldThrow_whenCriteriaQueryIsNull() {
+    SearchHelpLinkRequest request = new SearchHelpLinkRequest();
+
+    assertThrows(IllegalArgumentException.class,
+        () -> HelpLinkFetchSpecification.buildSearchQuery(request)
+            .toPredicate(helpLink, null, cb));
+  }
+
+  @Test
+  @DisplayName("should build base query when no filters are supplied")
+  void buildSearchQuery_shouldBuildBaseQuery_whenNoFiltersAreSupplied() {
+    SearchHelpLinkRequest request = new SearchHelpLinkRequest();
+
+    when(cb.conjunction()).thenReturn(conjunction);
+
+    Predicate result = HelpLinkFetchSpecification.buildSearchQuery(request)
+        .toPredicate(helpLink, query, cb);
+
+    assertEquals(conjunction, result);
+
+    verify(query).distinct(true);
+    verify(cb).conjunction();
+  }
+
+  @Test
+  @DisplayName("should apply all help link context filters")
+  void buildSearchQuery_shouldApplyAllHelpLinkContextFilters() {
+    SearchHelpLinkRequest request = new SearchHelpLinkRequest();
+    request.setCountryId(123L);
+    request.setCaseStage(CandidateOpportunityStage.prospect);
+    request.setFocus(HelpFocus.updateStage);
+    request.setJobStage(JobOpportunityStage.candidateSearch);
+    request.setNextStepName("Upload CV");
+
+    stubBaseAnd();
+
+    when(helpLink.<Object>get("country")).thenReturn(countryPath);
+    when(countryPath.<Long>get("id")).thenReturn(countryIdPath);
+    when(cb.equal(countryIdPath, 123L)).thenReturn(countryPredicate);
+
+    when(helpLink.<CandidateOpportunityStage>get("caseStage")).thenReturn(caseStagePath);
+    when(cb.equal(caseStagePath, CandidateOpportunityStage.prospect))
+        .thenReturn(caseStagePredicate);
+
+    when(helpLink.<HelpFocus>get("focus")).thenReturn(focusPath);
+    when(cb.equal(focusPath, HelpFocus.updateStage)).thenReturn(focusPredicate);
+
+    when(helpLink.<JobOpportunityStage>get("jobStage")).thenReturn(jobStagePath);
+    when(cb.equal(jobStagePath, JobOpportunityStage.candidateSearch))
+        .thenReturn(jobStagePredicate);
+
+    when(helpLink.<Object>get("nextStepInfo")).thenReturn(nextStepInfoPath);
+    when(nextStepInfoPath.<String>get("nextStepName")).thenReturn(nextStepNamePath);
+    when(cb.equal(nextStepNamePath, "Upload CV")).thenReturn(nextStepPredicate);
+
+    Predicate result = HelpLinkFetchSpecification.buildSearchQuery(request)
+        .toPredicate(helpLink, query, cb);
+
+    assertNotNull(result);
+
+    verify(query).distinct(true);
+    verify(cb).equal(countryIdPath, 123L);
+    verify(cb).equal(caseStagePath, CandidateOpportunityStage.prospect);
+    verify(cb).equal(focusPath, HelpFocus.updateStage);
+    verify(cb).equal(jobStagePath, JobOpportunityStage.candidateSearch);
+    verify(cb).equal(nextStepNamePath, "Upload CV");
+  }
+
+  @Test
+  @DisplayName("should apply country filter only")
+  void buildSearchQuery_shouldApplyCountryFilterOnly() {
+    SearchHelpLinkRequest request = new SearchHelpLinkRequest();
+    request.setCountryId(456L);
+
+    stubBaseAnd();
+
+    when(helpLink.<Object>get("country")).thenReturn(countryPath);
+    when(countryPath.<Long>get("id")).thenReturn(countryIdPath);
+    when(cb.equal(countryIdPath, 456L)).thenReturn(countryPredicate);
+
+    Predicate result = HelpLinkFetchSpecification.buildSearchQuery(request)
+        .toPredicate(helpLink, query, cb);
+
+    assertNotNull(result);
+
+    verify(query).distinct(true);
+    verify(cb).equal(countryIdPath, 456L);
+  }
+
+  @Test
+  @DisplayName("should apply case stage filter only")
+  void buildSearchQuery_shouldApplyCaseStageFilterOnly() {
+    SearchHelpLinkRequest request = new SearchHelpLinkRequest();
+    request.setCaseStage(CandidateOpportunityStage.relocated);
+
+    stubBaseAnd();
+
+    when(helpLink.<CandidateOpportunityStage>get("caseStage")).thenReturn(caseStagePath);
+    when(cb.equal(caseStagePath, CandidateOpportunityStage.relocated))
+        .thenReturn(caseStagePredicate);
+
+    Predicate result = HelpLinkFetchSpecification.buildSearchQuery(request)
+        .toPredicate(helpLink, query, cb);
+
+    assertNotNull(result);
+
+    verify(query).distinct(true);
+    verify(cb).equal(caseStagePath, CandidateOpportunityStage.relocated);
+  }
+
+  @Test
+  @DisplayName("should apply focus filter only")
+  void buildSearchQuery_shouldApplyFocusFilterOnly() {
+    SearchHelpLinkRequest request = new SearchHelpLinkRequest();
+    request.setFocus(HelpFocus.updateNextStep);
+
+    stubBaseAnd();
+
+    when(helpLink.<HelpFocus>get("focus")).thenReturn(focusPath);
+    when(cb.equal(focusPath, HelpFocus.updateNextStep)).thenReturn(focusPredicate);
+
+    Predicate result = HelpLinkFetchSpecification.buildSearchQuery(request)
+        .toPredicate(helpLink, query, cb);
+
+    assertNotNull(result);
+
+    verify(query).distinct(true);
+    verify(cb).equal(focusPath, HelpFocus.updateNextStep);
+  }
+
+  @Test
+  @DisplayName("should apply job stage filter only")
+  void buildSearchQuery_shouldApplyJobStageFilterOnly() {
+    SearchHelpLinkRequest request = new SearchHelpLinkRequest();
+    request.setJobStage(JobOpportunityStage.jobOffer);
+
+    stubBaseAnd();
+
+    when(helpLink.<JobOpportunityStage>get("jobStage")).thenReturn(jobStagePath);
+    when(cb.equal(jobStagePath, JobOpportunityStage.jobOffer)).thenReturn(jobStagePredicate);
+
+    Predicate result = HelpLinkFetchSpecification.buildSearchQuery(request)
+        .toPredicate(helpLink, query, cb);
+
+    assertNotNull(result);
+
+    verify(query).distinct(true);
+    verify(cb).equal(jobStagePath, JobOpportunityStage.jobOffer);
+  }
+
+  @Test
+  @DisplayName("should apply next step name filter only")
+  void buildSearchQuery_shouldApplyNextStepNameFilterOnly() {
+    SearchHelpLinkRequest request = new SearchHelpLinkRequest();
+    request.setNextStepName("Send contract");
+
+    stubBaseAnd();
+
+    when(helpLink.<Object>get("nextStepInfo")).thenReturn(nextStepInfoPath);
+    when(nextStepInfoPath.<String>get("nextStepName")).thenReturn(nextStepNamePath);
+    when(cb.equal(nextStepNamePath, "Send contract")).thenReturn(nextStepPredicate);
+
+    Predicate result = HelpLinkFetchSpecification.buildSearchQuery(request)
+        .toPredicate(helpLink, query, cb);
+
+    assertNotNull(result);
+
+    verify(query).distinct(true);
+    verify(cb).equal(nextStepNamePath, "Send contract");
+  }
+
+  private void stubBaseAnd() {
+    when(cb.conjunction()).thenReturn(conjunction);
+    when(cb.and(any(Predicate.class), any(Predicate.class))).thenReturn(combinedPredicate);
+  }
+}

--- a/server/src/test/java/org/tctalent/server/repository/db/HelpLinkSettingsSpecificationTest.java
+++ b/server/src/test/java/org/tctalent/server/repository/db/HelpLinkSettingsSpecificationTest.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) 2026 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free
+ *  Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.repository.db;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.Path;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tctalent.server.model.db.HelpLink;
+import org.tctalent.server.request.helplink.SearchHelpLinkRequest;
+
+@ExtendWith(MockitoExtension.class)
+class HelpLinkSettingsSpecificationTest {
+
+  @Mock private Root<HelpLink> helpLink;
+  @Mock private CriteriaQuery<?> query;
+  @Mock private CriteriaBuilder cb;
+
+  @Mock private Predicate conjunction;
+  @Mock private Predicate combinedPredicate;
+
+  @Mock private Path<String> labelPath;
+  @Mock private Path<String> linkPath;
+  @Mock private Expression<String> lowerLabelPath;
+  @Mock private Expression<String> lowerLinkPath;
+  @Mock private Predicate labelLikePredicate;
+  @Mock private Predicate linkLikePredicate;
+  @Mock private Predicate keywordPredicate;
+
+  @Mock private Path<Object> countryPath;
+  @Mock private Path<Long> countryIdPath;
+  @Mock private Predicate countryPredicate;
+
+  @Test
+  @DisplayName("should cover default constructor")
+  void constructor_shouldCreateInstance() {
+    assertNotNull(new HelpLinkSettingsSpecification());
+  }
+
+  @Test
+  @DisplayName("should throw when criteria query is null")
+  void buildSearchQuery_shouldThrow_whenCriteriaQueryIsNull() {
+    SearchHelpLinkRequest request = new SearchHelpLinkRequest();
+
+    assertThrows(IllegalArgumentException.class,
+        () -> HelpLinkSettingsSpecification.buildSearchQuery(request)
+            .toPredicate(helpLink, null, cb));
+  }
+
+  @Test
+  @DisplayName("should build base query when keyword and country are null")
+  void buildSearchQuery_shouldBuildBaseQuery_whenKeywordAndCountryAreNull() {
+    SearchHelpLinkRequest request = new SearchHelpLinkRequest();
+
+    when(cb.conjunction()).thenReturn(conjunction);
+
+    Predicate result = HelpLinkSettingsSpecification.buildSearchQuery(request)
+        .toPredicate(helpLink, query, cb);
+
+    assertEquals(conjunction, result);
+
+    verify(query).distinct(true);
+    verify(cb).conjunction();
+  }
+
+  @Test
+  @DisplayName("should build base query when keyword is blank")
+  void buildSearchQuery_shouldBuildBaseQuery_whenKeywordIsBlank() {
+    SearchHelpLinkRequest request = new SearchHelpLinkRequest();
+    request.setKeyword("   ");
+
+    when(cb.conjunction()).thenReturn(conjunction);
+
+    Predicate result = HelpLinkSettingsSpecification.buildSearchQuery(request)
+        .toPredicate(helpLink, query, cb);
+
+    assertEquals(conjunction, result);
+
+    verify(query).distinct(true);
+    verify(cb).conjunction();
+  }
+
+  @Test
+  @DisplayName("should apply keyword filter")
+  void buildSearchQuery_shouldApplyKeywordFilter() {
+    SearchHelpLinkRequest request = new SearchHelpLinkRequest();
+    request.setKeyword("Visa Help");
+
+    stubBaseAnd();
+    stubKeyword("visa help");
+
+    Predicate result = HelpLinkSettingsSpecification.buildSearchQuery(request)
+        .toPredicate(helpLink, query, cb);
+
+    assertEquals(combinedPredicate, result);
+
+    verify(query).distinct(true);
+    verify(cb).like(lowerLabelPath, "%visa help%");
+    verify(cb).like(lowerLinkPath, "%visa help%");
+  }
+
+  @Test
+  @DisplayName("should apply country filter")
+  void buildSearchQuery_shouldApplyCountryFilter() {
+    SearchHelpLinkRequest request = new SearchHelpLinkRequest();
+    request.setCountryId(123L);
+
+    stubBaseAnd();
+    stubCountry(123L);
+
+    Predicate result = HelpLinkSettingsSpecification.buildSearchQuery(request)
+        .toPredicate(helpLink, query, cb);
+
+    assertEquals(combinedPredicate, result);
+
+    verify(query).distinct(true);
+    verify(cb).equal(countryIdPath, 123L);
+  }
+
+  @Test
+  @DisplayName("should apply keyword and country filters")
+  void buildSearchQuery_shouldApplyKeywordAndCountryFilters() {
+    SearchHelpLinkRequest request = new SearchHelpLinkRequest();
+    request.setKeyword("Next Step");
+    request.setCountryId(456L);
+
+    stubBaseAnd();
+    stubKeyword("next step");
+    stubCountry(456L);
+
+    Predicate result = HelpLinkSettingsSpecification.buildSearchQuery(request)
+        .toPredicate(helpLink, query, cb);
+
+    assertEquals(combinedPredicate, result);
+
+    verify(query).distinct(true);
+    verify(cb).like(lowerLabelPath, "%next step%");
+    verify(cb).like(lowerLinkPath, "%next step%");
+    verify(cb).equal(countryIdPath, 456L);
+  }
+
+  private void stubBaseAnd() {
+    when(cb.conjunction()).thenReturn(conjunction);
+    when(cb.and(any(Predicate.class), any(Predicate.class))).thenReturn(combinedPredicate);
+  }
+
+  private void stubKeyword(String lowerCaseKeyword) {
+    when(helpLink.<String>get("label")).thenReturn(labelPath);
+    when(helpLink.<String>get("link")).thenReturn(linkPath);
+
+    when(cb.lower(labelPath)).thenReturn(lowerLabelPath);
+    when(cb.lower(linkPath)).thenReturn(lowerLinkPath);
+
+    when(cb.like(lowerLabelPath, "%" + lowerCaseKeyword + "%"))
+        .thenReturn(labelLikePredicate);
+    when(cb.like(lowerLinkPath, "%" + lowerCaseKeyword + "%"))
+        .thenReturn(linkLikePredicate);
+
+    when(cb.or(labelLikePredicate, linkLikePredicate)).thenReturn(keywordPredicate);
+  }
+
+  private void stubCountry(Long countryId) {
+    when(helpLink.<Object>get("country")).thenReturn(countryPath);
+    when(countryPath.<Long>get("id")).thenReturn(countryIdPath);
+    when(cb.equal(countryIdPath, countryId)).thenReturn(countryPredicate);
+  }
+}

--- a/server/src/test/java/org/tctalent/server/repository/db/IndustrySpecificationTest.java
+++ b/server/src/test/java/org/tctalent/server/repository/db/IndustrySpecificationTest.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2026 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free
+ *  Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.repository.db;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.Path;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tctalent.server.model.db.Industry;
+import org.tctalent.server.model.db.Status;
+import org.tctalent.server.request.industry.SearchIndustryRequest;
+
+@ExtendWith(MockitoExtension.class)
+class IndustrySpecificationTest {
+
+  @Mock private Root<Industry> industry;
+  @Mock private CriteriaQuery<?> query;
+  @Mock private CriteriaBuilder cb;
+
+  @Mock private Predicate conjunction;
+  @Mock private Predicate combinedPredicate;
+
+  @Mock private Path<String> namePath;
+  @Mock private Expression<String> lowerNamePath;
+  @Mock private Predicate nameLikePredicate;
+
+  @Mock private Path<Status> statusPath;
+  @Mock private Predicate statusPredicate;
+
+  @Test
+  @DisplayName("should cover default constructor")
+  void constructor_shouldCreateInstance() {
+    assertNotNull(new IndustrySpecification());
+  }
+
+  @Test
+  @DisplayName("should throw when criteria query is null")
+  void buildSearchQuery_shouldThrow_whenCriteriaQueryIsNull() {
+    SearchIndustryRequest request = new SearchIndustryRequest();
+
+    assertThrows(IllegalArgumentException.class,
+        () -> IndustrySpecification.buildSearchQuery(request)
+            .toPredicate(industry, null, cb));
+  }
+
+  @Test
+  @DisplayName("should build base query when keyword and status are null")
+  void buildSearchQuery_shouldBuildBaseQuery_whenKeywordAndStatusAreNull() {
+    SearchIndustryRequest request = new SearchIndustryRequest();
+
+    when(cb.conjunction()).thenReturn(conjunction);
+
+    Predicate result = IndustrySpecification.buildSearchQuery(request)
+        .toPredicate(industry, query, cb);
+
+    assertEquals(conjunction, result);
+
+    verify(query).distinct(true);
+    verify(cb).conjunction();
+  }
+
+  @Test
+  @DisplayName("should build base query when keyword is blank")
+  void buildSearchQuery_shouldBuildBaseQuery_whenKeywordIsBlank() {
+    SearchIndustryRequest request = new SearchIndustryRequest();
+    request.setKeyword("   ");
+
+    when(cb.conjunction()).thenReturn(conjunction);
+
+    Predicate result = IndustrySpecification.buildSearchQuery(request)
+        .toPredicate(industry, query, cb);
+
+    assertEquals(conjunction, result);
+
+    verify(query).distinct(true);
+    verify(cb).conjunction();
+  }
+
+  @Test
+  @DisplayName("should apply keyword filter")
+  void buildSearchQuery_shouldApplyKeywordFilter() {
+    SearchIndustryRequest request = new SearchIndustryRequest();
+    request.setKeyword("Information Technology");
+
+    stubBaseAnd();
+    stubKeyword("information technology");
+
+    Predicate result = IndustrySpecification.buildSearchQuery(request)
+        .toPredicate(industry, query, cb);
+
+    assertEquals(combinedPredicate, result);
+
+    verify(query).distinct(true);
+    verify(cb).like(lowerNamePath, "%information technology%");
+  }
+
+  @Test
+  @DisplayName("should apply status filter")
+  void buildSearchQuery_shouldApplyStatusFilter() {
+    SearchIndustryRequest request = new SearchIndustryRequest();
+    request.setStatus(Status.active);
+
+    stubBaseAnd();
+    stubStatus();
+
+    Predicate result = IndustrySpecification.buildSearchQuery(request)
+        .toPredicate(industry, query, cb);
+
+    assertEquals(combinedPredicate, result);
+
+    verify(query).distinct(true);
+    verify(cb).equal(statusPath, Status.active);
+  }
+
+  @Test
+  @DisplayName("should apply keyword and status filters")
+  void buildSearchQuery_shouldApplyKeywordAndStatusFilters() {
+    SearchIndustryRequest request = new SearchIndustryRequest();
+    request.setKeyword("Health Care");
+    request.setStatus(Status.active);
+
+    stubBaseAnd();
+    stubKeyword("health care");
+    stubStatus();
+
+    Predicate result = IndustrySpecification.buildSearchQuery(request)
+        .toPredicate(industry, query, cb);
+
+    assertEquals(combinedPredicate, result);
+
+    verify(query).distinct(true);
+    verify(cb).like(lowerNamePath, "%health care%");
+    verify(cb).equal(statusPath, Status.active);
+  }
+
+  private void stubBaseAnd() {
+    when(cb.conjunction()).thenReturn(conjunction);
+    when(cb.and(any(Predicate.class), any(Predicate.class))).thenReturn(combinedPredicate);
+  }
+
+  private void stubKeyword(String lowerCaseKeyword) {
+    when(industry.<String>get("name")).thenReturn(namePath);
+    when(cb.lower(namePath)).thenReturn(lowerNamePath);
+    when(cb.like(lowerNamePath, "%" + lowerCaseKeyword + "%"))
+        .thenReturn(nameLikePredicate);
+  }
+
+  private void stubStatus() {
+    when(industry.<Status>get("status")).thenReturn(statusPath);
+    when(cb.equal(statusPath, Status.active)).thenReturn(statusPredicate);
+  }
+}

--- a/server/src/test/java/org/tctalent/server/repository/db/JobSpecificationTest.java
+++ b/server/src/test/java/org/tctalent/server/repository/db/JobSpecificationTest.java
@@ -1,0 +1,325 @@
+/*
+ * Copyright (c) 2026 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free
+ *  Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.repository.db;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.Fetch;
+import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.JoinType;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import jakarta.persistence.criteria.Subquery;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Sort;
+import org.tctalent.server.model.db.JobOpportunityStage;
+import org.tctalent.server.model.db.PartnerImpl;
+import org.tctalent.server.model.db.SalesforceJobOpp;
+import org.tctalent.server.model.db.User;
+import org.tctalent.server.request.job.SearchJobRequest;
+import org.tctalent.server.util.SpecificationHelper;
+
+@ExtendWith(MockitoExtension.class)
+class JobSpecificationTest {
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private Root<SalesforceJobOpp> job;
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private CriteriaQuery<SalesforceJobOpp> query;
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private CriteriaQuery<Long> countQuery;
+
+  @Mock
+  private JoinFetch submissionList;
+
+  @Mock
+  private Expression<Boolean> disjunctionExpression;
+
+  @Test
+  @DisplayName("should cover default constructor")
+  void constructor_shouldCreateInstance() {
+    assertNotNull(new JobSpecification());
+  }
+
+  @Test
+  @DisplayName("should throw when criteria query is null")
+  void buildSearchQuery_shouldThrow_whenCriteriaQueryIsNull() {
+    SearchJobRequest request = new SearchJobRequest();
+
+    assertThrows(IllegalArgumentException.class,
+        () -> JobSpecification.buildSearchQuery(request, null)
+            .toPredicate(job, null, criteriaBuilder(true)));
+  }
+
+  @Test
+  @DisplayName("should build non-count query with stable id ordering")
+  void buildSearchQuery_shouldBuildNonCountQuery_withStableIdOrdering() {
+    CriteriaContext context = nonCountContext();
+
+    assertNotNull(JobSpecification.buildSearchQuery(new SearchJobRequest(), null)
+        .toPredicate(context.job, context.query, context.cb));
+
+    verify(context.job).fetch("submissionList", JoinType.INNER);
+    verify(context.query).orderBy(anyList());
+  }
+
+  @Test
+  @DisplayName("should build count query without fetch sorting")
+  void buildSearchQuery_shouldBuildCountQuery_withoutFetchSorting() {
+    CriteriaContext context = countContext();
+
+    assertNotNull(JobSpecification.buildSearchQuery(new SearchJobRequest(), null)
+        .toPredicate(context.job, context.query, context.cb));
+
+    verify(context.job, never()).fetch("submissionList", JoinType.INNER);
+    verify(context.query, never()).orderBy(anyList());
+  }
+
+  @Test
+  @DisplayName("should apply keyword, stage and destination filters")
+  void buildSearchQuery_shouldApplyKeywordStageAndDestinationFilters() {
+    SearchJobRequest request = new SearchJobRequest();
+    request.setKeyword("Developer Role");
+    request.setStages(List.of(JobOpportunityStage.candidateSearch, JobOpportunityStage.jobOffer));
+    request.setDestinationIds(List.of(1L, 2L));
+    request.setActiveStages(true);
+    request.setSfOppClosed(false);
+
+    assertNotNull(runNonCount(request, null));
+  }
+
+  @Test
+  @DisplayName("should apply active stages without closed or unpublished union")
+  void buildSearchQuery_shouldApplyActiveStagesOnly() {
+    SearchJobRequest request = new SearchJobRequest();
+    request.setActiveStages(true);
+    request.setSfOppClosed(false);
+    request.setPublished(true);
+
+    assertNotNull(runNonCount(request, null));
+  }
+
+  @Test
+  @DisplayName("should apply active stages with closed and unpublished union")
+  void buildSearchQuery_shouldApplyActiveStagesWithClosedAndUnpublishedUnion() {
+    SearchJobRequest request = new SearchJobRequest();
+    request.setActiveStages(true);
+    request.setSfOppClosed(true);
+    request.setPublished(false);
+
+    assertNotNull(runNonCount(request, null));
+  }
+
+  @Test
+  @DisplayName("should skip active stage disjunction when expression list is empty")
+  void buildSearchQuery_shouldSkipActiveDisjunction_whenExpressionListIsEmpty() {
+    SearchJobRequest request = new SearchJobRequest();
+    request.setActiveStages(true);
+
+    CriteriaContext context = nonCountContext(false);
+
+    assertNotNull(JobSpecification.buildSearchQuery(request, null)
+        .toPredicate(context.job, context.query, context.cb));
+  }
+
+  @Test
+  @DisplayName("should handle explicit false boolean filters")
+  void buildSearchQuery_shouldHandleExplicitFalseBooleanFilters() {
+    SearchJobRequest request = new SearchJobRequest();
+    request.setActiveStages(false);
+    request.setWithUnreadMessages(false);
+    request.setOwnedByMe(false);
+    request.setOwnedByMyPartner(false);
+    request.setStarred(false);
+    request.setSfOppClosed(false);
+
+    assertNotNull(runNonCount(request, null));
+  }
+
+  @Test
+  @DisplayName("should apply unread messages filter")
+  void buildSearchQuery_shouldApplyUnreadMessagesFilter() {
+    SearchJobRequest request = new SearchJobRequest();
+    request.setWithUnreadMessages(true);
+
+    User loggedInUser = mock(User.class);
+    Predicate unreadPredicate = mock(Predicate.class);
+
+    try (MockedStatic<SpecificationHelper> mockedHelper = mockStatic(SpecificationHelper.class)) {
+      mockedHelper.when(() -> SpecificationHelper.hasUnreadChats(
+          any(User.class),
+          any(CriteriaQuery.class),
+          any(CriteriaBuilder.class),
+          any(Subquery.class),
+          any(Root.class),
+          any(Predicate.class)
+      )).thenReturn(unreadPredicate);
+
+      assertNotNull(runNonCount(request, loggedInUser));
+    }
+  }
+
+  @Test
+  @DisplayName("should apply owned by me, owned by partner and starred filters")
+  void buildSearchQuery_shouldApplyOwnedAndStarredFilters() {
+    SearchJobRequest request = new SearchJobRequest();
+    request.setOwnedByMe(true);
+    request.setOwnedByMyPartner(true);
+    request.setStarred(true);
+
+    User loggedInUser = mock(User.class);
+    PartnerImpl loggedInUserPartner = mock(PartnerImpl.class);
+
+    when(loggedInUser.getId()).thenReturn(42L);
+    when(loggedInUser.getPartner()).thenReturn(loggedInUserPartner);
+    when(loggedInUserPartner.getId()).thenReturn(99L);
+
+    assertNotNull(runNonCount(request, loggedInUser));
+  }
+
+  @Test
+  @DisplayName("should skip ownership filters when logged in user is null")
+  void buildSearchQuery_shouldSkipOwnershipFilters_whenLoggedInUserIsNull() {
+    SearchJobRequest request = new SearchJobRequest();
+    request.setOwnedByMe(true);
+    request.setOwnedByMyPartner(true);
+    request.setStarred(true);
+
+    assertNotNull(runNonCount(request, null));
+  }
+
+  @Test
+  @DisplayName("should skip partner ownership when logged in user has no partner")
+  void buildSearchQuery_shouldSkipPartnerOwnership_whenUserHasNoPartner() {
+    SearchJobRequest request = new SearchJobRequest();
+    request.setOwnedByMyPartner(true);
+
+    User loggedInUser = mock(User.class);
+    when(loggedInUser.getPartner()).thenReturn(null);
+
+    assertNotNull(runNonCount(request, loggedInUser));
+  }
+
+  @Test
+  @DisplayName("should apply submission list ASC ordering and stable id ordering")
+  void buildSearchQuery_shouldApplySubmissionListAscOrderingAndStableIdOrdering() {
+    SearchJobRequest request = new SearchJobRequest();
+    request.setSortDirection(Sort.Direction.ASC);
+    request.setSortFields(new String[] {"submissionList.name", "name"});
+
+    assertNotNull(runNonCount(request, null));
+  }
+
+  @Test
+  @DisplayName("should apply id DESC ordering without extra stable id ordering")
+  void buildSearchQuery_shouldApplyIdDescOrderingWithoutExtraStableIdOrdering() {
+    SearchJobRequest request = new SearchJobRequest();
+    request.setSortDirection(Sort.Direction.DESC);
+    request.setSortFields(new String[] {"id"});
+
+    assertNotNull(runNonCount(request, null));
+  }
+
+  private Predicate runNonCount(SearchJobRequest request, User loggedInUser) {
+    CriteriaContext context = nonCountContext();
+
+    return JobSpecification.buildSearchQuery(request, loggedInUser)
+        .toPredicate(context.job, context.query, context.cb);
+  }
+
+  private CriteriaContext nonCountContext() {
+    return nonCountContext(true);
+  }
+
+  private CriteriaContext nonCountContext(boolean orHasExpressions) {
+    CriteriaBuilder localCb = criteriaBuilder(orHasExpressions);
+
+    when(query.getResultType()).thenReturn(SalesforceJobOpp.class);
+    doReturn(query).when(query).orderBy(anyList());
+    doReturn(submissionList).when(job).fetch("submissionList", JoinType.INNER);
+
+    return new CriteriaContext(job, query, localCb);
+  }
+
+  private CriteriaContext countContext() {
+    CriteriaBuilder localCb = criteriaBuilder(true);
+
+    when(countQuery.getResultType()).thenReturn(Long.class);
+
+    return new CriteriaContext(job, countQuery, localCb);
+  }
+
+  private CriteriaBuilder criteriaBuilder(boolean orHasExpressions) {
+    Predicate conjunction = predicateWithExpressions(false);
+    Predicate disjunction = predicateWithExpressions(false);
+    Predicate orPredicate = predicateWithExpressions(orHasExpressions);
+
+    return mock(CriteriaBuilder.class, invocation -> {
+      String methodName = invocation.getMethod().getName();
+
+      return switch (methodName) {
+        case "conjunction" -> conjunction;
+        case "disjunction" -> disjunction;
+        case "and" -> conjunction;
+        case "or" -> orPredicate;
+        default -> RETURNS_DEEP_STUBS.answer(invocation);
+      };
+    });
+  }
+
+  private Predicate predicateWithExpressions(boolean hasExpressions) {
+    return mock(Predicate.class, invocation -> {
+      if ("getExpressions".equals(invocation.getMethod().getName())) {
+        return hasExpressions ? List.of(disjunctionExpression) : List.of();
+      }
+
+      return RETURNS_DEEP_STUBS.answer(invocation);
+    });
+  }
+
+  private interface JoinFetch extends Join<Object, Object>, Fetch<Object, Object> {
+  }
+
+  private record CriteriaContext(
+      Root<SalesforceJobOpp> job,
+      CriteriaQuery<?> query,
+      CriteriaBuilder cb
+  ) {
+  }
+}

--- a/server/src/test/java/org/tctalent/server/repository/db/LanguageLevelSpecificationTest.java
+++ b/server/src/test/java/org/tctalent/server/repository/db/LanguageLevelSpecificationTest.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2026 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free
+ *  Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.repository.db;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.Path;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tctalent.server.model.db.LanguageLevel;
+import org.tctalent.server.model.db.Status;
+import org.tctalent.server.request.language.level.SearchLanguageLevelRequest;
+
+@ExtendWith(MockitoExtension.class)
+class LanguageLevelSpecificationTest {
+
+  @Mock private Root<LanguageLevel> languageLevel;
+  @Mock private CriteriaQuery<?> query;
+  @Mock private CriteriaBuilder cb;
+
+  @Mock private Predicate conjunction;
+  @Mock private Predicate combinedPredicate;
+
+  @Mock private Path<String> namePath;
+  @Mock private Expression<String> lowerNamePath;
+  @Mock private Predicate nameLikePredicate;
+
+  @Mock private Path<Status> statusPath;
+  @Mock private Predicate statusPredicate;
+
+  @Test
+  @DisplayName("should cover default constructor")
+  void constructor_shouldCreateInstance() {
+    assertNotNull(new LanguageLevelSpecification());
+  }
+
+  @Test
+  @DisplayName("should throw when criteria query is null")
+  void buildSearchQuery_shouldThrow_whenCriteriaQueryIsNull() {
+    SearchLanguageLevelRequest request = new SearchLanguageLevelRequest();
+
+    assertThrows(IllegalArgumentException.class,
+        () -> LanguageLevelSpecification.buildSearchQuery(request)
+            .toPredicate(languageLevel, null, cb));
+  }
+
+  @Test
+  @DisplayName("should build base query when keyword and status are null")
+  void buildSearchQuery_shouldBuildBaseQuery_whenKeywordAndStatusAreNull() {
+    SearchLanguageLevelRequest request = new SearchLanguageLevelRequest();
+
+    when(cb.conjunction()).thenReturn(conjunction);
+
+    Predicate result = LanguageLevelSpecification.buildSearchQuery(request)
+        .toPredicate(languageLevel, query, cb);
+
+    assertEquals(conjunction, result);
+
+    verify(query).distinct(true);
+    verify(cb).conjunction();
+  }
+
+  @Test
+  @DisplayName("should build base query when keyword is blank")
+  void buildSearchQuery_shouldBuildBaseQuery_whenKeywordIsBlank() {
+    SearchLanguageLevelRequest request = new SearchLanguageLevelRequest();
+    request.setKeyword("   ");
+
+    when(cb.conjunction()).thenReturn(conjunction);
+
+    Predicate result = LanguageLevelSpecification.buildSearchQuery(request)
+        .toPredicate(languageLevel, query, cb);
+
+    assertEquals(conjunction, result);
+
+    verify(query).distinct(true);
+    verify(cb).conjunction();
+  }
+
+  @Test
+  @DisplayName("should apply keyword filter")
+  void buildSearchQuery_shouldApplyKeywordFilter() {
+    SearchLanguageLevelRequest request = new SearchLanguageLevelRequest();
+    request.setKeyword("Fluent");
+
+    stubBaseAnd();
+    stubKeyword("fluent");
+
+    Predicate result = LanguageLevelSpecification.buildSearchQuery(request)
+        .toPredicate(languageLevel, query, cb);
+
+    assertEquals(combinedPredicate, result);
+
+    verify(query).distinct(true);
+    verify(cb).like(lowerNamePath, "%fluent%");
+  }
+
+  @Test
+  @DisplayName("should apply status filter")
+  void buildSearchQuery_shouldApplyStatusFilter() {
+    SearchLanguageLevelRequest request = new SearchLanguageLevelRequest();
+    request.setStatus(Status.active);
+
+    stubBaseAnd();
+    stubStatus();
+
+    Predicate result = LanguageLevelSpecification.buildSearchQuery(request)
+        .toPredicate(languageLevel, query, cb);
+
+    assertEquals(combinedPredicate, result);
+
+    verify(query).distinct(true);
+    verify(cb).equal(statusPath, Status.active);
+  }
+
+  @Test
+  @DisplayName("should apply keyword and status filters")
+  void buildSearchQuery_shouldApplyKeywordAndStatusFilters() {
+    SearchLanguageLevelRequest request = new SearchLanguageLevelRequest();
+    request.setKeyword("Intermediate");
+    request.setStatus(Status.active);
+
+    stubBaseAnd();
+    stubKeyword("intermediate");
+    stubStatus();
+
+    Predicate result = LanguageLevelSpecification.buildSearchQuery(request)
+        .toPredicate(languageLevel, query, cb);
+
+    assertEquals(combinedPredicate, result);
+
+    verify(query).distinct(true);
+    verify(cb).like(lowerNamePath, "%intermediate%");
+    verify(cb).equal(statusPath, Status.active);
+  }
+
+  private void stubBaseAnd() {
+    when(cb.conjunction()).thenReturn(conjunction);
+    when(cb.and(any(Predicate.class), any(Predicate.class))).thenReturn(combinedPredicate);
+  }
+
+  private void stubKeyword(String lowerCaseKeyword) {
+    when(languageLevel.<String>get("name")).thenReturn(namePath);
+    when(cb.lower(namePath)).thenReturn(lowerNamePath);
+    when(cb.like(lowerNamePath, "%" + lowerCaseKeyword + "%"))
+        .thenReturn(nameLikePredicate);
+  }
+
+  private void stubStatus() {
+    when(languageLevel.<Status>get("status")).thenReturn(statusPath);
+    when(cb.equal(statusPath, Status.active)).thenReturn(statusPredicate);
+  }
+}

--- a/server/src/test/java/org/tctalent/server/repository/db/LanguageSpecificationTest.java
+++ b/server/src/test/java/org/tctalent/server/repository/db/LanguageSpecificationTest.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2026 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free
+ *  Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.repository.db;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.Path;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tctalent.server.model.db.Language;
+import org.tctalent.server.model.db.Status;
+import org.tctalent.server.request.language.SearchLanguageRequest;
+
+@ExtendWith(MockitoExtension.class)
+class LanguageSpecificationTest {
+
+  @Mock private Root<Language> language;
+  @Mock private CriteriaQuery<?> query;
+  @Mock private CriteriaBuilder cb;
+
+  @Mock private Predicate conjunction;
+  @Mock private Predicate combinedPredicate;
+
+  @Mock private Path<String> namePath;
+  @Mock private Expression<String> lowerNamePath;
+  @Mock private Predicate nameLikePredicate;
+
+  @Mock private Path<Status> statusPath;
+  @Mock private Predicate statusPredicate;
+
+  @Test
+  @DisplayName("should cover default constructor")
+  void constructor_shouldCreateInstance() {
+    assertNotNull(new LanguageSpecification());
+  }
+
+  @Test
+  @DisplayName("should throw when criteria query is null")
+  void buildSearchQuery_shouldThrow_whenCriteriaQueryIsNull() {
+    SearchLanguageRequest request = new SearchLanguageRequest();
+
+    assertThrows(IllegalArgumentException.class,
+        () -> LanguageSpecification.buildSearchQuery(request)
+            .toPredicate(language, null, cb));
+  }
+
+  @Test
+  @DisplayName("should build base query when keyword and status are null")
+  void buildSearchQuery_shouldBuildBaseQuery_whenKeywordAndStatusAreNull() {
+    SearchLanguageRequest request = new SearchLanguageRequest();
+
+    when(cb.conjunction()).thenReturn(conjunction);
+
+    Predicate result = LanguageSpecification.buildSearchQuery(request)
+        .toPredicate(language, query, cb);
+
+    assertEquals(conjunction, result);
+
+    verify(query).distinct(true);
+    verify(cb).conjunction();
+  }
+
+  @Test
+  @DisplayName("should build base query when keyword is blank")
+  void buildSearchQuery_shouldBuildBaseQuery_whenKeywordIsBlank() {
+    SearchLanguageRequest request = new SearchLanguageRequest();
+    request.setKeyword("   ");
+
+    when(cb.conjunction()).thenReturn(conjunction);
+
+    Predicate result = LanguageSpecification.buildSearchQuery(request)
+        .toPredicate(language, query, cb);
+
+    assertEquals(conjunction, result);
+
+    verify(query).distinct(true);
+    verify(cb).conjunction();
+  }
+
+  @Test
+  @DisplayName("should apply keyword filter")
+  void buildSearchQuery_shouldApplyKeywordFilter() {
+    SearchLanguageRequest request = new SearchLanguageRequest();
+    request.setKeyword("English");
+
+    stubBaseAnd();
+    stubKeyword("english");
+
+    Predicate result = LanguageSpecification.buildSearchQuery(request)
+        .toPredicate(language, query, cb);
+
+    assertEquals(combinedPredicate, result);
+
+    verify(query).distinct(true);
+    verify(cb).like(lowerNamePath, "%english%");
+  }
+
+  @Test
+  @DisplayName("should apply status filter")
+  void buildSearchQuery_shouldApplyStatusFilter() {
+    SearchLanguageRequest request = new SearchLanguageRequest();
+    request.setStatus(Status.active);
+
+    stubBaseAnd();
+    stubStatus();
+
+    Predicate result = LanguageSpecification.buildSearchQuery(request)
+        .toPredicate(language, query, cb);
+
+    assertEquals(combinedPredicate, result);
+
+    verify(query).distinct(true);
+    verify(cb).equal(statusPath, Status.active);
+  }
+
+  @Test
+  @DisplayName("should apply keyword and status filters")
+  void buildSearchQuery_shouldApplyKeywordAndStatusFilters() {
+    SearchLanguageRequest request = new SearchLanguageRequest();
+    request.setKeyword("Dari");
+    request.setStatus(Status.active);
+
+    stubBaseAnd();
+    stubKeyword("dari");
+    stubStatus();
+
+    Predicate result = LanguageSpecification.buildSearchQuery(request)
+        .toPredicate(language, query, cb);
+
+    assertEquals(combinedPredicate, result);
+
+    verify(query).distinct(true);
+    verify(cb).like(lowerNamePath, "%dari%");
+    verify(cb).equal(statusPath, Status.active);
+  }
+
+  private void stubBaseAnd() {
+    when(cb.conjunction()).thenReturn(conjunction);
+    when(cb.and(any(Predicate.class), any(Predicate.class))).thenReturn(combinedPredicate);
+  }
+
+  private void stubKeyword(String lowerCaseKeyword) {
+    when(language.<String>get("name")).thenReturn(namePath);
+    when(cb.lower(namePath)).thenReturn(lowerNamePath);
+    when(cb.like(lowerNamePath, "%" + lowerCaseKeyword + "%"))
+        .thenReturn(nameLikePredicate);
+  }
+
+  private void stubStatus() {
+    when(language.<Status>get("status")).thenReturn(statusPath);
+    when(cb.equal(statusPath, Status.active)).thenReturn(statusPredicate);
+  }
+}

--- a/server/src/test/java/org/tctalent/server/repository/db/OccupationSpecificationTest.java
+++ b/server/src/test/java/org/tctalent/server/repository/db/OccupationSpecificationTest.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2026 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free
+ *  Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.repository.db;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.Path;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tctalent.server.model.db.Occupation;
+import org.tctalent.server.model.db.Status;
+import org.tctalent.server.request.occupation.SearchOccupationRequest;
+
+@ExtendWith(MockitoExtension.class)
+class OccupationSpecificationTest {
+
+  @Mock private Root<Occupation> occupation;
+  @Mock private CriteriaQuery<?> query;
+  @Mock private CriteriaBuilder cb;
+
+  @Mock private Predicate conjunction;
+  @Mock private Predicate combinedPredicate;
+
+  @Mock private Path<String> namePath;
+  @Mock private Expression<String> lowerNamePath;
+  @Mock private Predicate nameLikePredicate;
+
+  @Mock private Path<Status> statusPath;
+  @Mock private Predicate statusPredicate;
+
+  @Test
+  @DisplayName("should cover default constructor")
+  void constructor_shouldCreateInstance() {
+    assertNotNull(new OccupationSpecification());
+  }
+
+  @Test
+  @DisplayName("should throw when criteria query is null")
+  void buildSearchQuery_shouldThrow_whenCriteriaQueryIsNull() {
+    SearchOccupationRequest request = new SearchOccupationRequest();
+
+    assertThrows(IllegalArgumentException.class,
+        () -> OccupationSpecification.buildSearchQuery(request)
+            .toPredicate(occupation, null, cb));
+  }
+
+  @Test
+  @DisplayName("should build base query when keyword and status are null")
+  void buildSearchQuery_shouldBuildBaseQuery_whenKeywordAndStatusAreNull() {
+    SearchOccupationRequest request = new SearchOccupationRequest();
+
+    when(cb.conjunction()).thenReturn(conjunction);
+
+    Predicate result = OccupationSpecification.buildSearchQuery(request)
+        .toPredicate(occupation, query, cb);
+
+    assertEquals(conjunction, result);
+
+    verify(query).distinct(true);
+    verify(cb).conjunction();
+  }
+
+  @Test
+  @DisplayName("should build base query when keyword is blank")
+  void buildSearchQuery_shouldBuildBaseQuery_whenKeywordIsBlank() {
+    SearchOccupationRequest request = new SearchOccupationRequest();
+    request.setKeyword("   ");
+
+    when(cb.conjunction()).thenReturn(conjunction);
+
+    Predicate result = OccupationSpecification.buildSearchQuery(request)
+        .toPredicate(occupation, query, cb);
+
+    assertEquals(conjunction, result);
+
+    verify(query).distinct(true);
+    verify(cb).conjunction();
+  }
+
+  @Test
+  @DisplayName("should apply keyword filter")
+  void buildSearchQuery_shouldApplyKeywordFilter() {
+    SearchOccupationRequest request = new SearchOccupationRequest();
+    request.setKeyword("Software Developer");
+
+    stubBaseAnd();
+    stubKeyword("software developer");
+
+    Predicate result = OccupationSpecification.buildSearchQuery(request)
+        .toPredicate(occupation, query, cb);
+
+    assertEquals(combinedPredicate, result);
+
+    verify(query).distinct(true);
+    verify(cb).like(lowerNamePath, "%software developer%");
+  }
+
+  @Test
+  @DisplayName("should apply status filter")
+  void buildSearchQuery_shouldApplyStatusFilter() {
+    SearchOccupationRequest request = new SearchOccupationRequest();
+    request.setStatus(Status.active);
+
+    stubBaseAnd();
+    stubStatus();
+
+    Predicate result = OccupationSpecification.buildSearchQuery(request)
+        .toPredicate(occupation, query, cb);
+
+    assertEquals(combinedPredicate, result);
+
+    verify(query).distinct(true);
+    verify(cb).equal(statusPath, Status.active);
+  }
+
+  @Test
+  @DisplayName("should apply keyword and status filters")
+  void buildSearchQuery_shouldApplyKeywordAndStatusFilters() {
+    SearchOccupationRequest request = new SearchOccupationRequest();
+    request.setKeyword("Data Analyst");
+    request.setStatus(Status.active);
+
+    stubBaseAnd();
+    stubKeyword("data analyst");
+    stubStatus();
+
+    Predicate result = OccupationSpecification.buildSearchQuery(request)
+        .toPredicate(occupation, query, cb);
+
+    assertEquals(combinedPredicate, result);
+
+    verify(query).distinct(true);
+    verify(cb).like(lowerNamePath, "%data analyst%");
+    verify(cb).equal(statusPath, Status.active);
+  }
+
+  private void stubBaseAnd() {
+    when(cb.conjunction()).thenReturn(conjunction);
+    when(cb.and(any(Predicate.class), any(Predicate.class))).thenReturn(combinedPredicate);
+  }
+
+  private void stubKeyword(String lowerCaseKeyword) {
+    when(occupation.<String>get("name")).thenReturn(namePath);
+    when(cb.lower(namePath)).thenReturn(lowerNamePath);
+    when(cb.like(lowerNamePath, "%" + lowerCaseKeyword + "%"))
+        .thenReturn(nameLikePredicate);
+  }
+
+  private void stubStatus() {
+    when(occupation.<Status>get("status")).thenReturn(statusPath);
+    when(cb.equal(statusPath, Status.active)).thenReturn(statusPredicate);
+  }
+}

--- a/server/src/test/java/org/tctalent/server/repository/db/OfferToAssistSpecificationTest.java
+++ b/server/src/test/java/org/tctalent/server/repository/db/OfferToAssistSpecificationTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2026 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free
+ *  Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.repository.db;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.Path;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tctalent.server.model.db.OfferToAssist;
+import org.tctalent.server.request.KeywordPagedSearchRequest;
+
+@ExtendWith(MockitoExtension.class)
+class OfferToAssistSpecificationTest {
+
+  @Mock private Root<OfferToAssist> ota;
+  @Mock private CriteriaQuery<?> query;
+  @Mock private CriteriaBuilder cb;
+
+  @Mock private Predicate conjunction;
+  @Mock private Predicate combinedPredicate;
+
+  @Mock private Path<Object> partnerPath;
+  @Mock private Path<String> partnerNamePath;
+  @Mock private Path<String> publicIdPath;
+  @Mock private Path<String> reasonPath;
+
+  @Mock private Expression<String> lowerPartnerNamePath;
+  @Mock private Expression<String> lowerPublicIdPath;
+  @Mock private Expression<String> lowerReasonPath;
+
+  @Mock private Predicate partnerNameLikePredicate;
+  @Mock private Predicate publicIdLikePredicate;
+  @Mock private Predicate reasonLikePredicate;
+  @Mock private Predicate keywordPredicate;
+
+  @Test
+  @DisplayName("should cover default constructor")
+  void constructor_shouldCreateInstance() {
+    assertNotNull(new OfferToAssistSpecification());
+  }
+
+  @Test
+  @DisplayName("should throw when criteria query is null")
+  void buildSearchQuery_shouldThrow_whenCriteriaQueryIsNull() {
+    KeywordPagedSearchRequest request = new KeywordPagedSearchRequest();
+
+    assertThrows(IllegalArgumentException.class,
+        () -> OfferToAssistSpecification.buildSearchQuery(request)
+            .toPredicate(ota, null, cb));
+  }
+
+  @Test
+  @DisplayName("should build base query when keyword is null")
+  void buildSearchQuery_shouldBuildBaseQuery_whenKeywordIsNull() {
+    KeywordPagedSearchRequest request = new KeywordPagedSearchRequest();
+
+    when(cb.conjunction()).thenReturn(conjunction);
+
+    Predicate result = OfferToAssistSpecification.buildSearchQuery(request)
+        .toPredicate(ota, query, cb);
+
+    assertEquals(conjunction, result);
+
+    verify(query).distinct(true);
+    verify(cb).conjunction();
+  }
+
+  @Test
+  @DisplayName("should build base query when keyword is blank")
+  void buildSearchQuery_shouldBuildBaseQuery_whenKeywordIsBlank() {
+    KeywordPagedSearchRequest request = new KeywordPagedSearchRequest();
+    request.setKeyword("   ");
+
+    when(cb.conjunction()).thenReturn(conjunction);
+
+    Predicate result = OfferToAssistSpecification.buildSearchQuery(request)
+        .toPredicate(ota, query, cb);
+
+    assertEquals(conjunction, result);
+
+    verify(query).distinct(true);
+    verify(cb).conjunction();
+  }
+
+  @Test
+  @DisplayName("should apply keyword filter")
+  void buildSearchQuery_shouldApplyKeywordFilter() {
+    KeywordPagedSearchRequest request = new KeywordPagedSearchRequest();
+    request.setKeyword("Partner Reason");
+
+    when(cb.conjunction()).thenReturn(conjunction);
+    when(cb.and(any(Predicate.class), any(Predicate.class))).thenReturn(combinedPredicate);
+
+    when(ota.<Object>get("partner")).thenReturn(partnerPath);
+    when(partnerPath.<String>get("name")).thenReturn(partnerNamePath);
+    when(ota.<String>get("publicId")).thenReturn(publicIdPath);
+    when(ota.<String>get("reason")).thenReturn(reasonPath);
+
+    when(cb.lower(partnerNamePath)).thenReturn(lowerPartnerNamePath);
+    when(cb.lower(publicIdPath)).thenReturn(lowerPublicIdPath);
+    when(cb.lower(reasonPath)).thenReturn(lowerReasonPath);
+
+    when(cb.like(lowerPartnerNamePath, "%partner reason%"))
+        .thenReturn(partnerNameLikePredicate);
+    when(cb.like(lowerPublicIdPath, "%partner reason%"))
+        .thenReturn(publicIdLikePredicate);
+    when(cb.like(lowerReasonPath, "%partner reason%"))
+        .thenReturn(reasonLikePredicate);
+
+    when(cb.or(partnerNameLikePredicate, publicIdLikePredicate, reasonLikePredicate))
+        .thenReturn(keywordPredicate);
+
+    Predicate result = OfferToAssistSpecification.buildSearchQuery(request)
+        .toPredicate(ota, query, cb);
+
+    assertEquals(combinedPredicate, result);
+
+    verify(query).distinct(true);
+    verify(cb).like(lowerPartnerNamePath, "%partner reason%");
+    verify(cb).like(lowerPublicIdPath, "%partner reason%");
+    verify(cb).like(lowerReasonPath, "%partner reason%");
+  }
+}

--- a/server/src/test/java/org/tctalent/server/repository/db/PartnerSpecificationTest.java
+++ b/server/src/test/java/org/tctalent/server/repository/db/PartnerSpecificationTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2026 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free
+ *  Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.repository.db;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.Path;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tctalent.server.model.db.PartnerImpl;
+import org.tctalent.server.model.db.Status;
+import org.tctalent.server.request.partner.SearchPartnerRequest;
+
+@ExtendWith(MockitoExtension.class)
+class PartnerSpecificationTest {
+
+  @Mock private Root<PartnerImpl> partner;
+  @Mock private CriteriaQuery<?> query;
+  @Mock private CriteriaBuilder cb;
+
+  @Mock private Predicate conjunction;
+  @Mock private Predicate combinedPredicate;
+
+  @Mock private Path<String> namePath;
+  @Mock private Path<String> abbreviationPath;
+  @Mock private Expression<String> lowerNamePath;
+  @Mock private Expression<String> lowerAbbreviationPath;
+  @Mock private Predicate nameLikePredicate;
+  @Mock private Predicate abbreviationLikePredicate;
+  @Mock private Predicate keywordPredicate;
+
+  @Mock private Path<Status> statusPath;
+  @Mock private Predicate statusPredicate;
+
+  @Mock private Path<Boolean> jobCreatorPath;
+  @Mock private Predicate jobCreatorPredicate;
+
+  @Mock private Path<Boolean> sourcePartnerPath;
+  @Mock private Predicate sourcePartnerPredicate;
+
+  @Test
+  @DisplayName("should cover default constructor")
+  void constructor_shouldCreateInstance() {
+    assertNotNull(new PartnerSpecification());
+  }
+
+  @Test
+  @DisplayName("should throw when criteria query is null")
+  void buildSearchQuery_shouldThrow_whenCriteriaQueryIsNull() {
+    SearchPartnerRequest request = new SearchPartnerRequest();
+
+    assertThrows(IllegalArgumentException.class,
+        () -> PartnerSpecification.buildSearchQuery(request)
+            .toPredicate(partner, null, cb));
+  }
+
+  @Test
+  @DisplayName("should build query with no optional filters")
+  void buildSearchQuery_shouldBuildQueryWithNoOptionalFilters() {
+    SearchPartnerRequest request = new SearchPartnerRequest();
+
+    when(cb.conjunction()).thenReturn(conjunction);
+
+    Predicate result = PartnerSpecification.buildSearchQuery(request)
+        .toPredicate(partner, query, cb);
+
+    assertEquals(conjunction, result);
+
+    verify(query).distinct(true);
+    verify(cb).conjunction();
+  }
+
+  @Test
+  @DisplayName("should apply keyword, status, job creator and source partner filters")
+  void buildSearchQuery_shouldApplyAllFilters() {
+    SearchPartnerRequest request = new SearchPartnerRequest();
+    request.setKeyword("Talent Partner");
+    request.setStatus(Status.active);
+    request.setJobCreator(true);
+    request.setSourcePartner(true);
+
+    stubBaseAnd();
+
+    when(partner.<String>get("name")).thenReturn(namePath);
+    when(partner.<String>get("abbreviation")).thenReturn(abbreviationPath);
+    when(cb.lower(namePath)).thenReturn(lowerNamePath);
+    when(cb.lower(abbreviationPath)).thenReturn(lowerAbbreviationPath);
+    when(cb.like(lowerNamePath, "%talent partner%")).thenReturn(nameLikePredicate);
+    when(cb.like(lowerAbbreviationPath, "%talent partner%"))
+        .thenReturn(abbreviationLikePredicate);
+    when(cb.or(nameLikePredicate, abbreviationLikePredicate)).thenReturn(keywordPredicate);
+
+    when(partner.<Status>get("status")).thenReturn(statusPath);
+    when(cb.equal(statusPath, Status.active)).thenReturn(statusPredicate);
+
+    when(partner.<Boolean>get("jobCreator")).thenReturn(jobCreatorPath);
+    when(cb.equal(jobCreatorPath, true)).thenReturn(jobCreatorPredicate);
+
+    when(partner.<Boolean>get("sourcePartner")).thenReturn(sourcePartnerPath);
+    when(cb.equal(sourcePartnerPath, true)).thenReturn(sourcePartnerPredicate);
+
+    Predicate result = PartnerSpecification.buildSearchQuery(request)
+        .toPredicate(partner, query, cb);
+
+    assertNotNull(result);
+
+    verify(query).distinct(true);
+    verify(cb).like(lowerNamePath, "%talent partner%");
+    verify(cb).like(lowerAbbreviationPath, "%talent partner%");
+    verify(cb).equal(statusPath, Status.active);
+    verify(cb).equal(jobCreatorPath, true);
+    verify(cb).equal(sourcePartnerPath, true);
+  }
+
+  @Test
+  @DisplayName("should skip blank keyword and apply false boolean filters")
+  void buildSearchQuery_shouldSkipBlankKeywordAndApplyFalseBooleanFilters() {
+    SearchPartnerRequest request = new SearchPartnerRequest();
+    request.setKeyword("   ");
+    request.setJobCreator(false);
+    request.setSourcePartner(false);
+
+    stubBaseAnd();
+
+    when(partner.<Boolean>get("jobCreator")).thenReturn(jobCreatorPath);
+    when(cb.equal(jobCreatorPath, false)).thenReturn(jobCreatorPredicate);
+
+    when(partner.<Boolean>get("sourcePartner")).thenReturn(sourcePartnerPath);
+    when(cb.equal(sourcePartnerPath, false)).thenReturn(sourcePartnerPredicate);
+
+    Predicate result = PartnerSpecification.buildSearchQuery(request)
+        .toPredicate(partner, query, cb);
+
+    assertNotNull(result);
+
+    verify(query).distinct(true);
+    verify(cb).equal(jobCreatorPath, false);
+    verify(cb).equal(sourcePartnerPath, false);
+  }
+
+  @Test
+  @DisplayName("should apply status filter only")
+  void buildSearchQuery_shouldApplyStatusFilterOnly() {
+    SearchPartnerRequest request = new SearchPartnerRequest();
+    request.setStatus(Status.active);
+
+    stubBaseAnd();
+
+    when(partner.<Status>get("status")).thenReturn(statusPath);
+    when(cb.equal(statusPath, Status.active)).thenReturn(statusPredicate);
+
+    Predicate result = PartnerSpecification.buildSearchQuery(request)
+        .toPredicate(partner, query, cb);
+
+    assertNotNull(result);
+
+    verify(query).distinct(true);
+    verify(cb).equal(statusPath, Status.active);
+  }
+
+  private void stubBaseAnd() {
+    when(cb.conjunction()).thenReturn(conjunction);
+    when(cb.and(any(Predicate.class), any(Predicate.class))).thenReturn(combinedPredicate);
+  }
+}

--- a/server/src/test/java/org/tctalent/server/repository/db/SavedListLinkSpecificationTest.java
+++ b/server/src/test/java/org/tctalent/server/repository/db/SavedListLinkSpecificationTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2026 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free
+ *  Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.repository.db;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.Path;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tctalent.server.model.db.SavedListLink;
+import org.tctalent.server.request.link.SearchLinkRequest;
+
+@ExtendWith(MockitoExtension.class)
+class SavedListLinkSpecificationTest {
+
+  @Mock private Root<SavedListLink> savedListLink;
+  @Mock private CriteriaQuery<?> query;
+  @Mock private CriteriaBuilder cb;
+
+  @Mock private Predicate conjunction;
+  @Mock private Predicate combinedPredicate;
+
+  @Mock private Path<String> namePath;
+  @Mock private Expression<String> lowerNamePath;
+  @Mock private Predicate nameLikePredicate;
+
+  @Test
+  @DisplayName("should cover default constructor")
+  void constructor_shouldCreateInstance() {
+    assertNotNull(new SavedListLinkSpecification());
+  }
+
+  @Test
+  @DisplayName("should throw when criteria query is null")
+  void buildSearchQuery_shouldThrow_whenCriteriaQueryIsNull() {
+    SearchLinkRequest request = new SearchLinkRequest();
+
+    assertThrows(IllegalArgumentException.class,
+        () -> SavedListLinkSpecification.buildSearchQuery(request)
+            .toPredicate(savedListLink, null, cb));
+  }
+
+  @Test
+  @DisplayName("should build base query when keyword is null")
+  void buildSearchQuery_shouldBuildBaseQuery_whenKeywordIsNull() {
+    SearchLinkRequest request = new SearchLinkRequest();
+
+    when(cb.conjunction()).thenReturn(conjunction);
+
+    Predicate result = SavedListLinkSpecification.buildSearchQuery(request)
+        .toPredicate(savedListLink, query, cb);
+
+    assertEquals(conjunction, result);
+
+    verify(query).distinct(true);
+    verify(cb).conjunction();
+  }
+
+  @Test
+  @DisplayName("should build base query when keyword is blank")
+  void buildSearchQuery_shouldBuildBaseQuery_whenKeywordIsBlank() {
+    SearchLinkRequest request = new SearchLinkRequest();
+    request.setKeyword("   ");
+
+    when(cb.conjunction()).thenReturn(conjunction);
+
+    Predicate result = SavedListLinkSpecification.buildSearchQuery(request)
+        .toPredicate(savedListLink, query, cb);
+
+    assertEquals(conjunction, result);
+
+    verify(query).distinct(true);
+    verify(cb).conjunction();
+  }
+
+  @Test
+  @DisplayName("should apply keyword filter")
+  void buildSearchQuery_shouldApplyKeywordFilter() {
+    SearchLinkRequest request = new SearchLinkRequest();
+    request.setKeyword("Important Link");
+
+    when(cb.conjunction()).thenReturn(conjunction);
+    when(cb.and(any(Predicate.class), any(Predicate.class))).thenReturn(combinedPredicate);
+
+    when(savedListLink.<String>get("name")).thenReturn(namePath);
+    when(cb.lower(namePath)).thenReturn(lowerNamePath);
+    when(cb.like(lowerNamePath, "%important link%")).thenReturn(nameLikePredicate);
+
+    Predicate result = SavedListLinkSpecification.buildSearchQuery(request)
+        .toPredicate(savedListLink, query, cb);
+
+    assertEquals(combinedPredicate, result);
+
+    verify(query).distinct(true);
+    verify(cb).like(lowerNamePath, "%important link%");
+  }
+}

--- a/server/src/test/java/org/tctalent/server/repository/db/SavedSearchSpecificationTest.java
+++ b/server/src/test/java/org/tctalent/server/repository/db/SavedSearchSpecificationTest.java
@@ -1,0 +1,373 @@
+/*
+ * Copyright (c) 2026 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free
+ *  Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.repository.db;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.Path;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tctalent.server.model.db.SavedSearch;
+import org.tctalent.server.model.db.SavedSearchSubtype;
+import org.tctalent.server.model.db.SavedSearchType;
+import org.tctalent.server.model.db.Status;
+import org.tctalent.server.model.db.User;
+import org.tctalent.server.request.search.SearchSavedSearchRequest;
+
+@ExtendWith(MockitoExtension.class)
+class SavedSearchSpecificationTest {
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS) private Root<SavedSearch> savedSearch;
+  @Mock private CriteriaQuery<?> query;
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS) private CriteriaBuilder cb;
+
+  @Mock private Predicate conjunction;
+  @Mock private Predicate combinedPredicate;
+  @Mock private Predicate disjunction;
+  @Mock private Expression<Boolean> disjunctionExpression;
+
+  @Mock private Path<String> namePath;
+  @Mock private Expression<String> lowerNamePath;
+  @Mock private Predicate nameLikePredicate;
+
+  @Mock private Path<Status> statusPath;
+  @Mock private Predicate statusPredicate;
+
+  @Mock private Path<Boolean> defaultSearchPath;
+  @Mock private Predicate notDefaultPredicate;
+
+  @Mock private Path<String> typePath;
+  @Mock private Predicate typePredicate;
+
+  @Mock private Path<Boolean> fixedPath;
+  @Mock private Predicate fixedPredicate;
+
+  @Mock private Path<Boolean> globalPath;
+  @Mock private Predicate globalPredicate;
+
+  @Mock private Path<Long> idPath;
+  @Mock private Predicate sharedPredicate;
+
+  @Mock private User loggedInUser;
+  @Mock private SavedSearch sharedSearchOne;
+  @Mock private SavedSearch sharedSearchTwo;
+
+  @Test
+  @DisplayName("should cover default constructor")
+  void constructor_shouldCreateInstance() {
+    assertNotNull(new SavedSearchSpecification());
+  }
+
+  @Test
+  @DisplayName("should throw when criteria query is null")
+  void buildSearchQuery_shouldThrow_whenCriteriaQueryIsNull() {
+    SearchSavedSearchRequest request = new SearchSavedSearchRequest();
+
+    assertThrows(IllegalArgumentException.class,
+        () -> SavedSearchSpecification.buildSearchQuery(request, null)
+            .toPredicate(savedSearch, null, cb));
+  }
+
+  @Test
+  @DisplayName("should apply base active and not default filters")
+  void buildSearchQuery_shouldApplyBaseFilters() {
+    SearchSavedSearchRequest request = new SearchSavedSearchRequest();
+
+    stubBaseQueryWithEmptyDisjunction();
+
+    Predicate result = SavedSearchSpecification.buildSearchQuery(request, null)
+        .toPredicate(savedSearch, query, cb);
+
+    assertEquals(combinedPredicate, result);
+
+    verify(query).distinct(true);
+    verify(cb).equal(statusPath, Status.active);
+    verify(cb).not(defaultSearchPath);
+  }
+
+  @Test
+  @DisplayName("should apply keyword and type filters")
+  void buildSearchQuery_shouldApplyKeywordAndTypeFilters() {
+    SearchSavedSearchRequest request = new SearchSavedSearchRequest();
+    request.setKeyword("Software Developers");
+    request.setSavedSearchType(SavedSearchType.profession);
+    request.setSavedSearchSubtype(SavedSearchSubtype.it);
+
+    stubBaseQueryWithEmptyDisjunction();
+    stubKeyword();
+    stubType(SavedSearch.makeStringSavedSearchType(
+        SavedSearchType.profession,
+        SavedSearchSubtype.it
+    ));
+
+    Predicate result = SavedSearchSpecification.buildSearchQuery(request, null)
+        .toPredicate(savedSearch, query, cb);
+
+    assertEquals(combinedPredicate, result);
+
+    verify(query).distinct(true);
+    verify(cb).like(lowerNamePath, "%software developers%");
+    verify(cb).equal(
+        typePath,
+        SavedSearch.makeStringSavedSearchType(SavedSearchType.profession, SavedSearchSubtype.it)
+    );
+  }
+
+  @Test
+  @DisplayName("should skip blank keyword and apply type without subtype")
+  void buildSearchQuery_shouldSkipBlankKeywordAndApplyTypeWithoutSubtype() {
+    SearchSavedSearchRequest request = new SearchSavedSearchRequest();
+    request.setKeyword("   ");
+    request.setSavedSearchType(SavedSearchType.job);
+
+    stubBaseQueryWithEmptyDisjunction();
+    stubType(SavedSearch.makeStringSavedSearchType(SavedSearchType.job, null));
+
+    Predicate result = SavedSearchSpecification.buildSearchQuery(request, null)
+        .toPredicate(savedSearch, query, cb);
+
+    assertEquals(combinedPredicate, result);
+
+    verify(query).distinct(true);
+    verify(cb).equal(
+        typePath,
+        SavedSearch.makeStringSavedSearchType(SavedSearchType.job, null)
+    );
+  }
+
+  @Test
+  @DisplayName("should apply fixed true and global true filters")
+  void buildSearchQuery_shouldApplyFixedAndGlobalFilters() {
+    SearchSavedSearchRequest request = new SearchSavedSearchRequest();
+    request.setFixed(true);
+    request.setGlobal(true);
+
+    stubBaseQueryWithNonEmptyDisjunction();
+    stubFixed();
+    stubGlobal();
+
+    Predicate result = SavedSearchSpecification.buildSearchQuery(request, null)
+        .toPredicate(savedSearch, query, cb);
+
+    assertEquals(combinedPredicate, result);
+
+    verify(query).distinct(true);
+    verify(cb).equal(fixedPath, true);
+    verify(cb).equal(globalPath, true);
+  }
+
+  @Test
+  @DisplayName("should ignore fixed false and global false filters")
+  void buildSearchQuery_shouldIgnoreFalseBooleanFilters() {
+    SearchSavedSearchRequest request = new SearchSavedSearchRequest();
+    request.setFixed(false);
+    request.setGlobal(false);
+    request.setShared(false);
+    request.setOwned(false);
+
+    stubBaseQueryWithEmptyDisjunction();
+
+    Predicate result = SavedSearchSpecification.buildSearchQuery(request, loggedInUser)
+        .toPredicate(savedSearch, query, cb);
+
+    assertEquals(combinedPredicate, result);
+
+    verify(query).distinct(true);
+  }
+
+  @Test
+  @DisplayName("should apply shared searches when logged in user has shared searches")
+  void buildSearchQuery_shouldApplySharedSearches() {
+    SearchSavedSearchRequest request = new SearchSavedSearchRequest();
+    request.setShared(true);
+
+    when(loggedInUser.getSharedSearches())
+        .thenReturn(Set.of(sharedSearchOne, sharedSearchTwo));
+    when(sharedSearchOne.getId()).thenReturn(11L);
+    when(sharedSearchTwo.getId()).thenReturn(22L);
+
+    stubBaseQueryWithNonEmptyDisjunction();
+
+    Predicate result = SavedSearchSpecification.buildSearchQuery(request, loggedInUser)
+        .toPredicate(savedSearch, query, cb);
+
+    assertEquals(combinedPredicate, result);
+
+    verify(query).distinct(true);
+    verify(loggedInUser).getSharedSearches();
+    verify(sharedSearchOne).getId();
+    verify(sharedSearchTwo).getId();
+  }
+
+  @Test
+  @DisplayName("should skip shared searches when logged in user is null")
+  void buildSearchQuery_shouldSkipSharedSearches_whenLoggedInUserIsNull() {
+    SearchSavedSearchRequest request = new SearchSavedSearchRequest();
+    request.setShared(true);
+
+    stubBaseQueryWithEmptyDisjunction();
+
+    Predicate result = SavedSearchSpecification.buildSearchQuery(request, null)
+        .toPredicate(savedSearch, query, cb);
+
+    assertEquals(combinedPredicate, result);
+
+    verify(query).distinct(true);
+  }
+
+  @Test
+  @DisplayName("should skip shared filter when shared search set is empty")
+  void buildSearchQuery_shouldSkipSharedFilter_whenSharedSearchesAreEmpty() {
+    SearchSavedSearchRequest request = new SearchSavedSearchRequest();
+    request.setShared(true);
+
+    when(loggedInUser.getSharedSearches()).thenReturn(Set.of());
+
+    stubBaseQueryWithEmptyDisjunction();
+
+    Predicate result = SavedSearchSpecification.buildSearchQuery(request, loggedInUser)
+        .toPredicate(savedSearch, query, cb);
+
+    assertEquals(combinedPredicate, result);
+
+    verify(query).distinct(true);
+    verify(loggedInUser).getSharedSearches();
+  }
+
+  @Test
+  @DisplayName("should apply owned filter")
+  void buildSearchQuery_shouldApplyOwnedFilter() {
+    SearchSavedSearchRequest request = new SearchSavedSearchRequest();
+    request.setOwned(true);
+
+    when(loggedInUser.getId()).thenReturn(42L);
+
+    stubBaseQueryWithNonEmptyDisjunction();
+
+    Predicate result = SavedSearchSpecification.buildSearchQuery(request, loggedInUser)
+        .toPredicate(savedSearch, query, cb);
+
+    assertEquals(combinedPredicate, result);
+
+    verify(query).distinct(true);
+    verify(loggedInUser).getId();
+  }
+
+  @Test
+  @DisplayName("should skip owned filter when logged in user is null")
+  void buildSearchQuery_shouldSkipOwnedFilter_whenLoggedInUserIsNull() {
+    SearchSavedSearchRequest request = new SearchSavedSearchRequest();
+    request.setOwned(true);
+
+    stubBaseQueryWithEmptyDisjunction();
+
+    Predicate result = SavedSearchSpecification.buildSearchQuery(request, null)
+        .toPredicate(savedSearch, query, cb);
+
+    assertEquals(combinedPredicate, result);
+
+    verify(query).distinct(true);
+  }
+
+  @Test
+  @DisplayName("should apply global shared and owned disjunction together")
+  void buildSearchQuery_shouldApplyGlobalSharedAndOwnedDisjunctionTogether() {
+    SearchSavedSearchRequest request = new SearchSavedSearchRequest();
+    request.setGlobal(true);
+    request.setShared(true);
+    request.setOwned(true);
+
+    when(loggedInUser.getSharedSearches()).thenReturn(Set.of(sharedSearchOne));
+    when(sharedSearchOne.getId()).thenReturn(55L);
+    when(loggedInUser.getId()).thenReturn(66L);
+
+    stubBaseQueryWithNonEmptyDisjunction();
+    stubGlobal();
+
+    Predicate result = SavedSearchSpecification.buildSearchQuery(request, loggedInUser)
+        .toPredicate(savedSearch, query, cb);
+
+    assertEquals(combinedPredicate, result);
+
+    verify(query).distinct(true);
+    verify(cb).equal(globalPath, true);
+    verify(loggedInUser).getSharedSearches();
+    verify(loggedInUser).getId();
+  }
+
+  private void stubBaseQueryWithEmptyDisjunction() {
+    stubRequiredBasePredicates();
+    when(cb.disjunction()).thenReturn(disjunction);
+    when(disjunction.getExpressions()).thenReturn(List.of());
+  }
+
+  private void stubBaseQueryWithNonEmptyDisjunction() {
+    stubRequiredBasePredicates();
+    when(cb.disjunction()).thenReturn(disjunction);
+    when(cb.or(any(Predicate.class), any(Predicate.class))).thenReturn(disjunction);
+    when(disjunction.getExpressions()).thenReturn(List.of(disjunctionExpression));
+  }
+
+  private void stubRequiredBasePredicates() {
+    when(cb.conjunction()).thenReturn(conjunction);
+    when(cb.and(any(Predicate.class), any(Predicate.class))).thenReturn(combinedPredicate);
+
+    when(savedSearch.<Status>get("status")).thenReturn(statusPath);
+    when(cb.equal(statusPath, Status.active)).thenReturn(statusPredicate);
+
+    when(savedSearch.<Boolean>get("defaultSearch")).thenReturn(defaultSearchPath);
+    when(cb.not(defaultSearchPath)).thenReturn(notDefaultPredicate);
+  }
+
+  private void stubKeyword() {
+    when(savedSearch.<String>get("name")).thenReturn(namePath);
+    when(cb.lower(namePath)).thenReturn(lowerNamePath);
+    when(cb.like(lowerNamePath, "%" + "software developers" + "%"))
+        .thenReturn(nameLikePredicate);
+  }
+
+  private void stubType(String type) {
+    when(savedSearch.<String>get("type")).thenReturn(typePath);
+    when(cb.equal(typePath, type)).thenReturn(typePredicate);
+  }
+
+  private void stubFixed() {
+    when(savedSearch.<Boolean>get("fixed")).thenReturn(fixedPath);
+    when(cb.equal(fixedPath, true)).thenReturn(fixedPredicate);
+  }
+
+  private void stubGlobal() {
+    when(savedSearch.<Boolean>get("global")).thenReturn(globalPath);
+    when(cb.equal(globalPath, true)).thenReturn(globalPredicate);
+  }
+}

--- a/server/src/test/java/org/tctalent/server/repository/db/SurveyTypeSpecificationTest.java
+++ b/server/src/test/java/org/tctalent/server/repository/db/SurveyTypeSpecificationTest.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2026 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free
+ *  Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.repository.db;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.Path;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tctalent.server.model.db.Status;
+import org.tctalent.server.model.db.SurveyType;
+import org.tctalent.server.request.survey.SearchSurveyTypeRequest;
+
+@ExtendWith(MockitoExtension.class)
+class SurveyTypeSpecificationTest {
+
+  @Mock private Root<SurveyType> surveyType;
+  @Mock private CriteriaQuery<?> query;
+  @Mock private CriteriaBuilder cb;
+
+  @Mock private Predicate conjunction;
+  @Mock private Predicate combinedPredicate;
+
+  @Mock private Path<String> namePath;
+  @Mock private Expression<String> lowerNamePath;
+  @Mock private Predicate nameLikePredicate;
+
+  @Mock private Path<Status> statusPath;
+  @Mock private Predicate statusPredicate;
+
+  @Test
+  @DisplayName("should cover default constructor")
+  void constructor_shouldCreateInstance() {
+    assertNotNull(new SurveyTypeSpecification());
+  }
+
+  @Test
+  @DisplayName("should throw when criteria query is null")
+  void buildSearchQuery_shouldThrow_whenCriteriaQueryIsNull() {
+    SearchSurveyTypeRequest request = new SearchSurveyTypeRequest();
+
+    assertThrows(IllegalArgumentException.class,
+        () -> SurveyTypeSpecification.buildSearchQuery(request)
+            .toPredicate(surveyType, null, cb));
+  }
+
+  @Test
+  @DisplayName("should build base query when keyword and status are null")
+  void buildSearchQuery_shouldBuildBaseQuery_whenKeywordAndStatusAreNull() {
+    SearchSurveyTypeRequest request = new SearchSurveyTypeRequest();
+
+    when(cb.conjunction()).thenReturn(conjunction);
+
+    Predicate result = SurveyTypeSpecification.buildSearchQuery(request)
+        .toPredicate(surveyType, query, cb);
+
+    assertEquals(conjunction, result);
+
+    verify(query).distinct(true);
+    verify(cb).conjunction();
+  }
+
+  @Test
+  @DisplayName("should build base query when keyword is blank")
+  void buildSearchQuery_shouldBuildBaseQuery_whenKeywordIsBlank() {
+    SearchSurveyTypeRequest request = new SearchSurveyTypeRequest();
+    request.setKeyword("   ");
+
+    when(cb.conjunction()).thenReturn(conjunction);
+
+    Predicate result = SurveyTypeSpecification.buildSearchQuery(request)
+        .toPredicate(surveyType, query, cb);
+
+    assertEquals(conjunction, result);
+
+    verify(query).distinct(true);
+    verify(cb).conjunction();
+  }
+
+  @Test
+  @DisplayName("should apply keyword filter")
+  void buildSearchQuery_shouldApplyKeywordFilter() {
+    SearchSurveyTypeRequest request = new SearchSurveyTypeRequest();
+    request.setKeyword("Mini Intake");
+
+    stubBaseAnd();
+    stubKeyword("mini intake");
+
+    Predicate result = SurveyTypeSpecification.buildSearchQuery(request)
+        .toPredicate(surveyType, query, cb);
+
+    assertEquals(combinedPredicate, result);
+
+    verify(query).distinct(true);
+    verify(cb).like(lowerNamePath, "%mini intake%");
+  }
+
+  @Test
+  @DisplayName("should apply status filter")
+  void buildSearchQuery_shouldApplyStatusFilter() {
+    SearchSurveyTypeRequest request = new SearchSurveyTypeRequest();
+    request.setStatus(Status.active);
+
+    stubBaseAnd();
+    stubStatus(Status.active);
+
+    Predicate result = SurveyTypeSpecification.buildSearchQuery(request)
+        .toPredicate(surveyType, query, cb);
+
+    assertEquals(combinedPredicate, result);
+
+    verify(query).distinct(true);
+    verify(cb).equal(statusPath, Status.active);
+  }
+
+  @Test
+  @DisplayName("should apply keyword and status filters")
+  void buildSearchQuery_shouldApplyKeywordAndStatusFilters() {
+    SearchSurveyTypeRequest request = new SearchSurveyTypeRequest();
+    request.setKeyword("Full Intake");
+    request.setStatus(Status.active);
+
+    stubBaseAnd();
+    stubKeyword("full intake");
+    stubStatus(Status.active);
+
+    Predicate result = SurveyTypeSpecification.buildSearchQuery(request)
+        .toPredicate(surveyType, query, cb);
+
+    assertEquals(combinedPredicate, result);
+
+    verify(query).distinct(true);
+    verify(cb).like(lowerNamePath, "%full intake%");
+    verify(cb).equal(statusPath, Status.active);
+  }
+
+  private void stubBaseAnd() {
+    when(cb.conjunction()).thenReturn(conjunction);
+    when(cb.and(any(Predicate.class), any(Predicate.class))).thenReturn(combinedPredicate);
+  }
+
+  private void stubKeyword(String lowerCaseKeyword) {
+    when(surveyType.<String>get("name")).thenReturn(namePath);
+    when(cb.lower(namePath)).thenReturn(lowerNamePath);
+    when(cb.like(lowerNamePath, "%" + lowerCaseKeyword + "%"))
+        .thenReturn(nameLikePredicate);
+  }
+
+  private void stubStatus(Status status) {
+    when(surveyType.<Status>get("status")).thenReturn(statusPath);
+    when(cb.equal(statusPath, status)).thenReturn(statusPredicate);
+  }
+}

--- a/server/src/test/java/org/tctalent/server/repository/db/TaskSpecificationTest.java
+++ b/server/src/test/java/org/tctalent/server/repository/db/TaskSpecificationTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2026 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free
+ *  Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.repository.db;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.Path;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tctalent.server.model.db.TaskImpl;
+import org.tctalent.server.request.task.SearchTaskRequest;
+
+@ExtendWith(MockitoExtension.class)
+class TaskSpecificationTest {
+
+  @Mock private Root<TaskImpl> task;
+  @Mock private CriteriaQuery<?> query;
+  @Mock private CriteriaBuilder cb;
+
+  @Mock private Predicate conjunction;
+  @Mock private Predicate combinedPredicate;
+
+  @Mock private Path<String> namePath;
+  @Mock private Path<String> displayNamePath;
+  @Mock private Path<String> descriptionPath;
+
+  @Mock private Expression<String> lowerNamePath;
+  @Mock private Expression<String> lowerDisplayNamePath;
+  @Mock private Expression<String> lowerDescriptionPath;
+
+  @Mock private Predicate nameLikePredicate;
+  @Mock private Predicate displayNameLikePredicate;
+  @Mock private Predicate descriptionLikePredicate;
+  @Mock private Predicate keywordPredicate;
+
+  @Test
+  @DisplayName("should cover default constructor")
+  void constructor_shouldCreateInstance() {
+    assertNotNull(new TaskSpecification());
+  }
+
+  @Test
+  @DisplayName("should throw when criteria query is null")
+  void buildSearchQuery_shouldThrow_whenCriteriaQueryIsNull() {
+    SearchTaskRequest request = new SearchTaskRequest();
+
+    assertThrows(IllegalArgumentException.class,
+        () -> TaskSpecification.buildSearchQuery(request)
+            .toPredicate(task, null, cb));
+  }
+
+  @Test
+  @DisplayName("should build base query when keyword is null")
+  void buildSearchQuery_shouldBuildBaseQuery_whenKeywordIsNull() {
+    SearchTaskRequest request = new SearchTaskRequest();
+
+    when(cb.conjunction()).thenReturn(conjunction);
+
+    Predicate result = TaskSpecification.buildSearchQuery(request)
+        .toPredicate(task, query, cb);
+
+    assertEquals(conjunction, result);
+
+    verify(query).distinct(true);
+    verify(cb).conjunction();
+  }
+
+  @Test
+  @DisplayName("should build base query when keyword is blank")
+  void buildSearchQuery_shouldBuildBaseQuery_whenKeywordIsBlank() {
+    SearchTaskRequest request = new SearchTaskRequest();
+    request.setKeyword("   ");
+
+    when(cb.conjunction()).thenReturn(conjunction);
+
+    Predicate result = TaskSpecification.buildSearchQuery(request)
+        .toPredicate(task, query, cb);
+
+    assertEquals(conjunction, result);
+
+    verify(query).distinct(true);
+    verify(cb).conjunction();
+  }
+
+  @Test
+  @DisplayName("should apply keyword filter")
+  void buildSearchQuery_shouldApplyKeywordFilter() {
+    SearchTaskRequest request = new SearchTaskRequest();
+    request.setKeyword("Review Document");
+
+    when(cb.conjunction()).thenReturn(conjunction);
+    when(cb.and(any(Predicate.class), any(Predicate.class))).thenReturn(combinedPredicate);
+
+    when(task.<String>get("name")).thenReturn(namePath);
+    when(task.<String>get("displayName")).thenReturn(displayNamePath);
+    when(task.<String>get("description")).thenReturn(descriptionPath);
+
+    when(cb.lower(namePath)).thenReturn(lowerNamePath);
+    when(cb.lower(displayNamePath)).thenReturn(lowerDisplayNamePath);
+    when(cb.lower(descriptionPath)).thenReturn(lowerDescriptionPath);
+
+    when(cb.like(lowerNamePath, "%review document%")).thenReturn(nameLikePredicate);
+    when(cb.like(lowerDisplayNamePath, "%review document%"))
+        .thenReturn(displayNameLikePredicate);
+    when(cb.like(lowerDescriptionPath, "%review document%"))
+        .thenReturn(descriptionLikePredicate);
+
+    when(cb.or(nameLikePredicate, displayNameLikePredicate, descriptionLikePredicate))
+        .thenReturn(keywordPredicate);
+
+    Predicate result = TaskSpecification.buildSearchQuery(request)
+        .toPredicate(task, query, cb);
+
+    assertEquals(combinedPredicate, result);
+
+    verify(query).distinct(true);
+    verify(cb).like(lowerNamePath, "%review document%");
+    verify(cb).like(lowerDisplayNamePath, "%review document%");
+    verify(cb).like(lowerDescriptionPath, "%review document%");
+  }
+}

--- a/server/src/test/java/org/tctalent/server/repository/db/UserSpecificationTest.java
+++ b/server/src/test/java/org/tctalent/server/repository/db/UserSpecificationTest.java
@@ -14,22 +14,6 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-/*
- * Copyright (c) 2026 Talent Catalog.
- *
- * This program is free software: you can redistribute it and/or modify it under
- * the terms of the GNU General Public License as published by the Free
- * Software Foundation, either version 3 of the License, or any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
- * for more details.
- *
- * You should have received a copy of the GNU General Public License.
- * If not, see https://www.gnu.org/licenses/.
- */
-
 package org.tctalent.server.repository.db;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/server/src/test/java/org/tctalent/server/repository/db/UserSpecificationTest.java
+++ b/server/src/test/java/org/tctalent/server/repository/db/UserSpecificationTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) 2026 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free
+ *  Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+/*
+ * Copyright (c) 2026 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License.
+ * If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.repository.db;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.JoinType;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tctalent.server.model.db.Role;
+import org.tctalent.server.model.db.Status;
+import org.tctalent.server.model.db.User;
+import org.tctalent.server.request.user.SearchUserRequest;
+
+@ExtendWith(MockitoExtension.class)
+class UserSpecificationTest {
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS) private Root<User> user;
+  @Mock private CriteriaQuery<?> query;
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS) private CriteriaBuilder cb;
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS) private Join<Object, Object> partner;
+
+  @Mock private Predicate conjunction;
+  @Mock private Predicate keywordPredicate;
+  @Mock private Predicate combinedPredicate;
+
+  @Test
+  @DisplayName("should cover default constructor")
+  void constructor_shouldCreateInstance() {
+    assertNotNull(new UserSpecification());
+  }
+
+  @Test
+  @DisplayName("should throw when criteria query is null")
+  void buildSearchQuery_shouldThrow_whenCriteriaQueryIsNull() {
+    SearchUserRequest request = new SearchUserRequest();
+
+    assertThrows(IllegalArgumentException.class,
+        () -> UserSpecification.buildSearchQuery(request)
+            .toPredicate(user, null, cb));
+  }
+
+  @Test
+  @DisplayName("should exclude candidate users when role list is null")
+  void buildSearchQuery_shouldExcludeCandidateUsers_whenRoleListIsNull() {
+    SearchUserRequest request = new SearchUserRequest();
+
+    stubBaseQuery();
+
+    assertNotNull(UserSpecification.buildSearchQuery(request)
+        .toPredicate(user, query, cb));
+
+    verify(query).distinct(true);
+    verify(cb).notEqual(user.get("role"), Role.user);
+  }
+
+  @Test
+  @DisplayName("should exclude candidate users when role list is empty")
+  void buildSearchQuery_shouldExcludeCandidateUsers_whenRoleListIsEmpty() {
+    SearchUserRequest request = new SearchUserRequest();
+    request.setRole(List.of());
+
+    stubBaseQuery();
+
+    assertNotNull(UserSpecification.buildSearchQuery(request)
+        .toPredicate(user, query, cb));
+
+    verify(query).distinct(true);
+    verify(cb).notEqual(user.get("role"), Role.user);
+  }
+
+  @Test
+  @DisplayName("should apply keyword, role, partner and status filters")
+  void buildSearchQuery_shouldApplyKeywordRolePartnerAndStatusFilters() {
+    SearchUserRequest request = new SearchUserRequest();
+    request.setKeyword("Ehsan Test");
+    request.setRole(List.of(Role.systemadmin, Role.admin));
+    request.setPartnerId(123L);
+    request.setStatus(Status.active);
+
+    stubBaseQuery();
+    doReturn(partner).when(user).join("partner", JoinType.LEFT);
+
+    assertNotNull(UserSpecification.buildSearchQuery(request)
+        .toPredicate(user, query, cb));
+
+    verify(query).distinct(true);
+    verify(user).join("partner", JoinType.LEFT);
+    verify(cb).equal(partner.get("id"), 123L);
+    verify(cb).equal(user.get("status"), Status.active);
+  }
+
+  @Test
+  @DisplayName("should skip keyword when it is blank")
+  void buildSearchQuery_shouldSkipKeyword_whenBlank() {
+    SearchUserRequest request = new SearchUserRequest();
+    request.setKeyword("   ");
+    request.setRole(List.of(Role.partneradmin));
+
+    stubBaseQuery();
+
+    assertNotNull(UserSpecification.buildSearchQuery(request)
+        .toPredicate(user, query, cb));
+
+    verify(query).distinct(true);
+  }
+
+  @Test
+  @DisplayName("should apply partner filter only")
+  void buildSearchQuery_shouldApplyPartnerFilterOnly() {
+    SearchUserRequest request = new SearchUserRequest();
+    request.setPartnerId(99L);
+
+    stubBaseQuery();
+    doReturn(partner).when(user).join("partner", JoinType.LEFT);
+
+    assertNotNull(UserSpecification.buildSearchQuery(request)
+        .toPredicate(user, query, cb));
+
+    verify(user).join("partner", JoinType.LEFT);
+    verify(cb).equal(partner.get("id"), 99L);
+  }
+
+  @Test
+  @DisplayName("should apply status filter only")
+  void buildSearchQuery_shouldApplyStatusFilterOnly() {
+    SearchUserRequest request = new SearchUserRequest();
+    request.setStatus(Status.active);
+
+    stubBaseQuery();
+
+    assertNotNull(UserSpecification.buildSearchQuery(request)
+        .toPredicate(user, query, cb));
+
+    verify(cb).equal(user.get("status"), Status.active);
+  }
+
+  private void stubBaseQuery() {
+    when(cb.conjunction()).thenReturn(conjunction);
+    when(cb.and(any(Predicate.class), any(Predicate.class))).thenReturn(combinedPredicate);
+    when(cb.or(
+        any(Predicate.class),
+        any(Predicate.class),
+        any(Predicate.class),
+        any(Predicate.class)
+    )).thenReturn(keywordPredicate);
+  }
+}


### PR DESCRIPTION
This PR increases test coverage to 72% by adding unit tests for repository specifications and query utility classes.
