### PR TITLE
TC-1337 Add UI alert confirming email notification on task assignment

### DIFF
--- a/ui/admin-portal/src/app/components/candidates/view/tasks/view-candidate-tasks.component.html
+++ b/ui/admin-portal/src/app/components/candidates/view/tasks/view-candidate-tasks.component.html
@@ -22,6 +22,12 @@
   <div><strong>{{error}}</strong></div>
 </tc-alert>
 
+<tc-alert type="success"
+          *ngIf="showAssignmentEmailNotification"
+          [dismissible]="false">
+  <div>Task assigned. Email notification will be sent to the candidate.</div>
+</tc-alert>
+
 <tc-card *ngIf="!loading">
   <tc-card-header>
     <span [ngClass]="{'custom-flex-40' : editable, 'custom-flex-75' : !editable}">

--- a/ui/admin-portal/src/app/components/candidates/view/tasks/view-candidate-tasks.component.ts
+++ b/ui/admin-portal/src/app/components/candidates/view/tasks/view-candidate-tasks.component.ts
@@ -47,6 +47,7 @@ export class ViewCandidateTasksComponent implements OnInit, OnChanges {
   loading;
   loadingResponse;
   error;
+  showAssignmentEmailNotification: boolean;
   saving;
   ongoingTasks: TaskAssignment[];
   completedTasks: TaskAssignment[];
@@ -91,6 +92,8 @@ export class ViewCandidateTasksComponent implements OnInit, OnChanges {
   }
 
   assignTask() {
+    this.showAssignmentEmailNotification = false;
+
     const assignTaskCandidateModal = this.modalService.open(AssignTasksCandidateComponent, {
       centered: true,
       backdrop: 'static'
@@ -99,7 +102,13 @@ export class ViewCandidateTasksComponent implements OnInit, OnChanges {
     assignTaskCandidateModal.componentInstance.candidateId = this.candidate.id;
 
     assignTaskCandidateModal.result
-      .then((taskAssignment: TaskAssignment) => this.candidateService.updateCandidate())
+      .then((taskAssignment: TaskAssignment) => {
+        if (taskAssignment?.task?.notifyOnAssignment) {
+          this.showAssignmentEmailNotification = true;
+          setTimeout(() => this.showAssignmentEmailNotification = false, 5000);
+        }
+        this.candidateService.updateCandidate();
+      })
       .catch(() => { /* Isn't possible */ });
 
   }

--- a/ui/admin-portal/src/app/components/tasks/assign-tasks-candidate/assign-tasks-candidate.component.html
+++ b/ui/admin-portal/src/app/components/tasks/assign-tasks-candidate/assign-tasks-candidate.component.html
@@ -62,6 +62,12 @@
             </span>
         </tc-description-item>
       </tc-description-list>
+      <tc-alert *ngIf="selectedTask?.notifyOnAssignment"
+                type="info"
+                [dismissible]="false"
+      >
+        Email notification will be sent to the candidate after this task is assigned.
+      </tc-alert>
       </div>
         <!-- CUSTOM DUE DATE -->
         <tc-field [checkbox]="true">


### PR DESCRIPTION
This PR adds an info alert in the assign-task modal to set expectations
before the candidate is assigned, letting the user know an email will
be sent.
<img width="579" height="593" alt="Screenshot 2026-06-30 at 12 11 05 AM" src="https://github.com/user-attachments/assets/4aea3065-5bd2-47cd-8159-96a92b6c8add" />

It also adds a success alert in the candidate tasks view, shown briefly after
assigning a task with notifyOnAssignment enabled. 
<img width="967" height="394" alt="Screenshot 2026-06-30 at 12 12 07 AM" src="https://github.com/user-attachments/assets/4ca771a8-6e57-4fa1-b61b-2c81589f324d" />
