### PR TITLE
Hiba/tc 1424 Remove custom styling from range inputs

### DIFF
--- a/ui/admin-portal/src/app/shared/components/input/input.component.scss
+++ b/ui/admin-portal/src/app/shared/components/input/input.component.scss
@@ -45,6 +45,19 @@
   top: 0.05rem;
 }
 
+// Override shared text-input styles so range inputs retain their native appearance, see TC-1424.
+.form-input[type='range'] {
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
+
+  &:focus {
+    outline: revert;
+    box-shadow: none;
+  }
+}
+
 // NgbTypeAhead dropdown, which Angular renders as a sibling of the input:
 ::ng-deep {
   @include dropdown-styles;

--- a/ui/candidate-portal/src/app/shared/components/input/input.component.scss
+++ b/ui/candidate-portal/src/app/shared/components/input/input.component.scss
@@ -45,6 +45,19 @@
   top: 0.05rem;
 }
 
+// Override shared text-input styles so range inputs retain their native appearance, see TC-1424.
+.form-input[type='range'] {
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
+
+  &:focus {
+    outline: revert;
+    box-shadow: none;
+  }
+}
+
 // NgbTypeAhead dropdown, which Angular renders as a sibling of the input:
 ::ng-deep {
   @include dropdown-styles;


### PR DESCRIPTION
The tc-input component applies text-field padding, border, border radius, and box shadow to every input type. For range inputs, the 0.5rem 0.75rem padding visually pushes the slider track away from the component’s outer edges, so the thumb does not appear to reach them. The component also displays a rounded text-field focus ring around the slider.

This PR removes the text-field styling and custom focus ring from range inputs.