### PR TITLE
Hiba/tc 1389 replace some old copyright text headers

### DIFF
--- a/server/src/main/java/org/tctalent/server/service/db/ChatUploadFileService.java
+++ b/server/src/main/java/org/tctalent/server/service/db/ChatUploadFileService.java
@@ -1,6 +1,18 @@
-// Copyright 2008 Orc Software AB. All rights reserved.
-// Reproduction in whole or in part in any form or medium without express
-// written permission of Orc Software AB is strictly prohibited.
+/*
+ * Copyright (c) 2026 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
 
 package org.tctalent.server.service.db;
 

--- a/server/src/main/java/org/tctalent/server/service/db/util/PagedCandidateBackProcessor.java
+++ b/server/src/main/java/org/tctalent/server/service/db/util/PagedCandidateBackProcessor.java
@@ -1,6 +1,18 @@
-// Copyright 2008 Orc Software AB. All rights reserved.
-// Reproduction in whole or in part in any form or medium without express
-// written permission of Orc Software AB is strictly prohibited.
+/*
+ * Copyright (c) 2026 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
 
 package org.tctalent.server.service.db.util;
 

--- a/server/src/main/java/org/tctalent/server/service/db/util/PagedPartnerBackProcessor.java
+++ b/server/src/main/java/org/tctalent/server/service/db/util/PagedPartnerBackProcessor.java
@@ -1,6 +1,18 @@
-// Copyright 2008 Orc Software AB. All rights reserved.
-// Reproduction in whole or in part in any form or medium without express
-// written permission of Orc Software AB is strictly prohibited.
+/*
+ * Copyright (c) 2026 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
 
 package org.tctalent.server.service.db.util;
 

--- a/server/src/main/java/org/tctalent/server/service/db/util/PagedSavedListBackProcessor.java
+++ b/server/src/main/java/org/tctalent/server/service/db/util/PagedSavedListBackProcessor.java
@@ -1,6 +1,18 @@
-// Copyright 2008 Orc Software AB. All rights reserved.
-// Reproduction in whole or in part in any form or medium without express
-// written permission of Orc Software AB is strictly prohibited.
+/*
+ * Copyright (c) 2026 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
 
 package org.tctalent.server.service.db.util;
 

--- a/server/src/main/java/org/tctalent/server/service/db/util/PagedSavedSearchBackProcessor.java
+++ b/server/src/main/java/org/tctalent/server/service/db/util/PagedSavedSearchBackProcessor.java
@@ -1,6 +1,18 @@
-// Copyright 2008 Orc Software AB. All rights reserved.
-// Reproduction in whole or in part in any form or medium without express
-// written permission of Orc Software AB is strictly prohibited.
+/*
+ * Copyright (c) 2026 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
 
 package org.tctalent.server.service.db.util;
 


### PR DESCRIPTION
## Summary
- Replaced leftover "Orc Software AB" copyright notices with the standard Talent Catalog GPL header
- Affected files:
  - server/.../service/db/ChatUploadFileService.java
  - server/.../service/db/util/PagedCandidateBackProcessor.java
  - server/.../service/db/util/PagedPartnerBackProcessor.java
  - server/.../service/db/util/PagedSavedListBackProcessor.java
  - server/.../service/db/util/PagedSavedSearchBackProcessor.java