### PR TITLE
Hiba/tc 723 Fix pasted email validation during candidate registration

### DIFF
--- a/docs/decisions/004-email-paste-sanitization.md
+++ b/docs/decisions/004-email-paste-sanitization.md
@@ -1,0 +1,117 @@
+# ADR 004: Candidate Registration Email Paste Sanitization — Trim over Invisible-Character Stripping
+
+**Date:** 2026-08-26
+**Status:** Accepted
+
+## Context
+
+TC-723 (#578): candidates copy-pasting their email address into the registration
+form sometimes see "This field must contain a valid email" even though the
+address is correct. The candidate portal validates email fields
+(`registration-create-account.component`, `registration-contact.component`)
+against a custom regex (`EMAIL_REGEX` in `ui/candidate-portal/src/app/model/base.ts`),
+applied as an HTML5 `pattern` attribute. Because `pattern` validation requires the
+*entire* value to match, any extra character carried along by a paste — visible or
+not — causes an otherwise-valid address to fail.
+
+Investigation found no existing trimming/sanitization anywhere in the registration
+path (frontend `tc-input` component, `AuthenticationService`) or on the backend
+(`BaseCandidateContactRequest.email` had no validation or normalization at all).
+
+A first fix stripped a broad set of invisible/blank Unicode characters — not just
+plain whitespace — from the leading/trailing edges of the pasted value only,
+leaving the middle of the address untouched (since a stray character mid-address
+indicates a genuinely malformed email, not a paste artifact). This was driven by
+reproducing the reported case with a **Hangul filler character (U+3164)**, which
+is invisible on screen but is *not* covered by standard whitespace definitions in
+either language runtime:
+
+- JavaScript's `\s` covers ordinary whitespace plus every Unicode "space
+  separator" (Zs) character and the byte-order mark (U+FEFF).
+- Java's `\s` (and `String.strip()`, via `Character.isWhitespace()`) covers only
+  ASCII whitespace and a narrower Zs subset — it does not include non-breaking
+  space, ideographic space, or the BOM the way JavaScript's does.
+- Neither language's built-in whitespace/strip logic covers zero-width
+  characters (`​`-`‍`), bidi marks, word joiners, or the Hangul/Khmer
+  filler-character family (`ᅟ`, `ᅠ`, `឴`, `឵`, `ㅤ`,
+  `ﾠ`) — Unicode classifies the latter as *letters*, despite rendering
+  blank.
+
+A regex-based sanitizer (`INVISIBLE_OR_WHITESPACE_CHAR`, using `\p{Zs}`/`\p{Cf}`
+plus the six explicit filler codepoints) was built and kept byte-for-byte
+identical across the frontend (`ui/candidate-portal/src/app/model/base.ts`) and a
+backend port (`server/.../request/candidate/BaseCandidateContactRequest.java`),
+each verified against the other in a Node/jshell cross-check.
+
+## Decision
+
+Use plain **`.trim()` (frontend) / `.strip()` (backend)** on the email field,
+dropping the custom invisible-character regex.
+
+## Reasoning
+
+### Scope tradeoff, made explicitly
+Plain trim/strip only catches ordinary whitespace and the small set of
+"space separator" characters each language already recognizes as
+whitespace — it does **not** catch zero-width characters, bidi marks, or the
+Hangul/Khmer filler family, including the exact character (U+3164) from the
+original bug report. This is a known, accepted regression in scope versus the
+regex-based version: pasting a Hangul-filler-prefixed email will fail validation
+again, the same as before any fix existed.
+
+### Consistent with observed industry precedent
+Manually testing Google's own email input (signup flow) with a pasted invisible
+character showed the same scope of behavior we're adopting: leading/trailing
+whitespace-like characters are trimmed, but if the resulting value still isn't a
+valid email address, Google surfaces a validation error rather than silently
+accepting it or attempting to strip characters from within the address. This
+matches our decision to trim at the edges and let genuinely malformed input
+continue to fail validation, rather than trying to guess and clean up every
+possible invisible character a user might paste.
+
+### Simplicity wins for the common case
+The overwhelming majority of real-world paste artifacts are ordinary leading/
+trailing whitespace (a stray space from copying out of an email client, a
+trailing newline). `.trim()`/`.strip()` are one-line, dependency-free, and
+require no cross-language Unicode-category reasoning to maintain — unlike the
+regex version, which needed careful verification (jshell/Node) every time either
+side was touched, because Java's and JavaScript's definitions of `\s` do not
+match.
+
+### Maintenance cost of the regex version was disproportionate
+Keeping the frontend and backend character classes in sync, correctly accounting
+for behavioral differences between `\s` in JS versus Java, and testing every
+individual codepoint's Unicode category classification, added meaningfully more
+surface area than the problem justified for a low-severity, infrequently-hit
+validation-message bug.
+
+## Consequences
+
+- `sanitizeEmailInput()` (`ui/candidate-portal/src/app/model/base.ts`) is now
+  `value == null ? value : value.trim()`, still used from both
+  `registration-create-account.component.ts` and
+  `registration-contact.component.ts`, so the entry point and its
+  TC-723-referencing comment are preserved even though the implementation is now
+  trivial.
+- `BaseCandidateContactRequest.setEmail()`
+  (`server/.../request/candidate/BaseCandidateContactRequest.java`) now calls
+  `email.strip()`, giving `SelfRegistrationRequest` and other subclasses the same
+  backstop with no format validation elsewhere on the backend.
+- Test suites (`base.spec.ts`, `registration-create-account.component.spec.ts`,
+  `registration-contact.component.spec.ts`, `BaseCandidateContactRequestTest.java`)
+  were trimmed to cover only trim/strip behavior — clean-value passthrough,
+  leading/trailing whitespace, a middle-embedded space left untouched, and
+  empty/null safety — removing the per-codepoint Unicode-category tests that no
+  longer reflect what the code does.
+- If the Hangul-filler (or similar invisible-character) case resurfaces as a
+  live complaint rather than a one-off report, the regex-based
+  `INVISIBLE_OR_WHITESPACE_CHAR` approach documented in this ADR's history is a
+  ready-made reference for reinstating broader coverage.
+
+## Alternatives Considered
+
+| Option | Outcome |
+|---|---|
+| No sanitization (status quo before TC-723) | Rejected: leaves the reported bug unfixed. |
+| Full invisible-character regex (`\p{Zs}`/`\p{Cf}` + explicit filler codepoints), mirrored frontend/backend | Rejected: fixes the reported case but adds ongoing cross-language maintenance cost disproportionate to the bug's severity. |
+| `.trim()` (frontend) / `.strip()` (backend) (chosen) | Accepted: fixes the common whitespace-paste case with minimal, easily maintained code; knowingly does not fix the specific Hangul-filler case from the original report. |

--- a/server/src/main/java/org/tctalent/server/request/candidate/BaseCandidateContactRequest.java
+++ b/server/src/main/java/org/tctalent/server/request/candidate/BaseCandidateContactRequest.java
@@ -16,40 +16,21 @@
 
 package org.tctalent.server.request.candidate;
 
-import java.util.regex.Pattern;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
 public class BaseCandidateContactRequest {
-
-    /**
-     * Matches one invisible/blank Unicode character: whitespace, plus the Hangul/Khmer filler
-     * characters that render blank but aren't classified as whitespace.
-     *
-     * <p>Mirrors INVISIBLE_OR_WHITESPACE_CHAR in
-     * ui/candidate-portal/src/app/model/base.ts - keep both in sync.
-     */
-    private static final String INVISIBLE_OR_WHITESPACE_CHAR =
-        "[\\s\\p{Zs}\\p{Cf}\\u115F\\u1160\\u17B4\\u17B5\\u3164\\uFFA0]";
-
-    /**
-     * Strips invisible/blank characters from the start and end of a pasted email address - see
-     * TC-723. Leaves anything in the middle untouched, since that would mean the email is
-     * genuinely malformed rather than just messily pasted.
-     */
-    private static final Pattern EDGE_INVISIBLE_OR_WHITESPACE = Pattern.compile(
-        "^" + INVISIBLE_OR_WHITESPACE_CHAR + "+|" + INVISIBLE_OR_WHITESPACE_CHAR + "+$"
-    );
-
     private Long id;
     private String email;
     private String phone;
     private String whatsapp;
 
+    /**
+     * Trims leading/trailing whitespace from a pasted email address - see TC-723.
+     */
     public void setEmail(String email) {
-      // Apply strip() as an additional safety net for Java-recognized whitespace.
-        this.email = email == null ? null : EDGE_INVISIBLE_OR_WHITESPACE.matcher(email).replaceAll("").strip();
+        this.email = email == null ? null : email.strip();
     }
 }

--- a/server/src/main/java/org/tctalent/server/request/candidate/BaseCandidateContactRequest.java
+++ b/server/src/main/java/org/tctalent/server/request/candidate/BaseCandidateContactRequest.java
@@ -16,14 +16,40 @@
 
 package org.tctalent.server.request.candidate;
 
+import java.util.regex.Pattern;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
 public class BaseCandidateContactRequest {
+
+    /**
+     * Matches one invisible/blank Unicode character: whitespace, plus the Hangul/Khmer filler
+     * characters that render blank but aren't classified as whitespace.
+     *
+     * <p>Mirrors INVISIBLE_OR_WHITESPACE_CHAR in
+     * ui/candidate-portal/src/app/model/base.ts - keep both in sync.
+     */
+    private static final String INVISIBLE_OR_WHITESPACE_CHAR =
+        "[\\s\\p{Zs}\\p{Cf}\\u115F\\u1160\\u17B4\\u17B5\\u3164\\uFFA0]";
+
+    /**
+     * Strips invisible/blank characters from the start and end of a pasted email address - see
+     * TC-723. Leaves anything in the middle untouched, since that would mean the email is
+     * genuinely malformed rather than just messily pasted.
+     */
+    private static final Pattern EDGE_INVISIBLE_OR_WHITESPACE = Pattern.compile(
+        "^" + INVISIBLE_OR_WHITESPACE_CHAR + "+|" + INVISIBLE_OR_WHITESPACE_CHAR + "+$"
+    );
+
     private Long id;
     private String email;
     private String phone;
     private String whatsapp;
+
+    public void setEmail(String email) {
+      // Apply strip() as an additional safety net for Java-recognized whitespace.
+        this.email = email == null ? null : EDGE_INVISIBLE_OR_WHITESPACE.matcher(email).replaceAll("").strip();
+    }
 }

--- a/server/src/test/java/org/tctalent/server/request/candidate/BaseCandidateContactRequestTest.java
+++ b/server/src/test/java/org/tctalent/server/request/candidate/BaseCandidateContactRequestTest.java
@@ -39,28 +39,13 @@ class BaseCandidateContactRequestTest {
     }
 
     @Test
-    void stripsAHangulFillerCharacterPastedBeforeTheAddress() {
-        assertEquals("example@example.com", sanitize("ㅤexample@example.com"));
-    }
-
-    @Test
-    void stripsAZeroWidthSpacePastedAfterTheAddress() {
-        assertEquals("example@example.com", sanitize("example@example.com​"));
-    }
-
-    @Test
-    void leavesAZeroWidthSpaceEmbeddedInTheMiddleOfTheAddressUntouched() {
-        assertEquals("example@example​.com", sanitize("example@example​.com"));
+    void trimsLeadingAndTrailingWhitespace() {
+        assertEquals("example@example.com", sanitize("  example@example.com  "));
     }
 
     @Test
     void leavesAnOrdinarySpaceEmbeddedInTheMiddleOfTheAddressUntouched() {
         assertEquals("exam ple@example.com", sanitize("exam ple@example.com"));
-    }
-
-    @Test
-    void trimsLeadingAndTrailingWhitespace() {
-        assertEquals("example@example.com", sanitize("  example@example.com  "));
     }
 
     @Test

--- a/server/src/test/java/org/tctalent/server/request/candidate/BaseCandidateContactRequestTest.java
+++ b/server/src/test/java/org/tctalent/server/request/candidate/BaseCandidateContactRequestTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.request.candidate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Mirrors the equivalent frontend tests in
+ * ui/candidate-portal/src/app/model/base.spec.ts (sanitizeEmailInput) - see TC-723.
+ */
+class BaseCandidateContactRequestTest {
+
+    private String sanitize(String email) {
+        BaseCandidateContactRequest request = new BaseCandidateContactRequest();
+        request.setEmail(email);
+        return request.getEmail();
+    }
+
+    @Test
+    void returnsACleanEmailAddressUnchanged() {
+        assertEquals("example@example.com", sanitize("example@example.com"));
+    }
+
+    @Test
+    void stripsAHangulFillerCharacterPastedBeforeTheAddress() {
+        assertEquals("example@example.com", sanitize("ㅤexample@example.com"));
+    }
+
+    @Test
+    void stripsAZeroWidthSpacePastedAfterTheAddress() {
+        assertEquals("example@example.com", sanitize("example@example.com​"));
+    }
+
+    @Test
+    void leavesAZeroWidthSpaceEmbeddedInTheMiddleOfTheAddressUntouched() {
+        assertEquals("example@example​.com", sanitize("example@example​.com"));
+    }
+
+    @Test
+    void leavesAnOrdinarySpaceEmbeddedInTheMiddleOfTheAddressUntouched() {
+        assertEquals("exam ple@example.com", sanitize("exam ple@example.com"));
+    }
+
+    @Test
+    void trimsLeadingAndTrailingWhitespace() {
+        assertEquals("example@example.com", sanitize("  example@example.com  "));
+    }
+
+    @Test
+    void returnsAnEmptyStringUnchanged() {
+        assertEquals("", sanitize(""));
+    }
+
+    @Test
+    void returnsNullUnchanged() {
+        assertNull(sanitize(null));
+    }
+}

--- a/ui/candidate-portal/src/app/components/register/contact/registration-contact.component.spec.ts
+++ b/ui/candidate-portal/src/app/components/register/contact/registration-contact.component.spec.ts
@@ -292,30 +292,14 @@ describe('RegistrationContactComponent', () => {
   // ---------------------------------------------------------------------------
 
   describe('email sanitization', () => {
-    it('should strip a Hangul filler character pasted before the email', () => {
-      component.form.get('email').setValue('ㅤuser@example.com');
-      expect(component.email).toBe('user@example.com');
-    });
-
-    it('should strip a zero-width space pasted after the email', () => {
-      component.form.get('email').setValue('user@example.com​');
+    it('should trim leading/trailing whitespace pasted around the email', () => {
+      component.form.get('email').setValue('  user@example.com  ');
       expect(component.email).toBe('user@example.com');
     });
 
     it('should leave a clean email unchanged', () => {
       component.form.get('email').setValue('user@example.com');
       expect(component.email).toBe('user@example.com');
-    });
-
-    it('should leave an invisible character embedded in the middle of the email untouched', () => {
-      component.form.get('email').setValue('user@examp​le.com');
-      expect(component.email).toBe('user@examp​le.com');
-    });
-
-    it('should clear a prior pattern error once the invisible character is sanitized', () => {
-      const control = component.form.get('email');
-      control.setValue('ㅤuser@example.com');
-      expect(control.errors?.['pattern']).toBeFalsy();
     });
   });
 

--- a/ui/candidate-portal/src/app/components/register/contact/registration-contact.component.spec.ts
+++ b/ui/candidate-portal/src/app/components/register/contact/registration-contact.component.spec.ts
@@ -306,6 +306,17 @@ describe('RegistrationContactComponent', () => {
       component.form.get('email').setValue('user@example.com');
       expect(component.email).toBe('user@example.com');
     });
+
+    it('should leave an invisible character embedded in the middle of the email untouched', () => {
+      component.form.get('email').setValue('user@examp​le.com');
+      expect(component.email).toBe('user@examp​le.com');
+    });
+
+    it('should clear a prior pattern error once the invisible character is sanitized', () => {
+      const control = component.form.get('email');
+      control.setValue('ㅤuser@example.com');
+      expect(control.errors?.['pattern']).toBeFalsy();
+    });
   });
 
   // ---------------------------------------------------------------------------

--- a/ui/candidate-portal/src/app/components/register/contact/registration-contact.component.spec.ts
+++ b/ui/candidate-portal/src/app/components/register/contact/registration-contact.component.spec.ts
@@ -288,6 +288,27 @@ describe('RegistrationContactComponent', () => {
   });
 
   // ---------------------------------------------------------------------------
+  // Email sanitization (TC-723)
+  // ---------------------------------------------------------------------------
+
+  describe('email sanitization', () => {
+    it('should strip a Hangul filler character pasted before the email', () => {
+      component.form.get('email').setValue('ㅤuser@example.com');
+      expect(component.email).toBe('user@example.com');
+    });
+
+    it('should strip a zero-width space pasted after the email', () => {
+      component.form.get('email').setValue('user@example.com​');
+      expect(component.email).toBe('user@example.com');
+    });
+
+    it('should leave a clean email unchanged', () => {
+      component.form.get('email').setValue('user@example.com');
+      expect(component.email).toBe('user@example.com');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
   // Form validation
   // ---------------------------------------------------------------------------
 

--- a/ui/candidate-portal/src/app/components/register/contact/registration-contact.component.ts
+++ b/ui/candidate-portal/src/app/components/register/contact/registration-contact.component.ts
@@ -20,7 +20,7 @@ import {CandidateService} from "../../../services/candidate.service";
 import {Candidate} from "../../../model/candidate";
 import {RegistrationService} from "../../../services/registration.service";
 import {AuthenticationService} from "../../../services/authentication.service";
-import {EMAIL_REGEX} from "../../../model/base";
+import {EMAIL_REGEX, sanitizeEmailInput} from "../../../model/base";
 import {CountryService} from "../../../services/country.service";
 import {Country} from "../../../model/country";
 
@@ -64,6 +64,15 @@ export class RegistrationContactComponent implements OnInit {
       email: ['', Validators.required],
       phone: [''],
       whatsapp: [''],
+    });
+
+    // Strip invisible characters (eg zero-width spaces) that copy-paste can silently add to an
+    // otherwise valid email address, causing pattern validation to fail - see TC-723.
+    this.form.get('email').valueChanges.subscribe((value: string) => {
+      const sanitized = sanitizeEmailInput(value);
+      if (sanitized !== value) {
+        this.form.get('email').setValue(sanitized, {emitEvent: false});
+      }
     });
 
     if (this.authenticationService.isAuthenticated()) {

--- a/ui/candidate-portal/src/app/components/register/create-account/registration-create-account.component.spec.ts
+++ b/ui/candidate-portal/src/app/components/register/create-account/registration-create-account.component.spec.ts
@@ -261,25 +261,14 @@ describe('RegistrationCreateAccountComponent', () => {
   describe('username sanitization', () => {
     beforeEach(async () => configureAndCreate());
 
-    it('should strip a Hangul filler character pasted before the username', () => {
-      component.registrationForm.get('username').setValue('ㅤuser@example.com');
-      expect(component.username).toBe('user@example.com');
-    });
-
-    it('should strip a zero-width space pasted after the username', () => {
-      component.registrationForm.get('username').setValue('user@example.com​');
+    it('should trim leading/trailing whitespace pasted around the username', () => {
+      component.registrationForm.get('username').setValue('  user@example.com  ');
       expect(component.username).toBe('user@example.com');
     });
 
     it('should leave a clean username unchanged', () => {
       component.registrationForm.get('username').setValue('user@example.com');
       expect(component.username).toBe('user@example.com');
-    });
-
-    it('should clear a prior pattern error once the invisible character is sanitized', () => {
-      const control = component.registrationForm.get('username');
-      control.setValue('ㅤuser@example.com');
-      expect(control.errors?.['pattern']).toBeFalsy();
     });
   });
 

--- a/ui/candidate-portal/src/app/components/register/create-account/registration-create-account.component.spec.ts
+++ b/ui/candidate-portal/src/app/components/register/create-account/registration-create-account.component.spec.ts
@@ -256,6 +256,33 @@ describe('RegistrationCreateAccountComponent', () => {
     });
   });
 
+  // ── username sanitization (TC-723) ──────────────────────────────────────
+
+  describe('username sanitization', () => {
+    beforeEach(async () => configureAndCreate());
+
+    it('should strip a Hangul filler character pasted before the username', () => {
+      component.registrationForm.get('username').setValue('ㅤuser@example.com');
+      expect(component.username).toBe('user@example.com');
+    });
+
+    it('should strip a zero-width space pasted after the username', () => {
+      component.registrationForm.get('username').setValue('user@example.com​');
+      expect(component.username).toBe('user@example.com');
+    });
+
+    it('should leave a clean username unchanged', () => {
+      component.registrationForm.get('username').setValue('user@example.com');
+      expect(component.username).toBe('user@example.com');
+    });
+
+    it('should clear a prior pattern error once the invisible character is sanitized', () => {
+      const control = component.registrationForm.get('username');
+      control.setValue('ㅤuser@example.com');
+      expect(control.errors?.['pattern']).toBeFalsy();
+    });
+  });
+
   // ── register() – success, non-US-Afghan ────────────────────────────────
 
   describe('register() success (non-US-Afghan)', () => {

--- a/ui/candidate-portal/src/app/components/register/create-account/registration-create-account.component.ts
+++ b/ui/candidate-portal/src/app/components/register/create-account/registration-create-account.component.ts
@@ -24,7 +24,7 @@ import {RegistrationService} from "../../../services/registration.service";
 import {LanguageService} from "../../../services/language.service";
 import {RegisterCandidateRequest} from "../../../model/candidate";
 import {US_AFGHAN_SURVEY_TYPE} from "../../../model/survey-type";
-import {EMAIL_REGEX} from "../../../model/base";
+import {EMAIL_REGEX, sanitizeEmailInput} from "../../../model/base";
 
 @Component({
   selector: 'app-registration-create-account',
@@ -68,6 +68,15 @@ export class RegistrationCreateAccountComponent implements OnInit {
       username: ['', Validators.required],
       password: ['', Validators.required],
       passwordConfirmation: ['', Validators.required]
+    });
+
+    // Strip invisible characters (eg zero-width spaces) that copy-paste can silently add to an
+    // otherwise valid email address, causing pattern validation to fail - see TC-723.
+    this.registrationForm.get('username').valueChanges.subscribe((value: string) => {
+      const sanitized = sanitizeEmailInput(value);
+      if (sanitized !== value) {
+        this.registrationForm.get('username').setValue(sanitized, {emitEvent: false});
+      }
     });
 
     if (this.authenticationService.isAuthenticated()) {

--- a/ui/candidate-portal/src/app/model/base.spec.ts
+++ b/ui/candidate-portal/src/app/model/base.spec.ts
@@ -21,32 +21,12 @@ describe('sanitizeEmailInput', () => {
     expect(sanitizeEmailInput('example@example.com')).toBe('example@example.com');
   });
 
-  it('strips a Hangul filler character pasted before the address (TC-723)', () => {
-    expect(sanitizeEmailInput('ㅤexample@example.com')).toBe('example@example.com');
-  });
-
-  it('strips a zero-width space pasted after the address', () => {
-    expect(sanitizeEmailInput('example@example.com​')).toBe('example@example.com');
-  });
-
-  it('leaves a zero-width space embedded in the middle of the address untouched', () => {
-    expect(sanitizeEmailInput('example@example​.com')).toBe('example@example​.com');
-  });
-
-  it('strips a byte order mark (BOM)', () => {
-    expect(sanitizeEmailInput('﻿example@example.com')).toBe('example@example.com');
-  });
-
-  it('strips a non-breaking space', () => {
-    expect(sanitizeEmailInput(' example@example.com ')).toBe('example@example.com');
+  it('trims leading and trailing whitespace', () => {
+    expect(sanitizeEmailInput('  example@example.com  ')).toBe('example@example.com');
   });
 
   it('leaves an ordinary space embedded in the middle of the address untouched', () => {
     expect(sanitizeEmailInput('exam ple@example.com')).toBe('exam ple@example.com');
-  });
-
-  it('trims leading and trailing whitespace', () => {
-    expect(sanitizeEmailInput('  example@example.com  ')).toBe('example@example.com');
   });
 
   it('returns an empty string unchanged', () => {

--- a/ui/candidate-portal/src/app/model/base.spec.ts
+++ b/ui/candidate-portal/src/app/model/base.spec.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free
+ *  Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+import {sanitizeEmailInput} from './base';
+
+describe('sanitizeEmailInput', () => {
+  it('returns a clean email address unchanged', () => {
+    expect(sanitizeEmailInput('example@example.com')).toBe('example@example.com');
+  });
+
+  it('strips a Hangul filler character pasted before the address (TC-723)', () => {
+    expect(sanitizeEmailInput('ㅤexample@example.com')).toBe('example@example.com');
+  });
+
+  it('strips a zero-width space pasted after the address', () => {
+    expect(sanitizeEmailInput('example@example.com​')).toBe('example@example.com');
+  });
+
+  it('leaves a zero-width space embedded in the middle of the address untouched', () => {
+    expect(sanitizeEmailInput('example@example​.com')).toBe('example@example​.com');
+  });
+
+  it('strips a byte order mark (BOM)', () => {
+    expect(sanitizeEmailInput('﻿example@example.com')).toBe('example@example.com');
+  });
+
+  it('strips a non-breaking space', () => {
+    expect(sanitizeEmailInput(' example@example.com ')).toBe('example@example.com');
+  });
+
+  it('leaves an ordinary space embedded in the middle of the address untouched', () => {
+    expect(sanitizeEmailInput('exam ple@example.com')).toBe('exam ple@example.com');
+  });
+
+  it('trims leading and trailing whitespace', () => {
+    expect(sanitizeEmailInput('  example@example.com  ')).toBe('example@example.com');
+  });
+
+  it('returns an empty string unchanged', () => {
+    expect(sanitizeEmailInput('')).toBe('');
+  });
+
+  it('returns null unchanged', () => {
+    expect(sanitizeEmailInput(null)).toBeNull();
+  });
+
+  it('returns undefined unchanged', () => {
+    expect(sanitizeEmailInput(undefined)).toBeUndefined();
+  });
+});

--- a/ui/candidate-portal/src/app/model/base.ts
+++ b/ui/candidate-portal/src/app/model/base.ts
@@ -281,27 +281,10 @@ export const EMAIL_REGEX: string =
   '(?!.*[@.]{2})[a-zA-Z0-9!#$%&\'*+-/=?^_`{|}~]+[a-zA-Z0-9.!#$%&\'*+-/=?^_`{|}~]*@(?!-)[a-zA-Z0-9-]+(?<!-)(\\.(?!-)[a-zA-Z0-9-]+(?<!-))*$';
 
 /**
- * Matches one invisible/blank Unicode character: whitespace, plus the Hangul/Khmer filler
- * characters that render blank but aren't classified as whitespace.
- *
- * Mirrors INVISIBLE_OR_WHITESPACE_CHAR in
- * server/.../request/candidate/BaseCandidateContactRequest.java - keep both in sync.
- */
-const INVISIBLE_OR_WHITESPACE_CHAR = '[\\s\\p{Zs}\\p{Cf}\\u115F\\u1160\\u17B4\\u17B5\\u3164\\uFFA0]';
-
-/**
- * Strips invisible/blank characters from the start and end of a pasted email address - see
- * TC-723. Leaves anything in the middle untouched, since that would mean the email is
- * genuinely malformed rather than just messily pasted.
+ * Trims leading/trailing whitespace from a pasted email address - see TC-723.
  */
 export function sanitizeEmailInput(value: string): string {
-  if (!value) {
-    return value;
-  }
-  const edgeRegex = new RegExp(
-    `^${INVISIBLE_OR_WHITESPACE_CHAR}+|${INVISIBLE_OR_WHITESPACE_CHAR}+$`, 'gu'
-  );
-  return value.replace(edgeRegex, '');
+  return value == null ? value : value.trim();
 }
 
 /**

--- a/ui/candidate-portal/src/app/model/base.ts
+++ b/ui/candidate-portal/src/app/model/base.ts
@@ -281,27 +281,25 @@ export const EMAIL_REGEX: string =
   '(?!.*[@.]{2})[a-zA-Z0-9!#$%&\'*+-/=?^_`{|}~]+[a-zA-Z0-9.!#$%&\'*+-/=?^_`{|}~]*@(?!-)[a-zA-Z0-9-]+(?<!-)(\\.(?!-)[a-zA-Z0-9-]+(?<!-))*$';
 
 /**
- * Matches a single invisible/blank Unicode character (eg zero-width space, non-breaking space,
- * BOM, Hangul filler character) or ordinary whitespace character.
+ * Matches one invisible/blank Unicode character: whitespace, plus the Hangul/Khmer filler
+ * characters that render blank but aren't classified as whitespace.
+ *
+ * Mirrors INVISIBLE_OR_WHITESPACE_CHAR in
+ * server/.../request/candidate/BaseCandidateContactRequest.java - keep both in sync.
  */
-const INVISIBLE_OR_WHITESPACE_CHAR =
-  '[\\s\\u00A0\\u1680\\u180E\\u2000-\\u200F\\u202F\\u205F\\u2060-\\u2064\\u3000\\u3164\\uFEFF\\uFFA0\\u115F\\u1160\\u17B4\\u17B5]';
+const INVISIBLE_OR_WHITESPACE_CHAR = '[\\s\\p{Zs}\\p{Cf}\\u115F\\u1160\\u17B4\\u17B5\\u3164\\uFFA0]';
 
 /**
- * Strips leading/trailing invisible/blank Unicode characters (eg zero-width spaces, non-breaking
- * spaces, BOM, Hangul filler characters) that are often silently included when an email address
- * is copy-pasted. Without this, a visibly-correct pasted email address can fail
- * {@link EMAIL_REGEX} validation - see TC-723.
- *
- * Only leading/trailing characters are stripped - one embedded in the middle of the address is
- * left alone, since that would indicate a genuinely invalid email rather than a paste artifact.
+ * Strips invisible/blank characters from the start and end of a pasted email address - see
+ * TC-723. Leaves anything in the middle untouched, since that would mean the email is
+ * genuinely malformed rather than just messily pasted.
  */
 export function sanitizeEmailInput(value: string): string {
   if (!value) {
     return value;
   }
   const edgeRegex = new RegExp(
-    `^${INVISIBLE_OR_WHITESPACE_CHAR}+|${INVISIBLE_OR_WHITESPACE_CHAR}+$`, 'g'
+    `^${INVISIBLE_OR_WHITESPACE_CHAR}+|${INVISIBLE_OR_WHITESPACE_CHAR}+$`, 'gu'
   );
   return value.replace(edgeRegex, '');
 }

--- a/ui/candidate-portal/src/app/model/base.ts
+++ b/ui/candidate-portal/src/app/model/base.ts
@@ -281,6 +281,32 @@ export const EMAIL_REGEX: string =
   '(?!.*[@.]{2})[a-zA-Z0-9!#$%&\'*+-/=?^_`{|}~]+[a-zA-Z0-9.!#$%&\'*+-/=?^_`{|}~]*@(?!-)[a-zA-Z0-9-]+(?<!-)(\\.(?!-)[a-zA-Z0-9-]+(?<!-))*$';
 
 /**
+ * Matches a single invisible/blank Unicode character (eg zero-width space, non-breaking space,
+ * BOM, Hangul filler character) or ordinary whitespace character.
+ */
+const INVISIBLE_OR_WHITESPACE_CHAR =
+  '[\\s\\u00A0\\u1680\\u180E\\u2000-\\u200F\\u202F\\u205F\\u2060-\\u2064\\u3000\\u3164\\uFEFF\\uFFA0\\u115F\\u1160\\u17B4\\u17B5]';
+
+/**
+ * Strips leading/trailing invisible/blank Unicode characters (eg zero-width spaces, non-breaking
+ * spaces, BOM, Hangul filler characters) that are often silently included when an email address
+ * is copy-pasted. Without this, a visibly-correct pasted email address can fail
+ * {@link EMAIL_REGEX} validation - see TC-723.
+ *
+ * Only leading/trailing characters are stripped - one embedded in the middle of the address is
+ * left alone, since that would indicate a genuinely invalid email rather than a paste artifact.
+ */
+export function sanitizeEmailInput(value: string): string {
+  if (!value) {
+    return value;
+  }
+  const edgeRegex = new RegExp(
+    `^${INVISIBLE_OR_WHITESPACE_CHAR}+|${INVISIBLE_OR_WHITESPACE_CHAR}+$`, 'g'
+  );
+  return value.replace(edgeRegex, '');
+}
+
+/**
  * URL validation, also accepting 'mailto:' links, from
  * <a href="https://regex101.com/library/4hNOPu">regex101</a>
  */


### PR DESCRIPTION
The main issue occurred when candidates copied and pasted their email addresses into the registration form. In some cases, the pasted value contained invisible Unicode characters, causing an otherwise valid email address to be rejected.

To address this properly, email sanitization was implemented in both the frontend and backend.
## Frontend

Frontend sanitization improves the user experience and directly addresses the reported copy-and-paste issue.

1- A reusable email-sanitization function is added to remove leading and trailing whitespace and invisible Unicode characters from pasted email addresses.
2-A regular expression is necessary because some invisible characters are not removed by standard whitespace-handling methods. The following character pattern is used:
```
const INVISIBLE_OR_WHITESPACE_CHAR =
  '[\\s\\p{Zs}\\p{Cf}\\u115F\\u1160\\u17B4\\u17B5\\u3164\\uFFA0]';
```

`\s —` whitespace characters, including spaces, tabs, and line breaks.
`\p{Zs}` — Unicode space-separator characters, including non-breaking, thin, and ideographic spaces.
`\p{Cf} `— Unicode formatting characters, including zero-width and bidirectional-control characters.
`\u115F and \u1160 `— Hangul filler characters that can appear as invisible blanks.
`\u17B4 and \u17B5` — invisible Khmer vowel characters.
`\u3164 and \uFFA0 `— additional Hangul filler characters that can appear as invisible blanks.

The sanitizer removes these characters only from the beginning and end of the email address, preserving its internal content so that genuinely invalid email addresses still fail validation.

## Backend
The same sanitization is implemented on the backend to protect data integrity and ensure consistent validation regardless of where a request originates. This is important because email addresses may also be submitted through future API integrations, mobile applications, or other clients that do not use the frontend sanitizer.

Neither Java’s `trim()` nor `strip()` is sufficient without the additional regular expression. 
Java’s `trim()` only removes leading and trailing characters with Unicode values less than or equal to `U+0020`. Therefore, it does not handle many Unicode spaces or invisible formatting characters.

Java’s `strip() `provides broader Unicode support by using `Character.isWhitespace()`, but it still does not recognize every invisible or blank-looking character covered by the pattern.

The additional regular expression is therefore necessary to remove the characters responsible for the reported copy-and-paste issue.