### PR TITLE
Hiba/tc 1407 tc input component does not properly support typerange or

### DIFF
--- a/ui/admin-portal/src/app/shared/components/input/input.component.html
+++ b/ui/admin-portal/src/app/shared/components/input/input.component.html
@@ -21,4 +21,6 @@
   [editable]="editable"
   (selectItem)="selectItem.emit($event)"
   [min]="min"
+  [max]="max"
+  [step]="step"
 />

--- a/ui/admin-portal/src/app/shared/components/input/input.component.spec.ts
+++ b/ui/admin-portal/src/app/shared/components/input/input.component.spec.ts
@@ -18,4 +18,17 @@ describe('InputComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should pass min, max and step through to the native input', () => {
+    component.type = 'range';
+    component.min = 0;
+    component.max = 1;
+    component.step = 0.1;
+    fixture.detectChanges();
+
+    const inputEl: HTMLInputElement = fixture.nativeElement.querySelector('input');
+    expect(inputEl.min).toBe('0');
+    expect(inputEl.max).toBe('1');
+    expect(inputEl.step).toBe('0.1');
+  });
 });

--- a/ui/admin-portal/src/app/shared/components/input/input.component.ts
+++ b/ui/admin-portal/src/app/shared/components/input/input.component.ts
@@ -33,6 +33,8 @@ import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
  * - `readonly: boolean = false` — makes the field non-editable but still focusable
  * - `editable?: boolean` — used by ngbTypeahead to control whether typed text is allowed
  * - `min?: number` — sets the native HTML `min` attribute (for numeric/date types)
+ * - `max?: number` — sets the native HTML `max` attribute (for numeric/date types)
+ * - `step?: number` — sets the native HTML `step` attribute (for numeric/date types)
  * - `ngbTypeahead?: (text$: Observable<string>) => Observable<any[]>`
  * - `resultTemplate?: TemplateRef<any>` — template for typeahead results
  * - `inputFormatter?: (value: any) => string`
@@ -97,6 +99,8 @@ export class InputComponent implements ControlValueAccessor, OnInit {
   @Input() editable: boolean;
   @Input() readonly: boolean = false;
   @Input() min?: number;
+  @Input() max?: number;
+  @Input() step?: number;
   @Input() type:
     | 'text'
     | 'password'


### PR DESCRIPTION
## Summary
- `tc-input` only supported the native `min` attribute; `type="range"` and `type="number"` also need `max` and `step` to fully define their value range/increment.
- Added `max` and `step` `@Input()`s to `InputComponent`, bound through to the native `<input>` alongside `min`.
- Added a unit test asserting `min`/`max`/`step` are passed through to the native input for `type="range"`