### PR TITLE
Sadat/tc 1363 feature verify 21 backend ingest endpoint capture unhcr

### DIFF
--- a/server/src/main/java/org/tctalent/server/api/portal/VerifyPlusPortalApi.java
+++ b/server/src/main/java/org/tctalent/server/api/portal/VerifyPlusPortalApi.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.api.portal;
+
+import jakarta.validation.Valid;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.tctalent.server.request.verify.VerifyPlusScanRequest;
+import org.tctalent.server.service.db.verify.VerifyPlusIngestResult;
+import org.tctalent.server.service.db.verify.VerifyPlusService;
+import org.tctalent.server.util.dto.DtoBuilder;
+
+/**
+ * Controller for handling Verify Plus scan requests from the portal.
+ * It provides an endpoint to submit scan requests and returns the result of the scan.
+ * The result includes the UNHCR number and a flag indicating if it is a duplicate.
+ *
+ * @author sadatmalik
+ */
+@RestController
+@RequestMapping("/api/portal/verify-plus")
+@RequiredArgsConstructor
+public class VerifyPlusPortalApi {
+
+    private final VerifyPlusService verifyPlusService;
+
+    @PostMapping
+    public Map<String, Object> submit(@Valid @RequestBody VerifyPlusScanRequest request) {
+        VerifyPlusIngestResult result = verifyPlusService.ingestScan(request);
+        return verifyPlusDto().build(result);
+    }
+
+    private DtoBuilder verifyPlusDto() {
+        return new DtoBuilder()
+            .add("unhcrNumber")
+            .add("duplicate");
+    }
+}

--- a/server/src/main/java/org/tctalent/server/exception/InvalidVerifyPlusPayloadException.java
+++ b/server/src/main/java/org/tctalent/server/exception/InvalidVerifyPlusPayloadException.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.exception;
+
+/**
+ * Exception thrown when the payload for a Verify Plus scan is invalid. This could occur due to
+ * reasons such as malformed data, missing required fields, or other validation errors. This exception
+ * is a subclass of InvalidRequestException and is used to indicate that the request payload does not
+ * meet the expected format or content requirements for processing a Verify Plus scan.
+ *
+ * @author sadatmalik
+ */
+public class InvalidVerifyPlusPayloadException extends InvalidRequestException {
+
+    public InvalidVerifyPlusPayloadException(String message) {
+        super(message);
+    }
+
+    public InvalidVerifyPlusPayloadException(String message, Throwable cause) {
+        super(message);
+        initCause(cause);
+    }
+}

--- a/server/src/main/java/org/tctalent/server/repository/db/CandidateRepository.java
+++ b/server/src/main/java/org/tctalent/server/repository/db/CandidateRepository.java
@@ -972,4 +972,17 @@ public interface CandidateRepository extends CacheEvictingRepository<Candidate, 
         @Param("id") long id
     );
 
+    @Query(
+        """
+        SELECT c FROM Candidate c
+        WHERE c.status IN :statuses
+          AND c.unhcrNumber = :unhcrNumber
+          AND c.id != :id
+        """)
+    List<Candidate> findOthersByUnhcrNumber(
+        @Param("statuses") List<CandidateStatus> statuses,
+        @Param("unhcrNumber") String unhcrNumber,
+        @Param("id") long id
+    );
+
 }

--- a/server/src/main/java/org/tctalent/server/request/verify/VerifyPlusScanRequest.java
+++ b/server/src/main/java/org/tctalent/server/request/verify/VerifyPlusScanRequest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.request.verify;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Represents a request to submit a Verify Plus scan.
+ * This request contains the raw payload to be processed for verification.
+ * The raw payload must be a non-blank string and should not exceed 8192 characters in length. This
+ * sets a generous limit, see:
+ * <a href="https://qrplanet.com/help/article/what-storage-capacity-does-a-qr-code-have">...</a>
+ *
+ * @author sadatmalik
+ */
+@Getter
+@Setter
+public class VerifyPlusScanRequest {
+
+    @NotBlank(message = "Raw payload is required")
+    @Size(max = 8192, message = "Raw payload exceeds maximum allowed length")
+    private String rawPayload;
+}

--- a/server/src/main/java/org/tctalent/server/service/db/verify/VerifyPlusIngestResult.java
+++ b/server/src/main/java/org/tctalent/server/service/db/verify/VerifyPlusIngestResult.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.service.db.verify;
+
+import lombok.Getter;
+
+/**
+ * Represents the result of a Verify Plus scan ingestion.
+ * It contains the UNHCR number associated with the scan and a flag indicating whether the scan
+ * is for a duplicate number.
+ *
+ * @author sadatmalik
+ */
+@Getter
+public class VerifyPlusIngestResult {
+
+    private final String unhcrNumber;
+    private final boolean duplicate;
+
+    public VerifyPlusIngestResult(String unhcrNumber, boolean duplicate) {
+        this.unhcrNumber = unhcrNumber;
+        this.duplicate = duplicate;
+    }
+}

--- a/server/src/main/java/org/tctalent/server/service/db/verify/VerifyPlusPayload.java
+++ b/server/src/main/java/org/tctalent/server/service/db/verify/VerifyPlusPayload.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.service.db.verify;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Represents the payload of a Verify Plus scan. It contains the version of the payload, the raw
+ * payload data, and the UNHCR ID associated with the scan. For now this is for testing and iterative
+ * development. The exact payload structure and fields are expected to change as the Verify Plus
+ * integration evolves.
+ *
+ * @author sadatmalik
+ */
+@Getter
+@RequiredArgsConstructor
+public class VerifyPlusPayload {
+
+    private final String version;
+    private final String rawPayload;
+    private final String unhcrId;
+
+}

--- a/server/src/main/java/org/tctalent/server/service/db/verify/VerifyPlusPayloadParser.java
+++ b/server/src/main/java/org/tctalent/server/service/db/verify/VerifyPlusPayloadParser.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.service.db.verify;
+
+/**
+ * Interface for parsing raw payloads from Verify Plus scans. Implementations of this interface are
+ * responsible for extracting relevant information from the raw payload string and creating a
+ * VerifyPlusPayload object that encapsulates the parsed data.
+ *
+ * @author sadatmalik
+ */
+public interface VerifyPlusPayloadParser {
+
+    VerifyPlusPayload parse(String rawPayload);
+}

--- a/server/src/main/java/org/tctalent/server/service/db/verify/VerifyPlusService.java
+++ b/server/src/main/java/org/tctalent/server/service/db/verify/VerifyPlusService.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.service.db.verify;
+
+import org.tctalent.server.request.verify.VerifyPlusScanRequest;
+
+/**
+ * Service interface for handling Verify Plus scan ingestion. Implementations of this interface are
+ * responsible for processing incoming Verify Plus scan requests, validating the payload, and
+ * returning the result of the ingestion process. The service may also handle any necessary business
+ * logic related to the scan data, such as checking for duplicates or storing relevant information
+ * in a database.
+ *
+ * @author sadatmalik
+ */
+public interface VerifyPlusService {
+
+    VerifyPlusIngestResult ingestScan(VerifyPlusScanRequest request);
+}

--- a/server/src/main/java/org/tctalent/server/service/db/verify/impl/VerifyPlusPayloadParserImpl.java
+++ b/server/src/main/java/org/tctalent/server/service/db/verify/impl/VerifyPlusPayloadParserImpl.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.service.db.verify.impl;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.tctalent.server.exception.InvalidVerifyPlusPayloadException;
+import org.tctalent.server.service.db.verify.VerifyPlusPayload;
+import org.tctalent.server.service.db.verify.VerifyPlusPayloadParser;
+
+/**
+ * Mock parser contract is currently provisionally mocked and versioned:
+ * {"v":"mock-1","unhcrId":"..."}.
+ * The raw payload string is never modified to preserve byte-exact handling.
+ *
+ * @author sadatmalik
+ */
+@Service
+@RequiredArgsConstructor
+public class VerifyPlusPayloadParserImpl implements VerifyPlusPayloadParser {
+
+    private static final String MOCK_1 = "mock-1";
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public VerifyPlusPayload parse(String rawPayload) {
+        try {
+            JsonNode root = objectMapper.readTree(rawPayload);
+
+            String version = textValue(root, "v");
+            if (!MOCK_1.equals(version)) {
+                throw new InvalidVerifyPlusPayloadException(
+                    "Unsupported Verify+ payload version: " + version);
+            }
+
+            String unhcrId = textValue(root, "unhcrId");
+
+            return new VerifyPlusPayload(version, rawPayload, unhcrId);
+        } catch (InvalidVerifyPlusPayloadException ex) {
+            throw ex;
+        } catch (Exception ex) {
+            throw new InvalidVerifyPlusPayloadException("Malformed Verify+ payload", ex);
+        }
+    }
+
+    private String textValue(JsonNode root, String fieldName) {
+        JsonNode node = root.get(fieldName);
+        if (node == null || node.isNull()) {
+            throw new InvalidVerifyPlusPayloadException("Missing field: " + fieldName);
+        }
+        if (!node.isTextual()) {
+            throw new InvalidVerifyPlusPayloadException("Field must be text: " + fieldName);
+        }
+
+        String value = node.textValue();
+        if (value == null || value.isEmpty()) {
+            throw new InvalidVerifyPlusPayloadException("Field cannot be empty: " + fieldName);
+        }
+        return value;
+    }
+}

--- a/server/src/main/java/org/tctalent/server/service/db/verify/impl/VerifyPlusServiceImpl.java
+++ b/server/src/main/java/org/tctalent/server/service/db/verify/impl/VerifyPlusServiceImpl.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.service.db.verify.impl;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.tctalent.server.exception.InvalidSessionException;
+import org.tctalent.server.model.db.Candidate;
+import org.tctalent.server.model.db.CandidateStatus;
+import org.tctalent.server.repository.db.CandidateRepository;
+import org.tctalent.server.request.verify.VerifyPlusScanRequest;
+import org.tctalent.server.service.db.CandidateService;
+import org.tctalent.server.service.db.verify.VerifyPlusIngestResult;
+import org.tctalent.server.service.db.verify.VerifyPlusPayload;
+import org.tctalent.server.service.db.verify.VerifyPlusPayloadParser;
+import org.tctalent.server.service.db.verify.VerifyPlusService;
+
+// TODO doco
+// Flow: logged-in candidate -> parse raw payload -> duplicate check across active-like statuses->
+// overwrite candidate.unhcrNumber -> return {unhcrNumber, duplicate}.
+@Service
+@RequiredArgsConstructor
+public class VerifyPlusServiceImpl implements VerifyPlusService {
+
+    private static final List<CandidateStatus> ACTIVE_STATUSES =
+        List.of(
+            CandidateStatus.active,
+            CandidateStatus.unreachable,
+            CandidateStatus.incomplete,
+            CandidateStatus.pending
+        );
+
+    private final CandidateService candidateService;
+    private final CandidateRepository candidateRepository;
+    private final VerifyPlusPayloadParser payloadParser;
+
+    @Override
+    @Transactional
+    public VerifyPlusIngestResult ingestScan(VerifyPlusScanRequest request) {
+        // TODO - SM - ok for testing via Casi service - but for registration flow confirm if the
+        //  candidate will be logged in if the scan is handled as a distinct "step 2"
+        Candidate candidate = candidateService.getLoggedInCandidate()
+            .orElseThrow(() -> new InvalidSessionException("Not logged in"));
+
+        VerifyPlusPayload payload = payloadParser.parse(request.getRawPayload());
+        String unhcrId = payload.getUnhcrId();
+
+        boolean duplicate = !candidateRepository.findOthersByUnhcrNumber(
+            ACTIVE_STATUSES,
+            unhcrId,
+            candidate.getId()
+        ).isEmpty();
+
+        candidate.setUnhcrNumber(unhcrId);
+        candidateService.save(candidate);
+
+        return new VerifyPlusIngestResult(unhcrId, duplicate);
+    }
+}

--- a/server/src/test/java/org/tctalent/server/api/portal/VerifyPlusPortalApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/portal/VerifyPlusPortalApiTest.java
@@ -1,0 +1,57 @@
+package org.tctalent.server.api.portal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.tctalent.server.exception.InvalidVerifyPlusPayloadException;
+import org.tctalent.server.request.verify.VerifyPlusScanRequest;
+import org.tctalent.server.service.db.verify.VerifyPlusIngestResult;
+import org.tctalent.server.service.db.verify.VerifyPlusService;
+
+class VerifyPlusPortalApiTest {
+
+    @Mock
+    private VerifyPlusService verifyPlusService;
+
+    @InjectMocks
+    private VerifyPlusPortalApi verifyPlusPortalApi;
+
+    private VerifyPlusScanRequest request;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        request = new VerifyPlusScanRequest();
+        request.setRawPayload("{\"v\":\"mock-1\",\"unhcrId\":\"UNHCR-1\"}");
+    }
+
+    @Test
+    void submit_validPayload_returnsMappedResult() {
+        VerifyPlusIngestResult result = new VerifyPlusIngestResult("UNHCR-1", true);
+        when(verifyPlusService.ingestScan(request)).thenReturn(result);
+
+        Map<String, Object> response = verifyPlusPortalApi.submit(request);
+
+        assertNotNull(response);
+        assertEquals("UNHCR-1", response.get("unhcrNumber"));
+        assertEquals(true, response.get("duplicate"));
+        verify(verifyPlusService).ingestScan(request);
+    }
+
+    @Test
+    void submit_malformedPayload_propagatesValidationException() {
+        when(verifyPlusService.ingestScan(request))
+            .thenThrow(new InvalidVerifyPlusPayloadException("Malformed Verify+ payload"));
+
+        assertThrows(InvalidVerifyPlusPayloadException.class, () -> verifyPlusPortalApi.submit(request));
+    }
+}

--- a/server/src/test/java/org/tctalent/server/api/portal/VerifyPlusPortalApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/portal/VerifyPlusPortalApiTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -35,6 +36,7 @@ class VerifyPlusPortalApiTest {
     }
 
     @Test
+    @DisplayName("Given a valid payload, when submitted, then returns a mapped result with UNHCR number and duplicate flag")
     void submit_validPayload_returnsMappedResult() {
         VerifyPlusIngestResult result = new VerifyPlusIngestResult("UNHCR-1", true);
         when(verifyPlusService.ingestScan(request)).thenReturn(result);
@@ -48,6 +50,7 @@ class VerifyPlusPortalApiTest {
     }
 
     @Test
+    @DisplayName("Given a malformed payload, when submitted, then propagates InvalidVerifyPlusPayloadException")
     void submit_malformedPayload_propagatesValidationException() {
         when(verifyPlusService.ingestScan(request))
             .thenThrow(new InvalidVerifyPlusPayloadException("Malformed Verify+ payload"));

--- a/server/src/test/java/org/tctalent/server/service/db/verify/impl/VerifyPlusPayloadParserImplTest.java
+++ b/server/src/test/java/org/tctalent/server/service/db/verify/impl/VerifyPlusPayloadParserImplTest.java
@@ -1,0 +1,68 @@
+package org.tctalent.server.service.db.verify.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.tctalent.server.exception.InvalidVerifyPlusPayloadException;
+import org.tctalent.server.service.db.verify.VerifyPlusPayload;
+
+class VerifyPlusPayloadParserImplTest {
+
+    private VerifyPlusPayloadParserImpl parser;
+
+    @BeforeEach
+    void setUp() {
+        parser = new VerifyPlusPayloadParserImpl(new ObjectMapper());
+    }
+
+    @Test
+    void parse_validMock1Payload_returnsParsedPayload() {
+        String raw = "{\"v\":\"mock-1\",\"unhcrId\":\"123-45C67890\",\"name\":\"Test User\"}";
+
+        VerifyPlusPayload payload = parser.parse(raw);
+
+        assertEquals("mock-1", payload.getVersion());
+        assertEquals("123-45C67890", payload.getUnhcrId());
+        assertEquals(raw, payload.getRawPayload());
+    }
+
+    @Test
+    void parse_missingVersion_throwsInvalidVerifyPlusPayloadException() {
+        String raw = "{\"unhcrId\":\"123-45C67890\"}";
+
+        assertThrows(InvalidVerifyPlusPayloadException.class, () -> parser.parse(raw));
+    }
+
+    @Test
+    void parse_unknownVersion_throwsInvalidVerifyPlusPayloadException() {
+        String raw = "{\"v\":\"mock-2\",\"unhcrId\":\"123-45C67890\"}";
+
+        assertThrows(InvalidVerifyPlusPayloadException.class, () -> parser.parse(raw));
+    }
+
+    @Test
+    void parse_malformedJson_throwsInvalidVerifyPlusPayloadException() {
+        String raw = "{\"v\":\"mock-1\",\"unhcrId\":\"123-45C67890\"";
+
+        assertThrows(InvalidVerifyPlusPayloadException.class, () -> parser.parse(raw));
+    }
+
+    @Test
+    void parse_missingUnhcrId_throwsInvalidVerifyPlusPayloadException() {
+        String raw = "{\"v\":\"mock-1\"}";
+
+        assertThrows(InvalidVerifyPlusPayloadException.class, () -> parser.parse(raw));
+    }
+
+    @Test
+    void parse_preservesRawPayloadExactly() {
+        String raw = "  {\"v\":\"mock-1\",\"unhcrId\":\"123-45C67890\"}  ";
+
+        VerifyPlusPayload payload = parser.parse(raw);
+
+        assertEquals(raw, payload.getRawPayload());
+    }
+}

--- a/server/src/test/java/org/tctalent/server/service/db/verify/impl/VerifyPlusPayloadParserImplTest.java
+++ b/server/src/test/java/org/tctalent/server/service/db/verify/impl/VerifyPlusPayloadParserImplTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.tctalent.server.exception.InvalidVerifyPlusPayloadException;
 import org.tctalent.server.service.db.verify.VerifyPlusPayload;
@@ -19,6 +20,7 @@ class VerifyPlusPayloadParserImplTest {
     }
 
     @Test
+    @DisplayName("Given a valid mock-1 payload, when parsed, then returns a VerifyPlusPayload with correct fields")
     void parse_validMock1Payload_returnsParsedPayload() {
         String raw = "{\"v\":\"mock-1\",\"unhcrId\":\"123-45C67890\",\"name\":\"Test User\"}";
 
@@ -30,6 +32,7 @@ class VerifyPlusPayloadParserImplTest {
     }
 
     @Test
+    @DisplayName("Given a payload missing the version field, when parsed, then throws InvalidVerifyPlusPayloadException")
     void parse_missingVersion_throwsInvalidVerifyPlusPayloadException() {
         String raw = "{\"unhcrId\":\"123-45C67890\"}";
 
@@ -37,6 +40,7 @@ class VerifyPlusPayloadParserImplTest {
     }
 
     @Test
+    @DisplayName("Given a payload with an unknown version, when parsed, then throws InvalidVerifyPlusPayloadException")
     void parse_unknownVersion_throwsInvalidVerifyPlusPayloadException() {
         String raw = "{\"v\":\"mock-2\",\"unhcrId\":\"123-45C67890\"}";
 
@@ -44,6 +48,7 @@ class VerifyPlusPayloadParserImplTest {
     }
 
     @Test
+    @DisplayName("Given a malformed JSON payload, when parsed, then throws InvalidVerifyPlusPayloadException")
     void parse_malformedJson_throwsInvalidVerifyPlusPayloadException() {
         String raw = "{\"v\":\"mock-1\",\"unhcrId\":\"123-45C67890\"";
 
@@ -51,6 +56,7 @@ class VerifyPlusPayloadParserImplTest {
     }
 
     @Test
+    @DisplayName("Given a payload missing the unhcrId field, when parsed, then throws InvalidVerifyPlusPayloadException")
     void parse_missingUnhcrId_throwsInvalidVerifyPlusPayloadException() {
         String raw = "{\"v\":\"mock-1\"}";
 
@@ -58,6 +64,7 @@ class VerifyPlusPayloadParserImplTest {
     }
 
     @Test
+    @DisplayName("Given a payload with extra whitespace, when parsed, then preserves the raw payload exactly")
     void parse_preservesRawPayloadExactly() {
         String raw = "  {\"v\":\"mock-1\",\"unhcrId\":\"123-45C67890\"}  ";
 

--- a/server/src/test/java/org/tctalent/server/service/db/verify/impl/VerifyPlusServiceImplTest.java
+++ b/server/src/test/java/org/tctalent/server/service/db/verify/impl/VerifyPlusServiceImplTest.java
@@ -1,0 +1,113 @@
+package org.tctalent.server.service.db.verify.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.tctalent.server.exception.InvalidSessionException;
+import org.tctalent.server.model.db.Candidate;
+import org.tctalent.server.repository.db.CandidateRepository;
+import org.tctalent.server.request.verify.VerifyPlusScanRequest;
+import org.tctalent.server.service.db.CandidateService;
+import org.tctalent.server.service.db.verify.VerifyPlusIngestResult;
+import org.tctalent.server.service.db.verify.VerifyPlusPayload;
+import org.tctalent.server.service.db.verify.VerifyPlusPayloadParser;
+
+class VerifyPlusServiceImplTest {
+
+    @Mock
+    private CandidateService candidateService;
+
+    @Mock
+    private CandidateRepository candidateRepository;
+
+    @Mock
+    private VerifyPlusPayloadParser payloadParser;
+
+    @InjectMocks
+    private VerifyPlusServiceImpl verifyPlusService;
+
+    private Candidate candidate;
+    private VerifyPlusScanRequest request;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+
+        candidate = new Candidate();
+        candidate.setId(10L);
+
+        request = new VerifyPlusScanRequest();
+        request.setRawPayload("{\"v\":\"mock-1\",\"unhcrId\":\"UNHCR-1\"}");
+    }
+
+    @Test
+    void ingestScan_uniqueUnhcrId_persistsAndReturnsDuplicateFalse() {
+        VerifyPlusPayload parsed = new VerifyPlusPayload("mock-1", request.getRawPayload(), "UNHCR-1");
+        when(candidateService.getLoggedInCandidate()).thenReturn(Optional.of(candidate));
+        when(payloadParser.parse(request.getRawPayload())).thenReturn(parsed);
+        when(candidateRepository.findOthersByUnhcrNumber(any(), any(), any(Long.class))).thenReturn(
+            Collections.emptyList());
+        when(candidateService.save(candidate)).thenReturn(candidate);
+
+        VerifyPlusIngestResult result = verifyPlusService.ingestScan(request);
+
+        assertEquals("UNHCR-1", candidate.getUnhcrNumber());
+        assertEquals("UNHCR-1", result.getUnhcrNumber());
+        assertFalse(result.isDuplicate());
+        verify(candidateService).save(candidate);
+    }
+
+    @Test
+    void ingestScan_duplicateUnhcrId_returnsDuplicateTrue() {
+        VerifyPlusPayload parsed = new VerifyPlusPayload("mock-1", request.getRawPayload(), "UNHCR-1");
+        Candidate other = new Candidate();
+        other.setId(20L);
+
+        when(candidateService.getLoggedInCandidate()).thenReturn(Optional.of(candidate));
+        when(payloadParser.parse(request.getRawPayload())).thenReturn(parsed);
+        when(candidateRepository.findOthersByUnhcrNumber(any(), any(), any(Long.class))).thenReturn(
+            List.of(other));
+        when(candidateService.save(candidate)).thenReturn(candidate);
+
+        VerifyPlusIngestResult result = verifyPlusService.ingestScan(request);
+
+        assertTrue(result.isDuplicate());
+    }
+
+    @Test
+    void ingestScan_overwritesUnhcrNumberOnRescan() {
+        candidate.setUnhcrNumber("OLD-UNHCR");
+        VerifyPlusPayload parsed = new VerifyPlusPayload("mock-1", request.getRawPayload(), "NEW-UNHCR");
+
+        when(candidateService.getLoggedInCandidate()).thenReturn(Optional.of(candidate));
+        when(payloadParser.parse(request.getRawPayload())).thenReturn(parsed);
+        when(candidateRepository.findOthersByUnhcrNumber(any(), any(), any(Long.class))).thenReturn(
+            Collections.emptyList());
+        when(candidateService.save(candidate)).thenReturn(candidate);
+
+        VerifyPlusIngestResult result = verifyPlusService.ingestScan(request);
+
+        assertEquals("NEW-UNHCR", candidate.getUnhcrNumber());
+        assertEquals("NEW-UNHCR", result.getUnhcrNumber());
+    }
+
+    @Test
+    void ingestScan_notLoggedIn_throwsInvalidSessionException() {
+        when(candidateService.getLoggedInCandidate()).thenReturn(Optional.empty());
+
+        assertThrows(InvalidSessionException.class, () -> verifyPlusService.ingestScan(request));
+    }
+}

--- a/server/src/test/java/org/tctalent/server/service/db/verify/impl/VerifyPlusServiceImplTest.java
+++ b/server/src/test/java/org/tctalent/server/service/db/verify/impl/VerifyPlusServiceImplTest.java
@@ -12,6 +12,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -54,6 +55,7 @@ class VerifyPlusServiceImplTest {
     }
 
     @Test
+    @DisplayName("Given a valid payload with a unique UNHCR ID, when ingestScan is called, then the candidate's UNHCR number is updated and duplicate is false")
     void ingestScan_uniqueUnhcrId_persistsAndReturnsDuplicateFalse() {
         VerifyPlusPayload parsed = new VerifyPlusPayload("mock-1", request.getRawPayload(), "UNHCR-1");
         when(candidateService.getLoggedInCandidate()).thenReturn(Optional.of(candidate));
@@ -71,6 +73,7 @@ class VerifyPlusServiceImplTest {
     }
 
     @Test
+    @DisplayName("Given a valid payload with a duplicate UNHCR ID, when ingestScan is called, then the candidate's UNHCR number is updated and duplicate is true")
     void ingestScan_duplicateUnhcrId_returnsDuplicateTrue() {
         VerifyPlusPayload parsed = new VerifyPlusPayload("mock-1", request.getRawPayload(), "UNHCR-1");
         Candidate other = new Candidate();
@@ -88,6 +91,7 @@ class VerifyPlusServiceImplTest {
     }
 
     @Test
+    @DisplayName("Given a candidate with an existing UNHCR number, when ingestScan is called with a new UNHCR number, then the candidate's UNHCR number is overwritten")
     void ingestScan_overwritesUnhcrNumberOnRescan() {
         candidate.setUnhcrNumber("OLD-UNHCR");
         VerifyPlusPayload parsed = new VerifyPlusPayload("mock-1", request.getRawPayload(), "NEW-UNHCR");
@@ -105,6 +109,7 @@ class VerifyPlusServiceImplTest {
     }
 
     @Test
+    @DisplayName("Given no logged-in candidate, when ingestScan is called, then an InvalidSessionException is thrown")
     void ingestScan_notLoggedIn_throwsInvalidSessionException() {
         when(candidateService.getLoggedInCandidate()).thenReturn(Optional.empty());
 


### PR DESCRIPTION
This PR delivers the backend for processing Verify+ QR payloads --

- API and services to ingest a raw Verify+ QR payload.
- Raw payload is handled byte-exact - so a future signature check stays valid.
- UNHCR ID is parsed out from a mocked QR payload and stored on Candidate.unhcrNumber.
- Signals duplicates in parsed response

