### PR TITLE
Sadat/tc 1368 bug redis cache failure breaks jwt authentication durable

### DIFF
--- a/server/src/main/java/org/tctalent/server/configuration/CacheConfig.java
+++ b/server/src/main/java/org/tctalent/server/configuration/CacheConfig.java
@@ -16,11 +16,54 @@
 
 package org.tctalent.server.configuration;
 
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.Cache;
+import org.springframework.cache.annotation.CachingConfigurer;
 import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.interceptor.CacheErrorHandler;
 import org.springframework.context.annotation.Configuration;
+import org.tctalent.server.logging.LogBuilder;
 
+@Slf4j
 @Configuration
 @EnableCaching
-public class CacheConfig {
+public class CacheConfig implements CachingConfigurer {
 
+  @Override
+  public CacheErrorHandler errorHandler() {
+    return new CacheErrorHandler() {
+      @Override
+      public void handleCacheGetError(RuntimeException exception, Cache cache, Object key) {
+        logCacheError("get", cache, key, exception);
+      }
+
+      @Override
+      public void handleCachePutError(RuntimeException exception, Cache cache, Object key,
+          Object value) {
+        logCacheError("put", cache, key, exception);
+      }
+
+      @Override
+      public void handleCacheEvictError(RuntimeException exception, Cache cache, Object key) {
+        logCacheError("evict", cache, key, exception);
+      }
+
+      @Override
+      public void handleCacheClearError(RuntimeException exception, Cache cache) {
+        logCacheError("clear", cache, null, exception);
+      }
+
+      private void logCacheError(String operation, Cache cache, Object key,
+                                 RuntimeException exception) {
+        LogBuilder.builder(log)
+            .action("cache-" + operation)
+            .message("Cache " + operation + " failed for cache '"
+                + (cache != null ? cache.getName() : "unknown")
+                + "'"
+                + (key != null ? " key '" + key + "'" : "")
+                + " - falling through to database")
+            .logError(exception);
+      }
+    };
+  }
 }

--- a/server/src/main/java/org/tctalent/server/configuration/properties/CandidateCacheProperties.java
+++ b/server/src/main/java/org/tctalent/server/configuration/properties/CandidateCacheProperties.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.configuration.properties;
+
+import java.time.Duration;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties for candidate JSON cache.
+ * <p>
+ * Properties are prefixed with {@code tc.cache.candidate}.
+ *
+ * @author sadatmalik
+ */
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "tc.cache.candidate")
+public class CandidateCacheProperties {
+
+    /**
+     * TTL applied to candidate JSON cache entries in Redis.
+     * A non-positive value (e.g. 0) disables expiry.
+     */
+    private Duration ttl = Duration.ofDays(7);
+}

--- a/server/src/main/java/org/tctalent/server/repository/db/read/cache/CandidateRedisCache.java
+++ b/server/src/main/java/org/tctalent/server/repository/db/read/cache/CandidateRedisCache.java
@@ -25,6 +25,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.stereotype.Repository;
+import org.tctalent.server.configuration.properties.CandidateCacheProperties;
 
 /**
  * Redis-backed L1 cache for candidate JSON.
@@ -46,15 +47,7 @@ import org.springframework.stereotype.Repository;
 public class CandidateRedisCache {
 
     private final StringRedisTemplate redisTemplate;
-
-    /**
-     * Optional TTL for Redis entries.
-     * Can be null to disable expiry.
-     * <p>
-     * In practice, 7–30 days is a reasonable default.
-     * </p>
-     */
-    private final Duration ttl = null; //todo Pick up from config
+    private final CandidateCacheProperties cacheProperties;
 
     private ValueOperations<String, String> values() {
         return redisTemplate.opsForValue();
@@ -109,7 +102,7 @@ public class CandidateRedisCache {
      * does not support per-key TTL.
      * </p>
      * <p>
-     * If TTL is null, entries are stored without expiry.
+     * If TTL is non-positive, entries are stored without expiry.
      * </p>
      */
     public void putAll(Map<Long, VersionedJson> rows) {
@@ -118,10 +111,13 @@ public class CandidateRedisCache {
             return;
         }
 
+        Duration ttl = cacheProperties.getTtl();
+        boolean hasTtl = ttl != null && !ttl.isZero() && !ttl.isNegative();
+
         for (VersionedJson row : rows.values()) {
             String key = key(row.candidateId(), row.version());
 
-            if (ttl == null) {
+            if (!hasTtl) {
                 values().set(key, row.json());
             } else {
                 values().set(key, row.json(), ttl);

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -1,4 +1,9 @@
 tc:
+  cache:
+    candidate:
+      # Memory-hygiene TTL for the candidate JSON read cache. Set to 0 to disable expiry.
+      ttl: ${TC_CANDIDATE_CACHE_TTL:7d}
+
   cors:
     urls: ${TC_CORS_URLS:http://localhost:4200,http://127.0.0.1:4200,http://localhost:4201,http://localhost:4202}
 

--- a/server/src/test/java/org/tctalent/server/configuration/CacheErrorHandlerTest.java
+++ b/server/src/test/java/org/tctalent/server/configuration/CacheErrorHandlerTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2026 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.support.SimpleCacheManager;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+class CacheErrorHandlerTest {
+
+  static class TestCacheableService {
+    private final CountingRepository countingRepository;
+
+    TestCacheableService(CountingRepository countingRepository) {
+      this.countingRepository = countingRepository;
+    }
+
+    @Cacheable(value = "users", key = "#username")
+    public String loadByUsername(String username) {
+      return countingRepository.load(username);
+    }
+  }
+
+  static class CountingRepository {
+    private final AtomicInteger calls = new AtomicInteger();
+
+    String load(String username) {
+      return "db-value-" + calls.incrementAndGet() + "-" + username;
+    }
+
+    int calls() {
+      return calls.get();
+    }
+  }
+
+  static class ThrowingCache implements Cache {
+    private final String name;
+
+    ThrowingCache(String name) {
+      this.name = name;
+    }
+
+    @Override
+    public String getName() {
+      return name;
+    }
+
+    @Override
+    public Object getNativeCache() {
+      return this;
+    }
+
+    @Override
+    public ValueWrapper get(Object key) {
+      throw new RuntimeException("Cache get failure");
+    }
+
+    @Override
+    public <T> T get(Object key, Class<T> type) {
+      throw new RuntimeException("Cache get failure");
+    }
+
+    @Override
+    public <T> T get(Object key, Callable<T> valueLoader) {
+      throw new RuntimeException("Cache get failure");
+    }
+
+    @Override
+    public void put(Object key, Object value) {
+      throw new RuntimeException("Cache put failure");
+    }
+
+    @Override
+    public ValueWrapper putIfAbsent(Object key, Object value) {
+      throw new RuntimeException("Cache put failure");
+    }
+
+    @Override
+    public void evict(Object key) {
+      throw new RuntimeException("Cache evict failure");
+    }
+
+    @Override
+    public void clear() {
+      throw new RuntimeException("Cache clear failure");
+    }
+  }
+
+  @Test
+  void cacheErrorsFallThroughToRepository() {
+    try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext()) {
+      context.register(CacheConfig.class);
+      context.registerBean(CacheManager.class, () -> {
+        SimpleCacheManager cacheManager = new SimpleCacheManager();
+        cacheManager.setCaches(List.of(new ThrowingCache("users")));
+        return cacheManager;
+      });
+      context.registerBean(CountingRepository.class);
+      context.registerBean(TestCacheableService.class);
+      context.refresh();
+
+      TestCacheableService service = context.getBean(TestCacheableService.class);
+      CountingRepository repository = context.getBean(CountingRepository.class);
+
+      String firstResult = service.loadByUsername("alice");
+      String secondResult = service.loadByUsername("alice");
+
+      assertThat(firstResult).isEqualTo("db-value-1-alice");
+      assertThat(secondResult).isEqualTo("db-value-2-alice");
+      assertThat(repository.calls()).isEqualTo(2);
+    }
+  }
+}


### PR DESCRIPTION
This PR fixes two Redis cache related problems:

- Implements a custom CacheErrorHandler to log cache operation failures and fall back to database
- Add custom candidate cache properties with configurable TTL for Redis entries on CandidateRedisCache

See the issue comments for further details.