### PR TITLE
Ehsan/tc 1400 set up playwright for the candidate portal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -365,3 +365,9 @@ server/src/test/resources/dump.sql
 /infra/aws/terraform/opc-prod/ssm-parameters.sh
 performance-tests/src/gatling/resources/users.csv
 /.idea
+
+# Playwright generated artifacts
+/ui/candidate-portal/playwright-report/
+/ui/candidate-portal/test-results/
+/ui/candidate-portal/blob-report/
+/ui/candidate-portal/playwright/.cache/

--- a/ui/candidate-portal/package-lock.json
+++ b/ui/candidate-portal/package-lock.json
@@ -50,6 +50,7 @@
         "@angular/cli": "^17.3.17",
         "@angular/compiler-cli": "^17.3.12",
         "@angular/language-service": "^17.3.12",
+        "@playwright/test": "^1.62.1",
         "@types/node": "^20.0.0",
         "codelyzer": "^6.0.2",
         "jasmine-spec-reporter": "^7.0.0",
@@ -3463,6 +3464,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@popperjs/core": {
@@ -11288,6 +11305,53 @@
       "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/ui/candidate-portal/package.json
+++ b/ui/candidate-portal/package.json
@@ -9,7 +9,11 @@
     "test": "ng test",
     "test:coverage": "ng test candidate-portal --watch=false --code-coverage=true --browsers=ChromeHeadless --source-map=true",
     "lint": "ng lint",
-    "e2e": "ng e2e"
+    "e2e": "playwright test",
+    "e2e:ui": "playwright test --ui",
+    "e2e:headed": "playwright test --headed",
+    "e2e:debug": "playwright test --debug",
+    "e2e:report": "playwright show-report"
   },
   "private": true,
   "engines": {
@@ -58,6 +62,7 @@
     "@angular/cli": "^17.3.17",
     "@angular/compiler-cli": "^17.3.12",
     "@angular/language-service": "^17.3.12",
+    "@playwright/test": "^1.62.1",
     "@types/node": "^20.0.0",
     "codelyzer": "^6.0.2",
     "jasmine-spec-reporter": "^7.0.0",

--- a/ui/candidate-portal/playwright-tests/auth/candidate-login.spec.ts
+++ b/ui/candidate-portal/playwright-tests/auth/candidate-login.spec.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free
+ *  Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+import {expect, test} from '@playwright/test';
+
+test('candidate login page loads', async ({ page }) => {
+  await page.goto('/login');
+
+  await expect(page).toHaveTitle(/Login/i);
+
+  await expect(page.locator('input#username')).toBeVisible();
+  await expect(page.locator('input#password')).toBeVisible();
+
+  await expect(page.locator('form')).toBeVisible();
+});

--- a/ui/candidate-portal/playwright.config.ts
+++ b/ui/candidate-portal/playwright.config.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2026 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free
+ *  Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+import {defineConfig, devices} from '@playwright/test';
+
+export default defineConfig({
+  testDir: './playwright-tests',
+
+  fullyParallel: true,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+
+  expect: {
+    timeout: 10_000,
+  },
+
+  reporter: [
+    ['list'],
+    [
+      'html',
+      {
+        outputFolder: 'playwright-report',
+        open: 'never',
+      },
+    ],
+  ],
+
+  use: {
+    baseURL: process.env.E2E_BASE_URL ?? 'http://127.0.0.1:4200',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+
+  projects: [
+    {
+      name: 'chromium-desktop',
+      use: {...devices['Desktop Chrome']},
+    },
+    {
+      name: 'firefox-desktop',
+      use: {...devices['Desktop Firefox']},
+    },
+    {
+      name: 'webkit-desktop',
+      use: {...devices['Desktop Safari']},
+    },
+    {
+      name: 'android-pixel',
+      use: {...devices['Pixel 7']},
+    },
+    {
+      name: 'ios-iphone',
+      use: {...devices['iPhone 14']},
+    },
+    {
+      name: 'ios-ipad',
+      use: {...devices['iPad Pro 11']},
+    },
+  ],
+
+  webServer: process.env.E2E_BASE_URL
+    ? undefined
+    : {
+      command: 'npm start -- --port 4200',
+      url: 'http://127.0.0.1:4200',
+      reuseExistingServer: !process.env.CI,
+      timeout: 300_000,
+      stdout: 'pipe',
+      stderr: 'pipe',
+    },
+});

--- a/ui/candidate-portal/playwright.config.ts
+++ b/ui/candidate-portal/playwright.config.ts
@@ -22,7 +22,9 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: Boolean(process.env.CI),
   retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : undefined,
+  workers: process.env.CI
+    ? Number(process.env.PLAYWRIGHT_WORKERS ?? 1)
+    : undefined,
 
   expect: {
     timeout: 10_000,


### PR DESCRIPTION
## Summary

- Add Playwright to the candidate portal
- Configure desktop coverage for Chromium, Firefox, and WebKit
- Configure mobile and tablet coverage for Pixel, iPhone, and iPad
- Add an initial candidate login-page smoke test
- Add scripts for standard, UI, headed, debug, and report modes
- Ignore generated Playwright reports and test artifacts

## Context

This setup establishes the cross-platform E2E foundation required for the upcoming Verify Plus test coverage.

## Testing

- Ran `npm run e2e`
- Confirmed the login-page smoke test passes across all six configured projects