### PR TITLE
Add copyright headers to new unit test classes

### DIFF
--- a/server/src/test/java/org/tctalent/server/api/portal/VerifyPlusPortalApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/portal/VerifyPlusPortalApiTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2026 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
 package org.tctalent.server.api.portal;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/server/src/test/java/org/tctalent/server/service/db/verify/impl/VerifyPlusPayloadParserImplTest.java
+++ b/server/src/test/java/org/tctalent/server/service/db/verify/impl/VerifyPlusPayloadParserImplTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2026 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
 package org.tctalent.server.service.db.verify.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/server/src/test/java/org/tctalent/server/service/db/verify/impl/VerifyPlusServiceImplTest.java
+++ b/server/src/test/java/org/tctalent/server/service/db/verify/impl/VerifyPlusServiceImplTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2026 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
 package org.tctalent.server.service.db.verify.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;


### PR DESCRIPTION
This PR --

- Adds the standard copyright header to VerifyPlusPayloadParserImplTest, VerifyPlusPortalApiTest, and VerifyPlusServiceImplTest

