### PR TITLE
Sadat/tc 1355 feature verify 11 candidate portal qr scanner component

### DIFF
--- a/ui/candidate-portal/package-lock.json
+++ b/ui/candidate-portal/package-lock.json
@@ -28,6 +28,8 @@
         "@popperjs/core": "^2.10.2",
         "@stomp/rx-stomp": "^1.1.4",
         "@types/jasmine": "^5.1.4",
+        "@zxing/library": "^0.21.3",
+        "@zxing/ngx-scanner": "^17.0.4",
         "bootstrap": "^5.0.2",
         "core-js": "^3.25.3",
         "jquery": "^3.6.1",
@@ -4488,6 +4490,58 @@
       "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
       "dev": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/@zxing/browser": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@zxing/browser/-/browser-0.1.5.tgz",
+      "integrity": "sha512-4Lmrn/il4+UNb87Gk8h1iWnhj39TASEHpd91CwwSJtY5u+wa0iH9qS0wNLAWbNVYXR66WmT5uiMhZ7oVTrKfxw==",
+      "license": "MIT",
+      "peer": true,
+      "optionalDependencies": {
+        "@zxing/text-encoding": "^0.9.0"
+      },
+      "peerDependencies": {
+        "@zxing/library": "^0.21.0"
+      }
+    },
+    "node_modules/@zxing/library": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@zxing/library/-/library-0.21.3.tgz",
+      "integrity": "sha512-hZHqFe2JyH/ZxviJZosZjV+2s6EDSY0O24R+FQmlWZBZXP9IqMo7S3nb3+2LBWxodJQkSurdQGnqE7KXqrYgow==",
+      "license": "MIT",
+      "dependencies": {
+        "ts-custom-error": "^3.2.1"
+      },
+      "engines": {
+        "node": ">= 10.4.0"
+      },
+      "optionalDependencies": {
+        "@zxing/text-encoding": "~0.9.0"
+      }
+    },
+    "node_modules/@zxing/ngx-scanner": {
+      "version": "17.0.4",
+      "resolved": "https://registry.npmjs.org/@zxing/ngx-scanner/-/ngx-scanner-17.0.4.tgz",
+      "integrity": "sha512-pR6y7WIr6SRajO9Gy28+eDqxiMakpNKqZcsDKsjjFwKwTEjc2Fx2exbf7PCN5kn7lZuB8zeNGi1muqmG8Vig8A==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/common": "^11.2.11 || ^12.0.4 || ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0",
+        "@angular/core": "^11.2.11 || ^12.0.4 || ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0",
+        "@angular/forms": "^11.2.11 || ^12.0.4 || ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0",
+        "@zxing/browser": "^0.1.4",
+        "@zxing/library": "^0.21.0",
+        "rxjs": "^6.6.3 || ^7.0.0"
+      }
+    },
+    "node_modules/@zxing/text-encoding": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@zxing/text-encoding/-/text-encoding-0.9.0.tgz",
+      "integrity": "sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==",
+      "license": "(Unlicense OR Apache-2.0)",
+      "optional": true
     },
     "node_modules/abbrev": {
       "version": "2.0.0",
@@ -13687,6 +13741,15 @@
       "license": "MIT",
       "bin": {
         "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/ts-custom-error": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/ts-custom-error/-/ts-custom-error-3.3.1.tgz",
+      "integrity": "sha512-5OX1tzOjxWEgsr/YEUWSuPrQ00deKLh6D7OTWcvNHm12/7QPyRh8SYpyWvA4IZv8H/+GQWQEh/kwo95Q9OVW1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/ts-node": {

--- a/ui/candidate-portal/package.json
+++ b/ui/candidate-portal/package.json
@@ -35,6 +35,8 @@
     "@popperjs/core": "^2.10.2",
     "@stomp/rx-stomp": "^1.1.4",
     "@types/jasmine": "^5.1.4",
+    "@zxing/library": "^0.21.3",
+    "@zxing/ngx-scanner": "^17.0.4",
     "bootstrap": "^5.0.2",
     "core-js": "^3.25.3",
     "jquery": "^3.6.1",

--- a/ui/candidate-portal/src/app/app.module.ts
+++ b/ui/candidate-portal/src/app/app.module.ts
@@ -151,6 +151,7 @@ import {
   CandidateOppComponent
 } from './components/profile/view/tab/opps/opp/candidate-opp/candidate-opp.component';
 import {NgxWigModule} from 'ngx-wig';
+import {ZXingScannerModule} from '@zxing/ngx-scanner';
 import {TruncatePipe} from "./pipes/truncate.pipe";
 import {RxStompService} from "./services/rx-stomp.service";
 import {ViewPostComponent} from "./components/chat/view-post/view-post.component";
@@ -240,6 +241,8 @@ import {
   ReferenceComponent
 } from './components/profile/view/tab/services/reference/reference.component';
 import {UnhcrComponent} from './components/profile/view/tab/services/unhcr/unhcr.component';
+import {VerifyPlusComponent} from './components/profile/view/tab/services/verify-plus/verify-plus.component';
+import {VerifyPlusScannerComponent} from './components/common/verify-plus-scanner/verify-plus-scanner.component';
 import {
   CandidateAgreementsComponent
 } from './components/profile/view/tab/agreements/candidate-agreements.component';
@@ -349,6 +352,8 @@ export function HttpLoaderFactory(http: HttpClient) {
     LinkedinRedeemedComponent,
     ReferenceComponent,
     UnhcrComponent,
+    VerifyPlusComponent,
+    VerifyPlusScannerComponent,
     CandidateAgreementsComponent,
     AgreementContentComponent
   ],
@@ -381,6 +386,7 @@ export function HttpLoaderFactory(http: HttpClient) {
     }),
     NgSelectModule,
     NgxWigModule,
+    ZXingScannerModule,
     QuillModule.forRoot(),
     PickerModule,
     TextPartsInputComponent,

--- a/ui/candidate-portal/src/app/components/common/verify-plus-scanner/verify-plus-scanner.component.html
+++ b/ui/candidate-portal/src/app/components/common/verify-plus-scanner/verify-plus-scanner.component.html
@@ -1,0 +1,54 @@
+<!--
+  ~ Copyright (c) 2026 Talent Catalog.
+  ~
+  ~ This program is free software: you can redistribute it and/or modify it under
+  ~ the terms of the GNU General Public License as published by the Free
+  ~ Software Foundation, either version 3 of the License, or any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful, but WITHOUT
+  ~ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+  ~ FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+  ~ for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program. If not, see https://www.gnu.org/licenses/.
+  -->
+
+<div class="verify-plus-scanner">
+  <div class="scanner-actions" *ngIf="!scanning && cameraPermission !== false && hasDevices !== false">
+    <tc-button [type]="'outline'" (onClick)="startScanning()">
+      Enable camera
+    </tc-button>
+  </div>
+
+  <div class="scanner-actions" *ngIf="cameraPermission === false && hasDevices !== false">
+    <p class="scanner-message scanner-message-error">
+    Camera access was denied. Please enable camera permission and try again.
+    </p>
+    <tc-button [type]="'outline'" (onClick)="startScanning()">
+      Try again
+    </tc-button>
+  </div>
+
+  <p class="scanner-message scanner-message-error" *ngIf="hasDevices === false">
+    No camera was detected on this device.
+  </p>
+
+  <zxing-scanner
+    *ngIf="hasDevices !== false"
+    [autostart]="false"
+    [enable]="scanning"
+    [formats]="formats"
+    [device]="selectedDevice"
+    (camerasFound)="onCamerasFound($event)"
+    (camerasNotFound)="onCamerasNotFound()"
+    (permissionResponse)="onPermissionResponse($event)"
+    (scanSuccess)="onScanSuccess($event)"
+    (scanFailure)="onScanFailure()"
+    (scanError)="onScanError($event)"
+  ></zxing-scanner>
+
+  <p class="scanner-message" *ngIf="scanning && invalidScan && cameraPermission !== false && hasDevices !== false">
+    A QR code has not been detected yet. Try moving closer and improving lighting.
+  </p>
+</div>

--- a/ui/candidate-portal/src/app/components/common/verify-plus-scanner/verify-plus-scanner.component.html
+++ b/ui/candidate-portal/src/app/components/common/verify-plus-scanner/verify-plus-scanner.component.html
@@ -35,11 +35,8 @@
   </p>
 
   <zxing-scanner
-    *ngIf="hasDevices !== false"
-    [autostart]="false"
-    [enable]="scanning"
+    *ngIf="scanning && hasDevices !== false"
     [formats]="formats"
-    [device]="selectedDevice"
     (camerasFound)="onCamerasFound($event)"
     (camerasNotFound)="onCamerasNotFound()"
     (permissionResponse)="onPermissionResponse($event)"

--- a/ui/candidate-portal/src/app/components/common/verify-plus-scanner/verify-plus-scanner.component.html
+++ b/ui/candidate-portal/src/app/components/common/verify-plus-scanner/verify-plus-scanner.component.html
@@ -17,7 +17,7 @@
 <div class="verify-plus-scanner">
   <div class="scanner-actions" *ngIf="!scanning && cameraPermission !== false && hasDevices !== false">
     <tc-button [type]="'outline'" (onClick)="startScanning()">
-      Enable camera
+      {{ hasScanned ? 'Scan again' : 'Enable camera' }}
     </tc-button>
   </div>
 

--- a/ui/candidate-portal/src/app/components/common/verify-plus-scanner/verify-plus-scanner.component.scss
+++ b/ui/candidate-portal/src/app/components/common/verify-plus-scanner/verify-plus-scanner.component.scss
@@ -1,0 +1,28 @@
+.verify-plus-scanner {
+  display: block;
+}
+
+.scanner-actions {
+  margin-bottom: 0.75rem;
+}
+
+.scanner-message {
+  margin-bottom: 0.75rem;
+}
+
+.scanner-message-error {
+  color: #8b1f1f;
+}
+
+zxing-scanner {
+  display: block;
+  width: 100%;
+  max-width: 420px;
+  aspect-ratio: 3 / 4;
+}
+
+:host ::ng-deep zxing-scanner video {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}

--- a/ui/candidate-portal/src/app/components/common/verify-plus-scanner/verify-plus-scanner.component.scss
+++ b/ui/candidate-portal/src/app/components/common/verify-plus-scanner/verify-plus-scanner.component.scss
@@ -17,8 +17,11 @@
 zxing-scanner {
   display: block;
   width: 100%;
-  max-width: 420px;
-  aspect-ratio: 3 / 4;
+  max-width: 100%;
+  aspect-ratio: 4 / 3;
+  max-height: 60vh;
+  margin: 0 auto;
+  overflow: hidden;
 }
 
 :host ::ng-deep zxing-scanner video {

--- a/ui/candidate-portal/src/app/components/common/verify-plus-scanner/verify-plus-scanner.component.spec.ts
+++ b/ui/candidate-portal/src/app/components/common/verify-plus-scanner/verify-plus-scanner.component.spec.ts
@@ -40,10 +40,22 @@ describe('VerifyPlusScannerComponent', () => {
 
   it('should emit scanned payload on successful scan', () => {
     spyOn(component.scanned, 'emit');
+    component.scanning = true;
 
     component.onScanSuccess('payload-value');
 
     expect(component.scanned.emit).toHaveBeenCalledWith('payload-value');
+    expect(component.scanning).toBeFalse();
+  });
+
+  it('should ignore duplicate onScanSuccess events after scanning stops', () => {
+    spyOn(component.scanned, 'emit');
+    component.scanning = true;
+
+    component.onScanSuccess('payload-value');
+    component.onScanSuccess('payload-value');
+
+    expect(component.scanned.emit).toHaveBeenCalledTimes(1);
   });
 
   it('should mark invalid scan on scan failure', () => {

--- a/ui/candidate-portal/src/app/components/common/verify-plus-scanner/verify-plus-scanner.component.spec.ts
+++ b/ui/candidate-portal/src/app/components/common/verify-plus-scanner/verify-plus-scanner.component.spec.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {NO_ERRORS_SCHEMA} from '@angular/core';
+
+import {VerifyPlusScannerComponent} from './verify-plus-scanner.component';
+
+describe('VerifyPlusScannerComponent', () => {
+  let component: VerifyPlusScannerComponent;
+  let fixture: ComponentFixture<VerifyPlusScannerComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [VerifyPlusScannerComponent],
+      schemas: [NO_ERRORS_SCHEMA]
+    });
+
+    fixture = TestBed.createComponent(VerifyPlusScannerComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should emit scanned payload on successful scan', () => {
+    spyOn(component.scanned, 'emit');
+
+    component.onScanSuccess('payload-value');
+
+    expect(component.scanned.emit).toHaveBeenCalledWith('payload-value');
+  });
+
+  it('should mark invalid scan on scan failure', () => {
+    component.onScanFailure();
+
+    expect(component.invalidScan).toBeTrue();
+  });
+
+  it('should start scanning and clear invalid scan state', () => {
+    component.invalidScan = true;
+    component.scanning = false;
+
+    component.startScanning();
+
+    expect(component.scanning).toBeTrue();
+    expect(component.invalidScan).toBeFalse();
+  });
+
+  it('should prefer a back camera when available', () => {
+    const devices = [
+      {label: 'Front Camera'} as MediaDeviceInfo,
+      {label: 'Back Camera'} as MediaDeviceInfo
+    ];
+
+    component.onCamerasFound(devices);
+
+    expect(component.selectedDevice).toBe(devices[1]);
+  });
+
+  it('should emit scanner errors', () => {
+    spyOn(component.scannerError, 'emit');
+    const error = new Error('scanner-failed');
+
+    component.onScanError(error);
+
+    expect(component.scannerError.emit).toHaveBeenCalledWith(error);
+  });
+
+  it('should stop scanning when permission is denied', () => {
+    component.scanning = true;
+
+    component.onPermissionResponse(false);
+
+    expect(component.cameraPermission).toBeFalse();
+    expect(component.scanning).toBeFalse();
+  });
+});

--- a/ui/candidate-portal/src/app/components/common/verify-plus-scanner/verify-plus-scanner.component.spec.ts
+++ b/ui/candidate-portal/src/app/components/common/verify-plus-scanner/verify-plus-scanner.component.spec.ts
@@ -62,15 +62,12 @@ describe('VerifyPlusScannerComponent', () => {
     expect(component.invalidScan).toBeFalse();
   });
 
-  it('should prefer a back camera when available', () => {
-    const devices = [
-      {label: 'Front Camera'} as MediaDeviceInfo,
-      {label: 'Back Camera'} as MediaDeviceInfo
-    ];
+  it('should update hasDevices when cameras are found or missing', () => {
+    component.onCamerasFound([{label: 'Front Camera'} as MediaDeviceInfo]);
+    expect(component.hasDevices).toBeTrue();
 
-    component.onCamerasFound(devices);
-
-    expect(component.selectedDevice).toBe(devices[1]);
+    component.onCamerasNotFound();
+    expect(component.hasDevices).toBeFalse();
   });
 
   it('should emit scanner errors', () => {

--- a/ui/candidate-portal/src/app/components/common/verify-plus-scanner/verify-plus-scanner.component.ts
+++ b/ui/candidate-portal/src/app/components/common/verify-plus-scanner/verify-plus-scanner.component.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2026 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+import {BarcodeFormat} from '@zxing/library';
+import {Component, EventEmitter, Output} from '@angular/core';
+
+/**
+ * Component for scanning QR codes using the device's camera.
+ *
+ * This component uses the ZXing library to scan QR codes. It emits events when a QR code is
+ * successfully scanned, when there is an error with the scanner, and when camera permissions are
+ * granted or denied.
+ *
+ * @author sadatmalik
+ */
+@Component({
+  selector: 'app-verify-plus-scanner',
+  templateUrl: './verify-plus-scanner.component.html',
+  styleUrl: './verify-plus-scanner.component.scss'
+})
+export class VerifyPlusScannerComponent {
+  @Output() scanned = new EventEmitter<string>();
+  @Output() scannerError = new EventEmitter<unknown>();
+
+  readonly formats = [BarcodeFormat.QR_CODE];
+
+  scanning = false;
+  hasDevices = true;
+  cameraPermission: boolean | null = null;
+  invalidScan = false;
+  selectedDevice: MediaDeviceInfo | undefined;
+
+  startScanning() {
+    this.invalidScan = false;
+    this.scanning = true;
+  }
+
+  onCamerasFound(devices: MediaDeviceInfo[]) {
+    this.hasDevices = devices.length > 0;
+    this.selectedDevice = this.selectBackCamera(devices);
+  }
+
+  onCamerasNotFound() {
+    this.hasDevices = false;
+  }
+
+  onPermissionResponse(hasPermission: boolean) {
+    this.cameraPermission = hasPermission;
+    if (!hasPermission) {
+      this.scanning = false;
+    }
+  }
+
+  onScanSuccess(decodedValue: string) {
+    if (!decodedValue) {
+      this.invalidScan = true;
+      return;
+    }
+
+    this.invalidScan = false;
+    this.scanned.emit(decodedValue);
+  }
+
+  onScanFailure() {
+    this.invalidScan = true;
+  }
+
+  onScanError(error: unknown) {
+    this.scannerError.emit(error);
+  }
+
+  private selectBackCamera(devices: MediaDeviceInfo[]): MediaDeviceInfo | undefined {
+    if (!devices.length) {
+      return undefined;
+    }
+
+    const backCamera = devices.find(device =>
+      /back|rear|environment/i.test(device.label)
+    );
+
+    return backCamera ?? devices[0];
+  }
+}

--- a/ui/candidate-portal/src/app/components/common/verify-plus-scanner/verify-plus-scanner.component.ts
+++ b/ui/candidate-portal/src/app/components/common/verify-plus-scanner/verify-plus-scanner.component.ts
@@ -38,6 +38,7 @@ export class VerifyPlusScannerComponent {
   readonly formats = [BarcodeFormat.QR_CODE];
 
   scanning = false;
+  hasScanned = false;
   hasDevices = true;
   cameraPermission: boolean | null = null;
   invalidScan = false;
@@ -63,12 +64,18 @@ export class VerifyPlusScannerComponent {
   }
 
   onScanSuccess(decodedValue: string) {
+    if (!this.scanning) {
+      return;  // ignore any late duplicate emit
+    }
+
     if (!decodedValue) {
       this.invalidScan = true;
       return;
     }
 
     this.invalidScan = false;
+    this.hasScanned = true;
+    this.scanning = false;  // stop the camera after a successful capture
     this.scanned.emit(decodedValue);
   }
 

--- a/ui/candidate-portal/src/app/components/common/verify-plus-scanner/verify-plus-scanner.component.ts
+++ b/ui/candidate-portal/src/app/components/common/verify-plus-scanner/verify-plus-scanner.component.ts
@@ -41,7 +41,6 @@ export class VerifyPlusScannerComponent {
   hasDevices = true;
   cameraPermission: boolean | null = null;
   invalidScan = false;
-  selectedDevice: MediaDeviceInfo | undefined;
 
   startScanning() {
     this.invalidScan = false;
@@ -50,7 +49,6 @@ export class VerifyPlusScannerComponent {
 
   onCamerasFound(devices: MediaDeviceInfo[]) {
     this.hasDevices = devices.length > 0;
-    this.selectedDevice = this.selectBackCamera(devices);
   }
 
   onCamerasNotFound() {
@@ -82,15 +80,4 @@ export class VerifyPlusScannerComponent {
     this.scannerError.emit(error);
   }
 
-  private selectBackCamera(devices: MediaDeviceInfo[]): MediaDeviceInfo | undefined {
-    if (!devices.length) {
-      return undefined;
-    }
-
-    const backCamera = devices.find(device =>
-      /back|rear|environment/i.test(device.label)
-    );
-
-    return backCamera ?? devices[0];
-  }
 }

--- a/ui/candidate-portal/src/app/components/profile/view/tab/services/services.component.html
+++ b/ui/candidate-portal/src/app/components/profile/view/tab/services/services.component.html
@@ -39,6 +39,11 @@
              (backButtonClicked)="onBackButtonClick()"
   ></app-unhcr>
 
+  <app-verify-plus *ngIf="(showVerifyPlus$ | async) && selectedService === Service.VERIFY_PLUS"
+                   [candidate]="candidate"
+                   (backButtonClicked)="onBackButtonClick()"
+  ></app-verify-plus>
+
   <ng-container *ngIf="!loading && !selectedService">
 
     <app-tab-header>
@@ -120,6 +125,25 @@
         </p>
       </div>
       <img src="assets/images/services/unhcr.png" alt="UNHCR Logo"/>
+    </div>
+
+    <!-- Verify+ -->
+    <div *ngIf="showVerifyPlus$ | async"
+         class="service-card unhcr"
+         (click)="selectService(Service.VERIFY_PLUS)"
+    >
+      <div>
+        <span class="service-tag unhcr">
+          Verify+
+        </span>
+        <h3>
+          UNHCR Verify+
+        </h3>
+        <p>
+          Scan your UNHCR Verify+ QR code to capture data from your card.
+        </p>
+      </div>
+      <img src="assets/images/services/unhcr.png" alt="UNHCR Verify+ Logo"/>
     </div>
 
   </ng-container>

--- a/ui/candidate-portal/src/app/components/profile/view/tab/services/services.component.spec.ts
+++ b/ui/candidate-portal/src/app/components/profile/view/tab/services/services.component.spec.ts
@@ -34,6 +34,7 @@ describe('ServicesComponent', () => {
     component = fixture.componentInstance;
     component.showLinkedin$ = of(true);
     component.showReference$ = of(true);
+    component.showVerifyPlus$ = of(true);
     fixture.detectChanges();
   });
 

--- a/ui/candidate-portal/src/app/components/profile/view/tab/services/services.component.ts
+++ b/ui/candidate-portal/src/app/components/profile/view/tab/services/services.component.ts
@@ -36,6 +36,7 @@ export class ServicesComponent {
   @Input() showLinkedin$: Observable<boolean>;
   @Input() showReference$: Observable<boolean>;
   @Input() showUnhcr$: Observable<boolean>;
+  @Input() showVerifyPlus$: Observable<boolean>;
   @Output() refresh = new EventEmitter();
 
   constructor() { }

--- a/ui/candidate-portal/src/app/components/profile/view/tab/services/verify-plus/verify-plus.component.html
+++ b/ui/candidate-portal/src/app/components/profile/view/tab/services/verify-plus/verify-plus.component.html
@@ -1,0 +1,47 @@
+<!--
+  ~ Copyright (c) 2026 Talent Catalog.
+  ~
+  ~ This program is free software: you can redistribute it and/or modify it under
+  ~ the terms of the GNU General Public License as published by the Free
+  ~ Software Foundation, either version 3 of the License, or any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful, but WITHOUT
+  ~ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+  ~ FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+  ~ for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program. If not, see https://www.gnu.org/licenses/.
+  -->
+
+<div class="service-title">
+  <div class="header">
+    <div>
+      <h2>UNHCR Verify+</h2>
+      <p>Scan your UNHCR Verify+ card QR code to capture the encoded payload.</p>
+    </div>
+  </div>
+</div>
+
+<div class="service-content">
+  <app-verify-plus-scanner
+    (scanned)="onScanned($event)"
+    (scannerError)="onScannerError($event)"
+  ></app-verify-plus-scanner>
+
+  <p class="mt-3 text-danger" *ngIf="scannerError">
+    A camera or scanner error occurred. Please refresh and try again.
+  </p>
+
+  <div class="scan-result mt-3" *ngIf="decodedPayload">
+    <h3>Decoded payload</h3>
+    <pre>{{ decodedPayload }}</pre>
+  </div>
+
+  <div class="mt-5">
+    <tc-button [type]="'outline'" (onClick)="onBackButtonClicked()">
+      <i class="me-1 fas fa-arrow-left"></i>
+      Back
+    </tc-button>
+  </div>
+</div>

--- a/ui/candidate-portal/src/app/components/profile/view/tab/services/verify-plus/verify-plus.component.scss
+++ b/ui/candidate-portal/src/app/components/profile/view/tab/services/verify-plus/verify-plus.component.scss
@@ -1,0 +1,4 @@
+.scan-result pre {
+  white-space: pre-wrap;
+  word-break: break-word;
+}

--- a/ui/candidate-portal/src/app/components/profile/view/tab/services/verify-plus/verify-plus.component.spec.ts
+++ b/ui/candidate-portal/src/app/components/profile/view/tab/services/verify-plus/verify-plus.component.spec.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {NO_ERRORS_SCHEMA} from '@angular/core';
+
+import {VerifyPlusComponent} from './verify-plus.component';
+
+describe('VerifyPlusComponent', () => {
+  let component: VerifyPlusComponent;
+  let fixture: ComponentFixture<VerifyPlusComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [VerifyPlusComponent],
+      schemas: [NO_ERRORS_SCHEMA]
+    });
+
+    fixture = TestBed.createComponent(VerifyPlusComponent);
+    component = fixture.componentInstance;
+    component.candidate = {id: 1} as any;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should store decoded payload when scanner emits', () => {
+    component.onScanned('decoded-qr');
+
+    expect(component.decodedPayload).toBe('decoded-qr');
+    expect(component.scannerError).toBeNull();
+  });
+
+  it('should emit backButtonClicked when back clicked', () => {
+    spyOn(component.backButtonClicked, 'emit');
+
+    component.onBackButtonClicked();
+
+    expect(component.backButtonClicked.emit).toHaveBeenCalled();
+  });
+});

--- a/ui/candidate-portal/src/app/components/profile/view/tab/services/verify-plus/verify-plus.component.ts
+++ b/ui/candidate-portal/src/app/components/profile/view/tab/services/verify-plus/verify-plus.component.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+import {Component, EventEmitter, Input, Output} from '@angular/core';
+import {Candidate} from '../../../../../../model/candidate';
+
+/**
+ * Component for verifying a candidate's credentials using a QR code scanner.
+ *
+ * This component displays a QR code scanner and handles the scanning process. It emits events when
+ * a QR code is successfully scanned, when there is an error with the scanner, and when the back
+ * button is clicked.
+ *
+ * @author sadatmalik
+ */
+@Component({
+  selector: 'app-verify-plus',
+  templateUrl: './verify-plus.component.html',
+  styleUrl: './verify-plus.component.scss'
+})
+export class VerifyPlusComponent {
+  @Input() candidate!: Candidate;
+  @Output() backButtonClicked = new EventEmitter<void>();
+
+  decodedPayload: string | null = null;
+  scannerError: unknown;
+
+  onScanned(payload: string) {
+    this.decodedPayload = payload;
+    this.scannerError = null;
+  }
+
+  onScannerError(error: unknown) {
+    this.scannerError = error;
+  }
+
+  onBackButtonClicked() {
+    this.backButtonClicked.emit();
+  }
+}

--- a/ui/candidate-portal/src/app/components/profile/view/view-candidate.component.html
+++ b/ui/candidate-portal/src/app/components/profile/view/view-candidate.component.html
@@ -111,6 +111,7 @@
             [showLinkedin$]="linkedinEligible$"
             [showReference$]="referenceEligible$"
             [showUnhcr$]="unhcrEligible$"
+            [showVerifyPlus$]="verifyPlusEligible$"
           ></app-services>
         </ng-template>
       </ng-container>

--- a/ui/candidate-portal/src/app/components/profile/view/view-candidate.component.ts
+++ b/ui/candidate-portal/src/app/components/profile/view/view-candidate.component.ts
@@ -20,7 +20,7 @@ import {CandidateService} from "../../../services/candidate.service";
 import {US_AFGHAN_SURVEY_TYPE} from "../../../model/survey-type";
 import {NgbNavChangeEvent} from "@ng-bootstrap/ng-bootstrap";
 import {ChatPost, JobChat, JobChatType, JobChatUserInfo} from "../../../model/chat";
-import {forkJoin, Observable, Subscription} from "rxjs";
+import {forkJoin, Observable, of, Subscription} from "rxjs";
 import {ChatService} from "../../../services/chat.service";
 import {LocalStorageService} from "../../../services/local-storage.service";
 import {Location} from "@angular/common";
@@ -69,6 +69,7 @@ export class ViewCandidateComponent implements OnInit {
   linkedinEligible$: Observable<boolean>;
   referenceEligible$: Observable<boolean>;
   unhcrEligible$: Observable<boolean>;
+  verifyPlusEligible$: Observable<boolean>;
 
   constructor(
     private authorizationService: AuthorizationService,
@@ -161,12 +162,13 @@ export class ViewCandidateComponent implements OnInit {
     const results$ = forkJoin({
       linkedIn: this.linkedinService.isEligible(this.candidate.id),
       reference: this.casiPortalService.checkEligibility('REFERENCE', 'VOUCHER'),
-      unhcr: this.casiPortalService.checkEligibility('UNHCR', 'HELP_SITE_LINK')
+      unhcr: this.casiPortalService.checkEligibility('UNHCR', 'HELP_SITE_LINK'),
+      verifyPlus: of(this.authenticationService.isGrnInstance())
       // Additional async service eligibility calls here
     }).pipe(shareReplay(1)); // Avoid re-triggering on multiple subscriptions
 
     this.showServicesTab$ = results$.pipe(
-      map(results => results.linkedIn || (this.isLocalEnv() && results.reference) || results.unhcr || !!this.activeDuolingoTask)
+      map(results => results.linkedIn || (this.isLocalEnv() && results.reference) || results.unhcr || results.verifyPlus || !!this.activeDuolingoTask)
     );
 
     this.linkedinEligible$ = results$.pipe(
@@ -179,6 +181,10 @@ export class ViewCandidateComponent implements OnInit {
 
     this.unhcrEligible$ = results$.pipe(
       map(results => results.unhcr)
+    );
+
+    this.verifyPlusEligible$ = results$.pipe(
+      map(results => results.verifyPlus)
     );
   }
 

--- a/ui/candidate-portal/src/app/components/profile/view/view-candidate.component.ts
+++ b/ui/candidate-portal/src/app/components/profile/view/view-candidate.component.ts
@@ -163,6 +163,8 @@ export class ViewCandidateComponent implements OnInit {
       linkedIn: this.linkedinService.isEligible(this.candidate.id),
       reference: this.casiPortalService.checkEligibility('REFERENCE', 'VOUCHER'),
       unhcr: this.casiPortalService.checkEligibility('UNHCR', 'HELP_SITE_LINK'),
+      // TODO - SM -when eligibility criteria is determined move this to the server as a
+      //  checkEligibility test (for example by enrolled/approved country)
       verifyPlus: of(this.authenticationService.isGrnInstance())
       // Additional async service eligibility calls here
     }).pipe(shareReplay(1)); // Avoid re-triggering on multiple subscriptions

--- a/ui/candidate-portal/src/app/model/services.ts
+++ b/ui/candidate-portal/src/app/model/services.ts
@@ -21,7 +21,8 @@ export enum ServiceProvider {
   LINKEDIN = "LINKEDIN",
   DUOLINGO = "DUOLINGO",
   REFERENCE = "REFERENCE",
-  UNHCR = "UNHCR"
+  UNHCR = "UNHCR",
+  VERIFY_PLUS = "VERIFY_PLUS"
 }
 
 /**


### PR DESCRIPTION
This PR --

- Introduces a reusable in-browser QR scanner using @zxing/ngx-scanner
- Adds a VERIFY_PLUS CASI Services card and app-verify-plus container that opens the scanner and displays the decoded payload (on-device only; no backend in this PR)
- Gates the Verify+ service to GRN instances (hidden on TBB)
- Adds/updates unit specs for the scanner, container, and services components.
