### PR TITLE
Sadat/tc 1357 feature verify 13 optional scan during registration to pre

### DIFF
--- a/server/src/main/java/org/tctalent/server/service/db/verify/impl/VerifyPlusServiceImpl.java
+++ b/server/src/main/java/org/tctalent/server/service/db/verify/impl/VerifyPlusServiceImpl.java
@@ -32,9 +32,17 @@ import org.tctalent.server.service.db.verify.VerifyPlusPayload;
 import org.tctalent.server.service.db.verify.VerifyPlusPayloadParser;
 import org.tctalent.server.service.db.verify.VerifyPlusService;
 
-// TODO doco
-// Flow: logged-in candidate -> parse raw payload -> duplicate check across active-like statuses->
-// overwrite candidate.unhcrNumber -> return {unhcrNumber, duplicate}.
+/**
+ * Ingests a Verify+ QR scan for the logged-in candidate.
+ * <p>
+ * Flow: resolve logged-in candidate → parse raw payload → duplicate-check UNHCR ID across
+ * active-like statuses → set {@code unhcrRegistered=Yes} and overwrite {@code unhcrNumber} →
+ * return {@code {unhcrNumber, duplicate}}.
+ * <p>
+ * Used by both the Services tab and the registration wizard scan step.
+ *
+ * @author sadatmalik
+ */
 @Service
 @RequiredArgsConstructor
 public class VerifyPlusServiceImpl implements VerifyPlusService {
@@ -51,11 +59,20 @@ public class VerifyPlusServiceImpl implements VerifyPlusService {
     private final CandidateRepository candidateRepository;
     private final VerifyPlusPayloadParser payloadParser;
 
+    /**
+     * Ingests a Verify+ scan for the currently logged-in candidate.
+     * <p>
+     * Both call sites require an authenticated session: the Services tab (profile) and the
+     * registration wizard scan step, which sits after account creation / contact so the
+     * candidate is already logged in when this method runs.
+     *
+     * @param request raw Verify+ QR payload from the portal
+     * @return ingested UNHCR number and whether it duplicates another active-like candidate
+     * @throws InvalidSessionException if no candidate is logged in
+     */
     @Override
     @Transactional
     public VerifyPlusIngestResult ingestScan(VerifyPlusScanRequest request) {
-        // TODO - SM - ok for testing via Casi service - but for registration flow confirm if the
-        //  candidate will be logged in if the scan is handled as a distinct "step 2"
         Candidate candidate = candidateService.getLoggedInCandidate()
             .orElseThrow(() -> new InvalidSessionException("Not logged in"));
 

--- a/server/src/main/java/org/tctalent/server/service/db/verify/impl/VerifyPlusServiceImpl.java
+++ b/server/src/main/java/org/tctalent/server/service/db/verify/impl/VerifyPlusServiceImpl.java
@@ -23,6 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.tctalent.server.exception.InvalidSessionException;
 import org.tctalent.server.model.db.Candidate;
 import org.tctalent.server.model.db.CandidateStatus;
+import org.tctalent.server.model.db.YesNoUnsure;
 import org.tctalent.server.repository.db.CandidateRepository;
 import org.tctalent.server.request.verify.VerifyPlusScanRequest;
 import org.tctalent.server.service.db.CandidateService;
@@ -67,6 +68,7 @@ public class VerifyPlusServiceImpl implements VerifyPlusService {
             candidate.getId()
         ).isEmpty();
 
+        candidate.setUnhcrRegistered(YesNoUnsure.Yes);
         candidate.setUnhcrNumber(unhcrId);
         candidateService.save(candidate);
 

--- a/server/src/test/java/org/tctalent/server/service/db/verify/impl/VerifyPlusServiceImplTest.java
+++ b/server/src/test/java/org/tctalent/server/service/db/verify/impl/VerifyPlusServiceImplTest.java
@@ -34,6 +34,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.tctalent.server.exception.InvalidSessionException;
 import org.tctalent.server.model.db.Candidate;
+import org.tctalent.server.model.db.YesNoUnsure;
 import org.tctalent.server.repository.db.CandidateRepository;
 import org.tctalent.server.request.verify.VerifyPlusScanRequest;
 import org.tctalent.server.service.db.CandidateService;
@@ -82,6 +83,7 @@ class VerifyPlusServiceImplTest {
         VerifyPlusIngestResult result = verifyPlusService.ingestScan(request);
 
         assertEquals("UNHCR-1", candidate.getUnhcrNumber());
+        assertEquals(YesNoUnsure.Yes, candidate.getUnhcrRegistered());
         assertEquals("UNHCR-1", result.getUnhcrNumber());
         assertFalse(result.isDuplicate());
         verify(candidateService).save(candidate);
@@ -108,6 +110,7 @@ class VerifyPlusServiceImplTest {
     @Test
     @DisplayName("Given a candidate with an existing UNHCR number, when ingestScan is called with a new UNHCR number, then the candidate's UNHCR number is overwritten")
     void ingestScan_overwritesUnhcrNumberOnRescan() {
+        candidate.setUnhcrRegistered(YesNoUnsure.Yes);
         candidate.setUnhcrNumber("OLD-UNHCR");
         VerifyPlusPayload parsed = new VerifyPlusPayload("mock-1", request.getRawPayload(), "NEW-UNHCR");
 
@@ -120,6 +123,7 @@ class VerifyPlusServiceImplTest {
         VerifyPlusIngestResult result = verifyPlusService.ingestScan(request);
 
         assertEquals("NEW-UNHCR", candidate.getUnhcrNumber());
+        assertEquals(YesNoUnsure.Yes, candidate.getUnhcrRegistered());
         assertEquals("NEW-UNHCR", result.getUnhcrNumber());
     }
 

--- a/ui/admin-portal/src/app/components/settings/translations/general/general-translations.component.ts
+++ b/ui/admin-portal/src/app/components/settings/translations/general/general-translations.component.ts
@@ -360,6 +360,7 @@ const ALL_FIELDS = {
           "CONTACT": null,
           "CONTACT/ALTERNATE": null,
           "CONTACT/ADDITIONAL": null,
+          "VERIFYPLUS": null,
           "PERSONAL": null,
           "OCCUPATION": null,
           "EXPERIENCE": null,

--- a/ui/candidate-portal/src/app/app.module.ts
+++ b/ui/candidate-portal/src/app/app.module.ts
@@ -37,6 +37,9 @@ import {
   RegistrationContactComponent
 } from './components/register/contact/registration-contact.component';
 import {
+  RegistrationVerifyPlusComponent
+} from './components/register/verify-plus/registration-verify-plus.component';
+import {
   RegistrationPersonalComponent
 } from './components/register/personal/registration-personal.component';
 import {
@@ -266,6 +269,7 @@ export function HttpLoaderFactory(http: HttpClient) {
     HeaderComponent,
     LandingComponent,
     RegistrationContactComponent,
+    RegistrationVerifyPlusComponent,
     RegistrationPersonalComponent,
     RegistrationCandidateOccupationComponent,
     RegistrationWorkExperienceComponent,

--- a/ui/candidate-portal/src/app/components/register/register.component.html
+++ b/ui/candidate-portal/src/app/components/register/register.component.html
@@ -36,7 +36,7 @@
   </div>
 
   <div class="step-progress">
-    <div class="step-progress-bar" *ngFor="let x of [].constructor(registrationService?.totalSections || 0); let i = index;"
+    <div class="step-progress-bar" *ngFor="let x of [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]; let i = index;"
          [class.selected]="registrationService?.currentStep?.section === i + 1"></div>
   </div>
 

--- a/ui/candidate-portal/src/app/components/register/register.component.html
+++ b/ui/candidate-portal/src/app/components/register/register.component.html
@@ -36,7 +36,7 @@
   </div>
 
   <div class="step-progress">
-    <div class="step-progress-bar" *ngFor="let x of [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]; let i = index;"
+    <div class="step-progress-bar" *ngFor="let x of [].constructor(registrationService?.totalSections || 0); let i = index;"
          [class.selected]="registrationService?.currentStep?.section === i + 1"></div>
   </div>
 
@@ -52,6 +52,9 @@
 
   <app-registration-contact *ngSwitchCase="'contact'">
   </app-registration-contact>
+
+  <app-registration-verify-plus *ngSwitchCase="'verifyplus'">
+  </app-registration-verify-plus>
 
   <app-registration-personal *ngSwitchCase="'personal'">
   </app-registration-personal>

--- a/ui/candidate-portal/src/app/components/register/verify-plus/registration-verify-plus.component.html
+++ b/ui/candidate-portal/src/app/components/register/verify-plus/registration-verify-plus.component.html
@@ -1,0 +1,74 @@
+<!--
+  ~ Copyright (c) 2026 Talent Catalog.
+  ~
+  ~ This program is free software: you can redistribute it and/or modify it under
+  ~ the terms of the GNU General Public License as published by the Free
+  ~ Software Foundation, either version 3 of the License, or any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful, but WITHOUT
+  ~ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+  ~ FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+  ~ for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program. If not, see https://www.gnu.org/licenses/.
+  -->
+
+<div class="container verify-plus-registration">
+  <h4>UNHCR Verify+ (optional)</h4>
+  <p>Scan your Verify+ card now to pre-fill your UNHCR registration number.</p>
+
+  <app-verify-plus-scanner
+    [hideScanAgain]="true"
+    (scanned)="onScanned($event)"
+    (scannerError)="onScannerError($event)"
+  ></app-verify-plus-scanner>
+
+  <p class="mt-3 text-danger" *ngIf="scannerError">
+    A camera or scanner error occurred. Please refresh and try again.
+  </p>
+
+  <div class="scan-result mt-3" *ngIf="decodedPayload && !submitResult">
+    <h5>Review scanned payload</h5>
+    <pre>{{ formattedPayload }}</pre>
+  </div>
+
+  <p class="mt-3 text-danger" *ngIf="submitError">
+    {{ submitErrorMessage || "We couldn't submit this scan. Please check your connection and try again." }}
+  </p>
+
+  <div class="mt-3 d-flex flex-wrap gap-2" *ngIf="decodedPayload && !submitResult">
+    <tc-button [type]="'outline'" [disabled]="submitting" (onClick)="onRescan()">
+      Rescan
+    </tc-button>
+    <tc-button [loading]="submitting" [disabled]="submitting" (onClick)="onConfirm()">
+      Confirm
+    </tc-button>
+  </div>
+
+  <div class="scan-result mt-3" *ngIf="submitResult && !submitResult.duplicate">
+    <h5>UNHCR number captured</h5>
+    <p>
+      Your scan was submitted successfully:
+      <strong>{{ submitResult.unhcrNumber }}</strong>
+    </p>
+  </div>
+
+  <div class="scan-result mt-3" *ngIf="submitResult?.duplicate">
+    <h5>Duplicate UNHCR number found</h5>
+    <p>
+      We submitted your scan, but this UNHCR number already exists on another active candidate:
+      <strong>{{ submitResult.unhcrNumber }}</strong>
+    </p>
+  </div>
+
+  <p class="text-muted mt-3" *ngIf="!submitResult">
+    You can skip this step for now and continue registration.
+  </p>
+</div>
+
+<app-registration-footer
+  [nextDisabled]="nextDisabled"
+  (backClicked)="onBack()"
+  (nextClicked)="onNext()"
+></app-registration-footer>

--- a/ui/candidate-portal/src/app/components/register/verify-plus/registration-verify-plus.component.scss
+++ b/ui/candidate-portal/src/app/components/register/verify-plus/registration-verify-plus.component.scss
@@ -1,0 +1,8 @@
+.verify-plus-registration {
+  padding-bottom: 6rem;
+}
+
+.scan-result pre {
+  white-space: pre-wrap;
+  word-break: break-word;
+}

--- a/ui/candidate-portal/src/app/components/register/verify-plus/registration-verify-plus.component.spec.ts
+++ b/ui/candidate-portal/src/app/components/register/verify-plus/registration-verify-plus.component.spec.ts
@@ -64,6 +64,75 @@ describe('RegistrationVerifyPlusComponent', () => {
     expect(registrationService.next).toHaveBeenCalled();
   });
 
+  it('should return empty formattedPayload when nothing has been scanned', () => {
+    component.decodedPayload = null;
+
+    expect(component.formattedPayload).toBe('');
+  });
+
+  it('should pretty-print valid JSON in formattedPayload', () => {
+    component.decodedPayload = '{"v":"mock-1","unhcrId":"123-45C67890"}';
+
+    expect(component.formattedPayload).toBe(JSON.stringify({
+      v: 'mock-1',
+      unhcrId: '123-45C67890'
+    }, null, 2));
+  });
+
+  it('should return raw payload when formattedPayload cannot parse JSON', () => {
+    component.decodedPayload = 'not-json';
+
+    expect(component.formattedPayload).toBe('not-json');
+  });
+
+  it('should disable next while submitting', () => {
+    component.submitting = false;
+    expect(component.nextDisabled).toBeFalse();
+
+    component.submitting = true;
+    expect(component.nextDisabled).toBeTrue();
+  });
+
+  it('should store decoded payload and clear previous submit state when scanner emits', () => {
+    component.scannerError = new Error('previous');
+    component.submitResult = {unhcrNumber: 'old', duplicate: false};
+    component.submitError = true;
+    component.submitErrorMessage = 'old error';
+
+    component.onScanned('decoded-qr');
+
+    expect(component.decodedPayload).toBe('decoded-qr');
+    expect(component.scannerError).toBeNull();
+    expect(component.submitResult).toBeNull();
+    expect(component.submitError).toBeFalse();
+    expect(component.submitErrorMessage).toBeNull();
+  });
+
+  it('should store scannerError when scanner fails', () => {
+    const error = new Error('camera denied');
+
+    component.onScannerError(error);
+
+    expect(component.scannerError).toBe(error);
+  });
+
+  it('should not submit when there is no decoded payload', () => {
+    component.decodedPayload = null;
+
+    component.onConfirm();
+
+    expect(verifyPlusService.submitScan).not.toHaveBeenCalled();
+  });
+
+  it('should not submit when already submitting', () => {
+    component.decodedPayload = '{"v":"mock-1","unhcrId":"123-45C67890"}';
+    component.submitting = true;
+
+    component.onConfirm();
+
+    expect(verifyPlusService.submitScan).not.toHaveBeenCalled();
+  });
+
   it('should submit scanned payload and store result on confirm success', () => {
     const payload = '{"v":"mock-1","unhcrId":"123-45C67890"}';
     component.onScanned(payload);
@@ -109,7 +178,20 @@ describe('RegistrationVerifyPlusComponent', () => {
     expect(component.submitErrorMessage).toBe(errorMessage);
   });
 
-  it('should reset submit state when rescanning', () => {
+  it('should set submitError without message when confirm fails with a non-string error', () => {
+    const payload = '{"v":"mock-2","unhcrId":"123-45C67890"}';
+    component.onScanned(payload);
+    verifyPlusService.submitScan.and.returnValue(throwError({status: 500}));
+
+    component.onConfirm();
+
+    expect(component.submitError).toBeTrue();
+    expect(component.submitErrorMessage).toBeNull();
+  });
+
+  it('should reset submit state and restart scanner when rescanning', () => {
+    const startScanning = jasmine.createSpy('startScanning');
+    component.scanner = {startScanning} as any;
     component.decodedPayload = '{"v":"mock-1","unhcrId":"123-45C67890"}';
     component.submitResult = {unhcrNumber: '123-45C67890', duplicate: true};
     component.submitError = true;
@@ -122,6 +204,7 @@ describe('RegistrationVerifyPlusComponent', () => {
     expect(component.submitResult).toBeNull();
     expect(component.submitError).toBeFalse();
     expect(component.submitErrorMessage).toBeNull();
+    expect(startScanning).toHaveBeenCalled();
   });
 
   it('should move to next step when continuing or skipping', () => {

--- a/ui/candidate-portal/src/app/components/register/verify-plus/registration-verify-plus.component.spec.ts
+++ b/ui/candidate-portal/src/app/components/register/verify-plus/registration-verify-plus.component.spec.ts
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2026 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {NO_ERRORS_SCHEMA} from '@angular/core';
+import {of, throwError} from 'rxjs';
+
+import {RegistrationVerifyPlusComponent} from './registration-verify-plus.component';
+import {VerifyPlusService} from '../../../services/verify-plus.service';
+import {RegistrationService} from '../../../services/registration.service';
+import {AuthenticationService} from '../../../services/authentication.service';
+
+describe('RegistrationVerifyPlusComponent', () => {
+  let component: RegistrationVerifyPlusComponent;
+  let fixture: ComponentFixture<RegistrationVerifyPlusComponent>;
+  let verifyPlusService: jasmine.SpyObj<VerifyPlusService>;
+  let registrationService: jasmine.SpyObj<RegistrationService>;
+  let authenticationService: jasmine.SpyObj<AuthenticationService>;
+
+  beforeEach(() => {
+    verifyPlusService = jasmine.createSpyObj<VerifyPlusService>('VerifyPlusService', ['submitScan']);
+    registrationService = jasmine.createSpyObj<RegistrationService>('RegistrationService', ['next', 'back']);
+    authenticationService = jasmine.createSpyObj<AuthenticationService>('AuthenticationService', ['isGrnInstance']);
+    authenticationService.isGrnInstance.and.returnValue(true);
+
+    TestBed.configureTestingModule({
+      declarations: [RegistrationVerifyPlusComponent],
+      providers: [
+        {provide: VerifyPlusService, useValue: verifyPlusService},
+        {provide: RegistrationService, useValue: registrationService},
+        {provide: AuthenticationService, useValue: authenticationService}
+      ],
+      schemas: [NO_ERRORS_SCHEMA]
+    });
+
+    fixture = TestBed.createComponent(RegistrationVerifyPlusComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should auto-skip step for non-GRN instances', () => {
+    authenticationService.isGrnInstance.and.returnValue(false);
+
+    const skippedFixture = TestBed.createComponent(RegistrationVerifyPlusComponent);
+    skippedFixture.detectChanges();
+
+    expect(registrationService.next).toHaveBeenCalled();
+  });
+
+  it('should submit scanned payload and store result on confirm success', () => {
+    const payload = '{"v":"mock-1","unhcrId":"123-45C67890"}';
+    component.onScanned(payload);
+    verifyPlusService.submitScan.and.returnValue(of({
+      unhcrNumber: '123-45C67890',
+      duplicate: false
+    }));
+
+    component.onConfirm();
+
+    expect(verifyPlusService.submitScan).toHaveBeenCalledWith(payload);
+    expect(component.submitResult).toEqual({
+      unhcrNumber: '123-45C67890',
+      duplicate: false
+    });
+    expect(component.submitError).toBeFalse();
+    expect(component.submitting).toBeFalse();
+  });
+
+  it('should capture duplicate result on confirm success', () => {
+    const payload = '{"v":"mock-1","unhcrId":"999-00A11111"}';
+    component.onScanned(payload);
+    verifyPlusService.submitScan.and.returnValue(of({
+      unhcrNumber: '999-00A11111',
+      duplicate: true
+    }));
+
+    component.onConfirm();
+
+    expect(component.submitResult?.duplicate).toBeTrue();
+  });
+
+  it('should set submitError and capture message when confirm fails', () => {
+    const payload = '{"v":"mock-2","unhcrId":"123-45C67890"}';
+    const errorMessage = 'Unsupported Verify+ payload version: mock-2';
+    component.onScanned(payload);
+    verifyPlusService.submitScan.and.returnValue(throwError(errorMessage));
+
+    component.onConfirm();
+
+    expect(verifyPlusService.submitScan).toHaveBeenCalledWith(payload);
+    expect(component.submitError).toBeTrue();
+    expect(component.submitErrorMessage).toBe(errorMessage);
+  });
+
+  it('should reset submit state when rescanning', () => {
+    component.decodedPayload = '{"v":"mock-1","unhcrId":"123-45C67890"}';
+    component.submitResult = {unhcrNumber: '123-45C67890', duplicate: true};
+    component.submitError = true;
+    component.submitErrorMessage = 'Unsupported Verify+ payload version: mock-2';
+    component.scannerError = new Error('scanner');
+
+    component.onRescan();
+
+    expect(component.decodedPayload).toBeNull();
+    expect(component.submitResult).toBeNull();
+    expect(component.submitError).toBeFalse();
+    expect(component.submitErrorMessage).toBeNull();
+  });
+
+  it('should move to next step when continuing or skipping', () => {
+    component.onNext();
+
+    expect(registrationService.next).toHaveBeenCalled();
+  });
+
+  it('should go back to previous step', () => {
+    component.onBack();
+
+    expect(registrationService.back).toHaveBeenCalled();
+  });
+});

--- a/ui/candidate-portal/src/app/components/register/verify-plus/registration-verify-plus.component.ts
+++ b/ui/candidate-portal/src/app/components/register/verify-plus/registration-verify-plus.component.ts
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2026 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+import {Component, OnInit, ViewChild} from '@angular/core';
+import {finalize} from 'rxjs/operators';
+import {VerifyPlusScannerComponent} from '../../common/verify-plus-scanner/verify-plus-scanner.component';
+import {VerifyPlusScanResult, VerifyPlusService} from '../../../services/verify-plus.service';
+import {RegistrationService} from '../../../services/registration.service';
+import {AuthenticationService} from '../../../services/authentication.service';
+
+/**
+ * Component for the Verify Plus registration step.
+ */
+@Component({
+  selector: 'app-registration-verify-plus',
+  templateUrl: './registration-verify-plus.component.html',
+  styleUrls: ['./registration-verify-plus.component.scss']
+})
+export class RegistrationVerifyPlusComponent implements OnInit {
+  @ViewChild(VerifyPlusScannerComponent) scanner?: VerifyPlusScannerComponent;
+
+  decodedPayload: string | null = null;
+  scannerError: unknown;
+  submitting = false;
+  submitResult: VerifyPlusScanResult | null = null;
+  submitError = false;
+  submitErrorMessage: string | null = null;
+
+  constructor(
+    private verifyPlusService: VerifyPlusService,
+    private authenticationService: AuthenticationService,
+    public registrationService: RegistrationService
+  ) {
+  }
+
+  ngOnInit(): void {
+    if (!this.authenticationService.isGrnInstance()) {
+      this.registrationService.next();
+    }
+  }
+
+  get formattedPayload(): string {
+    if (!this.decodedPayload) {
+      return '';
+    }
+    try {
+      return JSON.stringify(JSON.parse(this.decodedPayload), null, 2);
+    } catch {
+      return this.decodedPayload;
+    }
+  }
+
+  get nextDisabled(): boolean {
+    return this.submitting;
+  }
+
+  onScanned(payload: string): void {
+    this.decodedPayload = payload;
+    this.scannerError = null;
+    this.submitResult = null;
+    this.submitError = false;
+    this.submitErrorMessage = null;
+  }
+
+  onScannerError(error: unknown): void {
+    this.scannerError = error;
+  }
+
+  onConfirm(): void {
+    if (!this.decodedPayload || this.submitting) {
+      return;
+    }
+
+    this.submitError = false;
+    this.submitErrorMessage = null;
+    this.submitting = true;
+
+    this.verifyPlusService.submitScan(this.decodedPayload)
+      .pipe(finalize(() => this.submitting = false))
+      .subscribe({
+        next: (result) => {
+          this.submitResult = result;
+        },
+        error: (message: unknown) => {
+          this.submitError = true;
+          this.submitErrorMessage = typeof message === 'string' ? message : null;
+        }
+      });
+  }
+
+  onRescan(): void {
+    this.decodedPayload = null;
+    this.submitResult = null;
+    this.submitError = false;
+    this.submitErrorMessage = null;
+    this.scanner?.startScanning();
+  }
+
+  onBack(): void {
+    this.registrationService.back();
+  }
+
+  onNext(): void {
+    this.registrationService.next();
+  }
+}

--- a/ui/candidate-portal/src/app/components/register/verify-plus/registration-verify-plus.component.ts
+++ b/ui/candidate-portal/src/app/components/register/verify-plus/registration-verify-plus.component.ts
@@ -33,7 +33,7 @@ export class RegistrationVerifyPlusComponent implements OnInit {
   @ViewChild(VerifyPlusScannerComponent) scanner?: VerifyPlusScannerComponent;
 
   decodedPayload: string | null = null;
-  scannerError: unknown;
+  scannerError: unknown | null = null;
   submitting = false;
   submitResult: VerifyPlusScanResult | null = null;
   submitError = false;
@@ -106,6 +106,7 @@ export class RegistrationVerifyPlusComponent implements OnInit {
     this.submitResult = null;
     this.submitError = false;
     this.submitErrorMessage = null;
+    this.scannerError = null;
     this.scanner?.startScanning();
   }
 

--- a/ui/candidate-portal/src/app/services/registration.service.ts
+++ b/ui/candidate-portal/src/app/services/registration.service.ts
@@ -38,60 +38,65 @@ export class RegistrationService {
       section: 1
     },
     {
+      key: 'verifyplus',
+      title: 'Scan your UNHCR Verify+ card (optional)',
+      section: 2
+    },
+    {
       key: 'personal',
       title: 'Tell us about yourself',
-      section: 2
+      section: 3
     },
     {
       key: 'occupation',
       title: 'Tell us about your occupation',
-      section: 3
+      section: 4
     },
     {
       key: 'experience',
       title: 'Tell us about your working history',
-      section: 4
+      section: 5
     },
     {
       key: 'education',
       title: 'Tell us about your education',
-      section: 5
+      section: 6
     },
     {
       key: 'language',
       title: 'What languages do you speak?',
-      section: 6
+      section: 7
     },
     {
       key: 'exam',
       title: 'Provide details of your language exams',
-      section: 7
+      section: 8
     },
     {
       key: 'certifications',
       title: 'Do you have any other professional certifications?',
-      section: 8
+      section: 9
     },
     {
       key: 'destinations',
       title: 'Do you have any destination preferences?',
-      section: 8
+      section: 9
     },
     {
       key: 'additional',
       title: 'How did you hear about us?',
-      section: 9
+      section: 10
     },
     {
       key: 'upload',
       title: 'Do you have any files to upload?',
-      section: 10
+      section: 11
     },
     {
       key: 'complete',
       title: '',
       hideHeader: true,
-      section: 10
+      section: 11
     }
   ];
   public totalSections: number = Math.max(...this.steps.map(s => s.section));


### PR DESCRIPTION
This PR adds the option to scan a Verify+ QR during registration --

- Adds Verify+ registration step with scanner functionality
- Renumbers downstream step sections (personal onward)
- Makes the registration progress bar scale by section count
- Sets candidate UNHCR number and marks them as UNHCR registered when they confirm their scan
- Add unit tests + resolves doc todos in VerifyPlusServiceImpl