### PR TITLE
Convert shared UI components to standalone components

### DIFF
--- a/ui/admin-portal/src/app/components/candidates/view/tab/candidate-visa-tab/au/job/visa-job-check-au.component.spec.ts
+++ b/ui/admin-portal/src/app/components/candidates/view/tab/candidate-visa-tab/au/job/visa-job-check-au.component.spec.ts
@@ -28,6 +28,7 @@ import {MockCandidate} from "../../../../../../../MockData/MockCandidate";
 import {CandidateVisa, CandidateVisaJobCheck} from "../../../../../../../model/candidate";
 import {of} from "rxjs";
 import {HttpClientTestingModule} from "@angular/common/http/testing";
+import {RouterTestingModule} from "@angular/router/testing";
 import {FormsModule, ReactiveFormsModule} from "@angular/forms";
 import {NgSelectModule} from "@ng-select/ng-select";
 import {CandidateService} from "../../../../../../../services/candidate.service";
@@ -56,11 +57,12 @@ describe('VisaJobCheckAuComponent', () => {
     const candidateOccupationServiceSpy = jasmine.createSpyObj('CandidateOccupationService', ['get']);
     const occupationServiceSpy = jasmine.createSpyObj('OccupationService', ['listOccupations']);
     await TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule,FormsModule,ReactiveFormsModule,NgSelectModule],
-      declarations: [ VisaJobCheckAuComponent,UpdatedByComponent,
+      imports: [HttpClientTestingModule,FormsModule,ReactiveFormsModule,NgSelectModule,
+        RouterTestingModule,
         TcAccordionComponent,
         TcAccordionItemComponent
       ],
+      declarations: [ VisaJobCheckAuComponent,UpdatedByComponent],
       providers: [
         { provide: CandidateEducationService, useValue: candidateEducationServiceSpy },
         { provide: CandidateOccupationService, useValue: candidateOccupationServiceSpy },

--- a/ui/admin-portal/src/app/components/candidates/view/tab/candidate-visa-tab/ca/job/visa-job-check-ca.component.spec.ts
+++ b/ui/admin-portal/src/app/components/candidates/view/tab/candidate-visa-tab/ca/job/visa-job-check-ca.component.spec.ts
@@ -14,6 +14,7 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 import {HttpClientTestingModule} from "@angular/common/http/testing";
+import {RouterTestingModule} from "@angular/router/testing";
 import {FormsModule, ReactiveFormsModule} from "@angular/forms";
 import {NgSelectModule} from "@ng-select/ng-select";
 import {VisaJobCheckCaComponent} from "./visa-job-check-ca.component";
@@ -94,15 +95,16 @@ describe('VisaJobCheckCaComponent', () => {
     const occupationSpy = jasmine.createSpyObj('CandidateOccupationService', ['get']);
     await TestBed.configureTestingModule({
       imports: [HttpClientTestingModule,FormsModule,ReactiveFormsModule,
-        NgSelectModule],
+        NgSelectModule,RouterTestingModule,
+        TcAccordionComponent,
+        TcAccordionItemComponent
+      ],
       declarations: [ VisaJobCheckCaComponent,DependantsComponent,VisaJobNotesComponent,FixedInputComponent,
         RelocatingDependantsComponent,JobEligibilityAssessmentComponent,JobInterestComponent,
         AgeRequirementComponent,RelevantWorkExpComponent,IneligiblePathwaysComponent,PreferredPathwaysComponent,
         EligiblePathwaysComponent,OccupationCategoryComponent,OccupationSubcategoryComponent
         ,AutosaveStatusComponent,VisaJobPutForwardComponent,QualificationRelevantComponent,
-        LanguageThresholdComponent,
-        TcAccordionComponent,
-        TcAccordionItemComponent
+        LanguageThresholdComponent
       ],
       providers: [
         { provide: CandidateEducationService, useValue: educationSpy },

--- a/ui/admin-portal/src/app/components/candidates/view/tab/candidate-visa-tab/uk/job/visa-job-check-uk.component.spec.ts
+++ b/ui/admin-portal/src/app/components/candidates/view/tab/candidate-visa-tab/uk/job/visa-job-check-uk.component.spec.ts
@@ -18,6 +18,7 @@ import {ComponentFixture, TestBed} from '@angular/core/testing';
 
 import {VisaJobCheckUkComponent} from './visa-job-check-uk.component';
 import {HttpClientTestingModule} from "@angular/common/http/testing";
+import {RouterTestingModule} from "@angular/router/testing";
 import {FormsModule, ReactiveFormsModule} from "@angular/forms";
 import {NgSelectModule} from "@ng-select/ng-select";
 import {
@@ -46,11 +47,11 @@ describe('VisaJobCheckUkComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [HttpClientTestingModule,FormsModule,ReactiveFormsModule,
-        NgSelectModule],
-      declarations: [ VisaJobCheckUkComponent, RelocatingDependantsComponent, DependantsComponent,
+        NgSelectModule,RouterTestingModule,
         TcAccordionComponent,
         TcAccordionItemComponent
-      ]
+      ],
+      declarations: [ VisaJobCheckUkComponent, RelocatingDependantsComponent, DependantsComponent]
     })
     .compileComponents();
   });

--- a/ui/admin-portal/src/app/shared/components/accordion/accordion-item/tc-accordion-item.component.spec.ts
+++ b/ui/admin-portal/src/app/shared/components/accordion/accordion-item/tc-accordion-item.component.spec.ts
@@ -9,7 +9,7 @@ describe('TcAccordionItemComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [TcAccordionItemComponent],
+      imports: [TcAccordionItemComponent],
       providers: [
         {
           provide: TcAccordionComponent,

--- a/ui/admin-portal/src/app/shared/components/accordion/accordion-item/tc-accordion-item.component.ts
+++ b/ui/admin-portal/src/app/shared/components/accordion/accordion-item/tc-accordion-item.component.ts
@@ -1,5 +1,7 @@
 import {Component, ContentChild, ElementRef, Input} from '@angular/core';
+import {CommonModule} from '@angular/common';
 import {TcAccordionComponent} from "../tc-accordion.component";
+import {TcIconComponent} from "../../icon-component/tc-icon.component";
 
 /**
  * @component TcAccordionItemComponent
@@ -48,7 +50,9 @@ import {TcAccordionComponent} from "../tc-accordion.component";
 @Component({
   selector: 'tc-accordion-item',
   templateUrl: './tc-accordion-item.component.html',
-  styleUrls: ['./tc-accordion-item.component.scss']
+  styleUrls: ['./tc-accordion-item.component.scss'],
+  standalone: true,
+  imports: [CommonModule, TcIconComponent]
 })
 export class TcAccordionItemComponent {
   /** The text displayed in the accordion header */

--- a/ui/admin-portal/src/app/shared/components/accordion/tc-accordion.component.spec.ts
+++ b/ui/admin-portal/src/app/shared/components/accordion/tc-accordion.component.spec.ts
@@ -1,4 +1,5 @@
 import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {RouterTestingModule} from '@angular/router/testing';
 
 import {TcAccordionComponent} from './tc-accordion.component';
 
@@ -8,7 +9,7 @@ describe('TcAccordionComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [TcAccordionComponent]
+      imports: [TcAccordionComponent, RouterTestingModule]
     });
     fixture = TestBed.createComponent(TcAccordionComponent);
     component = fixture.componentInstance;

--- a/ui/admin-portal/src/app/shared/components/accordion/tc-accordion.component.ts
+++ b/ui/admin-portal/src/app/shared/components/accordion/tc-accordion.component.ts
@@ -7,7 +7,9 @@ import {
   Output,
   QueryList
 } from '@angular/core';
+import {CommonModule} from '@angular/common';
 import {TcAccordionItemComponent} from "./accordion-item/tc-accordion-item.component";
+import {ButtonComponent} from "../button/button.component";
 
 /**
  * @component TcAccordionComponent
@@ -84,7 +86,9 @@ import {TcAccordionItemComponent} from "./accordion-item/tc-accordion-item.compo
 @Component({
   selector: 'tc-accordion',
   templateUrl: './tc-accordion.component.html',
-  styleUrls: ['./tc-accordion.component.scss']
+  styleUrls: ['./tc-accordion.component.scss'],
+  standalone: true,
+  imports: [CommonModule, ButtonComponent]
 })
 export class TcAccordionComponent implements AfterContentInit {
   /** Initialise with all panels opened - default false */

--- a/ui/admin-portal/src/app/shared/components/alert/alert.component.spec.ts
+++ b/ui/admin-portal/src/app/shared/components/alert/alert.component.spec.ts
@@ -8,7 +8,7 @@ describe('AlertComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [AlertComponent]
+      imports: [AlertComponent]
     });
     fixture = TestBed.createComponent(AlertComponent);
     component = fixture.componentInstance;

--- a/ui/admin-portal/src/app/shared/components/alert/alert.component.ts
+++ b/ui/admin-portal/src/app/shared/components/alert/alert.component.ts
@@ -1,4 +1,6 @@
 import {Component, EventEmitter, Input, Output} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {NgbAlert} from '@ng-bootstrap/ng-bootstrap';
 
 /**
  * @component AlertComponent
@@ -77,6 +79,8 @@ import {Component, EventEmitter, Input, Output} from '@angular/core';
   selector: 'tc-alert',
   templateUrl: './alert.component.html',
   styleUrls: ['./alert.component.scss'],
+  standalone: true,
+  imports: [CommonModule, NgbAlert]
 })
 export class AlertComponent {
   @Input() type: 'success' | 'info' | 'warning' | 'danger' | 'primary' | 'secondary' | 'light' | 'dark' = 'warning';

--- a/ui/admin-portal/src/app/shared/components/badge/badge.component.spec.ts
+++ b/ui/admin-portal/src/app/shared/components/badge/badge.component.spec.ts
@@ -8,7 +8,7 @@ describe('BadgeComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [BadgeComponent]
+      imports: [BadgeComponent]
     });
     fixture = TestBed.createComponent(BadgeComponent);
     component = fixture.componentInstance;

--- a/ui/admin-portal/src/app/shared/components/badge/badge.component.ts
+++ b/ui/admin-portal/src/app/shared/components/badge/badge.component.ts
@@ -1,4 +1,5 @@
 import {Component, Input} from '@angular/core';
+import {CommonModule} from '@angular/common';
 
 /**
  * @component BadgeComponent
@@ -52,7 +53,9 @@ export type BadgeColor = 'red' | 'orange' | 'yellow' | 'green' | 'blue' | 'purpl
 @Component({
   selector: 'tc-badge',
   templateUrl: './badge.component.html',
-  styleUrls: ['./badge.component.scss']
+  styleUrls: ['./badge.component.scss'],
+  standalone: true,
+  imports: [CommonModule]
 })
 export class BadgeComponent {
   @Input() color: BadgeColor = 'gray';

--- a/ui/admin-portal/src/app/shared/components/button/button.component.spec.ts
+++ b/ui/admin-portal/src/app/shared/components/button/button.component.spec.ts
@@ -1,6 +1,7 @@
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {ButtonComponent} from './button.component';
 import {By} from '@angular/platform-browser';
+import {RouterTestingModule} from '@angular/router/testing';
 
 describe('ButtonComponent', () => {
   let component: ButtonComponent;
@@ -8,7 +9,7 @@ describe('ButtonComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [ButtonComponent]
+      imports: [ButtonComponent, RouterTestingModule]
     });
     fixture = TestBed.createComponent(ButtonComponent);
     component = fixture.componentInstance;

--- a/ui/admin-portal/src/app/shared/components/button/button.component.ts
+++ b/ui/admin-portal/src/app/shared/components/button/button.component.ts
@@ -1,5 +1,6 @@
 import {Component, EventEmitter, HostBinding, Input, Output} from '@angular/core';
-import {QueryParamsHandling} from '@angular/router';
+import {QueryParamsHandling, RouterLink} from '@angular/router';
+import {CommonModule} from '@angular/common';
 
 /**
  * @component ButtonComponent
@@ -84,6 +85,8 @@ import {QueryParamsHandling} from '@angular/router';
   selector: 'tc-button',
   templateUrl: './button.component.html',
   styleUrls: ['./button.component.scss'],
+  standalone: true,
+  imports: [CommonModule, RouterLink]
 })
 export class ButtonComponent {
   @Input() size: 'xs' | 'sm' | 'default' | 'lg' | 'xl'  = 'default';

--- a/ui/admin-portal/src/app/shared/components/card/card-header/tc-card-header.component.spec.ts
+++ b/ui/admin-portal/src/app/shared/components/card/card-header/tc-card-header.component.spec.ts
@@ -8,7 +8,7 @@ describe('TcCardHeaderComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [TcCardHeaderComponent]
+      imports: [TcCardHeaderComponent]
     });
     fixture = TestBed.createComponent(TcCardHeaderComponent);
     component = fixture.componentInstance;

--- a/ui/admin-portal/src/app/shared/components/card/card-header/tc-card-header.component.ts
+++ b/ui/admin-portal/src/app/shared/components/card/card-header/tc-card-header.component.ts
@@ -50,7 +50,9 @@ import {Component} from '@angular/core';
 @Component({
   selector: 'tc-card-header',
   templateUrl: './tc-card-header.component.html',
-  styleUrls: ['./tc-card-header.component.scss']
+  styleUrls: ['./tc-card-header.component.scss'],
+  standalone: true,
+  imports: []
 })
 export class TcCardHeaderComponent {
 

--- a/ui/admin-portal/src/app/shared/components/card/tc-card.component.spec.ts
+++ b/ui/admin-portal/src/app/shared/components/card/tc-card.component.spec.ts
@@ -8,7 +8,7 @@ describe('TcCardComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [TcCardComponent]
+      imports: [TcCardComponent]
     });
     fixture = TestBed.createComponent(TcCardComponent);
     component = fixture.componentInstance;

--- a/ui/admin-portal/src/app/shared/components/card/tc-card.component.ts
+++ b/ui/admin-portal/src/app/shared/components/card/tc-card.component.ts
@@ -1,4 +1,5 @@
 import {Component, Input} from '@angular/core';
+import {CommonModule} from '@angular/common';
 
 /**
  * @component CardComponent
@@ -44,7 +45,9 @@ import {Component, Input} from '@angular/core';
 @Component({
   selector: 'tc-card',
   templateUrl: './tc-card.component.html',
-  styleUrls: ['./tc-card.component.scss']
+  styleUrls: ['./tc-card.component.scss'],
+  standalone: true,
+  imports: [CommonModule]
 })
 export class TcCardComponent {
   @Input() header: boolean = true;

--- a/ui/admin-portal/src/app/shared/components/date-picker/tc-date-picker.component.spec.ts
+++ b/ui/admin-portal/src/app/shared/components/date-picker/tc-date-picker.component.spec.ts
@@ -8,10 +8,11 @@ import {
   ReactiveFormsModule,
   UntypedFormControl
 } from "@angular/forms";
-import {DebugElement, NO_ERRORS_SCHEMA} from "@angular/core";
+import {DebugElement} from "@angular/core";
 import {By} from "@angular/platform-browser";
 import {LanguageService} from "../../../services/language.service";
 import {of} from "rxjs";
+import {RouterTestingModule} from "@angular/router/testing";
 
 describe('TcDatePickerComponent', () => {
   let component: TcDatePickerComponent;
@@ -20,15 +21,19 @@ describe('TcDatePickerComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [TcDatePickerComponent],
-      imports: [FormsModule, ReactiveFormsModule, NgbDatepickerModule],
+      imports: [
+        TcDatePickerComponent,
+        FormsModule,
+        ReactiveFormsModule,
+        NgbDatepickerModule,
+        RouterTestingModule
+      ],
       providers: [
         {
           provide: LanguageService,
           useValue: { loadDatePickerLanguageData: () => of(null) }
         }
-      ],
-      schemas: [NO_ERRORS_SCHEMA]
+      ]
     }).compileComponents();
 
     fixture = TestBed.createComponent(TcDatePickerComponent);

--- a/ui/admin-portal/src/app/shared/components/date-picker/tc-date-picker.component.ts
+++ b/ui/admin-portal/src/app/shared/components/date-picker/tc-date-picker.component.ts
@@ -1,7 +1,11 @@
 import {Component, Input, OnInit} from '@angular/core';
-import {AbstractControl, UntypedFormControl} from "@angular/forms";
-import {NgbDate, NgbDateStruct} from "@ng-bootstrap/ng-bootstrap";
+import {AbstractControl, FormsModule, UntypedFormControl} from "@angular/forms";
+import {CommonModule} from "@angular/common";
+import {NgbDate, NgbDateStruct, NgbInputDatepicker} from "@ng-bootstrap/ng-bootstrap";
 import {LanguageService} from "../../../services/language.service";
+import {ButtonComponent} from "../button/button.component";
+import {TcIconComponent} from "../icon-component/tc-icon.component";
+import {AlertComponent} from "../alert/alert.component";
 
 /**
  * @component TcDatePickerComponent
@@ -67,7 +71,16 @@ import {LanguageService} from "../../../services/language.service";
 @Component({
   selector: 'tc-date-picker',
   templateUrl: './tc-date-picker.component.html',
-  styleUrls: ['./tc-date-picker.component.scss']
+  styleUrls: ['./tc-date-picker.component.scss'],
+  standalone: true,
+  imports: [
+    CommonModule,
+    FormsModule,
+    NgbInputDatepicker,
+    ButtonComponent,
+    TcIconComponent,
+    AlertComponent
+  ]
 })
 export class TcDatePickerComponent implements OnInit {
   @Input() control: AbstractControl;

--- a/ui/admin-portal/src/app/shared/components/date-range-picker/tc-date-range-picker.component.spec.ts
+++ b/ui/admin-portal/src/app/shared/components/date-range-picker/tc-date-range-picker.component.spec.ts
@@ -15,9 +15,9 @@
  */
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {NgbDate, NgbDatepickerModule} from '@ng-bootstrap/ng-bootstrap';
-import {NO_ERRORS_SCHEMA} from "@angular/core";
 import {LanguageService} from "../../../services/language.service";
 import {of} from "rxjs";
+import {RouterTestingModule} from "@angular/router/testing";
 
 import {TcDateRangePickerComponent} from './tc-date-range-picker.component';
 
@@ -27,15 +27,17 @@ describe('TcDateRangePickerComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [TcDateRangePickerComponent],
-      imports: [NgbDatepickerModule],
+      imports: [
+        TcDateRangePickerComponent,
+        NgbDatepickerModule,
+        RouterTestingModule
+      ],
       providers: [
         {
           provide: LanguageService,
           useValue: { loadDatePickerLanguageData: () => of(null) }
         }
-      ],
-      schemas: [NO_ERRORS_SCHEMA]
+      ]
     });
     fixture = TestBed.createComponent(TcDateRangePickerComponent);
     component = fixture.componentInstance;

--- a/ui/admin-portal/src/app/shared/components/date-range-picker/tc-date-range-picker.component.ts
+++ b/ui/admin-portal/src/app/shared/components/date-range-picker/tc-date-range-picker.component.ts
@@ -15,8 +15,10 @@
  */
 
 import {Component, EventEmitter, Input, OnInit, Output} from '@angular/core';
-import {NgbDate, NgbDateStruct} from "@ng-bootstrap/ng-bootstrap";
+import {NgbDate, NgbDateStruct, NgbInputDatepicker} from "@ng-bootstrap/ng-bootstrap";
 import {LanguageService} from "../../../services/language.service";
+import {ButtonComponent} from "../button/button.component";
+import {TcIconComponent} from "../icon-component/tc-icon.component";
 
 /**
  * @component TcDateRangePickerComponent
@@ -72,7 +74,13 @@ import {LanguageService} from "../../../services/language.service";
 @Component({
   selector: 'tc-date-range-picker',
   templateUrl: './tc-date-range-picker.component.html',
-  styleUrls: ['./tc-date-range-picker.component.scss']
+  styleUrls: ['./tc-date-range-picker.component.scss'],
+  standalone: true,
+  imports: [
+    NgbInputDatepicker,
+    ButtonComponent,
+    TcIconComponent
+  ]
 })
 export class TcDateRangePickerComponent implements OnInit {
 

--- a/ui/admin-portal/src/app/shared/components/description-list/description-item/description-item.component.spec.ts
+++ b/ui/admin-portal/src/app/shared/components/description-list/description-item/description-item.component.spec.ts
@@ -8,7 +8,7 @@ describe('DescriptionItemComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [DescriptionItemComponent]
+      imports: [DescriptionItemComponent]
     });
     fixture = TestBed.createComponent(DescriptionItemComponent);
     component = fixture.componentInstance;

--- a/ui/admin-portal/src/app/shared/components/description-list/description-item/description-item.component.ts
+++ b/ui/admin-portal/src/app/shared/components/description-list/description-item/description-item.component.ts
@@ -1,4 +1,5 @@
 import {Component, Input} from '@angular/core';
+import {CommonModule} from '@angular/common';
 
 /**
  * @component DescriptionItemComponent
@@ -34,7 +35,9 @@ import {Component, Input} from '@angular/core';
 @Component({
   selector: 'tc-description-item',
   templateUrl: './description-item.component.html',
-  styleUrls: ['./description-item.component.scss']
+  styleUrls: ['./description-item.component.scss'],
+  standalone: true,
+  imports: [CommonModule]
 })
 export class DescriptionItemComponent {
   @Input() label!: string;

--- a/ui/admin-portal/src/app/shared/components/description-list/description-list.component.spec.ts
+++ b/ui/admin-portal/src/app/shared/components/description-list/description-list.component.spec.ts
@@ -8,7 +8,7 @@ describe('DescriptionListComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [DescriptionListComponent]
+      imports: [DescriptionListComponent]
     });
     fixture = TestBed.createComponent(DescriptionListComponent);
     component = fixture.componentInstance;

--- a/ui/admin-portal/src/app/shared/components/description-list/description-list.component.ts
+++ b/ui/admin-portal/src/app/shared/components/description-list/description-list.component.ts
@@ -1,4 +1,5 @@
 import {Component, Input} from '@angular/core';
+import {CommonModule} from '@angular/common';
 
 /**
  * @component DescriptionListComponent
@@ -58,7 +59,9 @@ import {Component, Input} from '@angular/core';
 @Component({
   selector: 'tc-description-list',
   templateUrl: './description-list.component.html',
-  styleUrls: ['./description-list.component.scss']
+  styleUrls: ['./description-list.component.scss'],
+  standalone: true,
+  imports: [CommonModule]
 })
 export class DescriptionListComponent {
   /** Direction of single item and all items */

--- a/ui/admin-portal/src/app/shared/components/dropdown/dropdown-button/tc-dropdown-button.component.spec.ts
+++ b/ui/admin-portal/src/app/shared/components/dropdown/dropdown-button/tc-dropdown-button.component.spec.ts
@@ -1,4 +1,5 @@
 import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {RouterTestingModule} from '@angular/router/testing';
 
 import {TcDropdownButtonComponent} from './tc-dropdown-button.component';
 
@@ -8,7 +9,7 @@ describe('TcDropdownButtonComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [TcDropdownButtonComponent]
+      imports: [TcDropdownButtonComponent, RouterTestingModule]
     });
     fixture = TestBed.createComponent(TcDropdownButtonComponent);
     component = fixture.componentInstance;

--- a/ui/admin-portal/src/app/shared/components/dropdown/dropdown-button/tc-dropdown-button.component.ts
+++ b/ui/admin-portal/src/app/shared/components/dropdown/dropdown-button/tc-dropdown-button.component.ts
@@ -1,4 +1,5 @@
 import {Component, Input} from '@angular/core';
+import {ButtonComponent} from "../../button/button.component";
 
 /**
  * @component TcDropdownButtonComponent
@@ -53,7 +54,9 @@ import {Component, Input} from '@angular/core';
 @Component({
   selector: 'tc-dropdown-button',
   templateUrl: './tc-dropdown-button.component.html',
-  styleUrls: ['./tc-dropdown-button.component.scss']
+  styleUrls: ['./tc-dropdown-button.component.scss'],
+  standalone: true,
+  imports: [ButtonComponent]
 })
 export class TcDropdownButtonComponent {
   @Input() type: 'solid' | 'outline' | 'plain' = 'plain';

--- a/ui/admin-portal/src/app/shared/components/dropdown/dropdown-divider/tc-dropdown-divider.component.spec.ts
+++ b/ui/admin-portal/src/app/shared/components/dropdown/dropdown-divider/tc-dropdown-divider.component.spec.ts
@@ -8,7 +8,7 @@ describe('TcDropdownDividerComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [TcDropdownDividerComponent]
+      imports: [TcDropdownDividerComponent]
     });
     fixture = TestBed.createComponent(TcDropdownDividerComponent);
     component = fixture.componentInstance;

--- a/ui/admin-portal/src/app/shared/components/dropdown/dropdown-divider/tc-dropdown-divider.component.ts
+++ b/ui/admin-portal/src/app/shared/components/dropdown/dropdown-divider/tc-dropdown-divider.component.ts
@@ -37,7 +37,9 @@ import {Component} from '@angular/core';
 @Component({
   selector: 'tc-dropdown-divider',
   templateUrl: './tc-dropdown-divider.component.html',
-  styleUrls: ['./tc-dropdown-divider.component.scss']
+  styleUrls: ['./tc-dropdown-divider.component.scss'],
+  standalone: true,
+  imports: []
 })
 export class TcDropdownDividerComponent {
 

--- a/ui/admin-portal/src/app/shared/components/dropdown/dropdown-item/tc-dropdown-item.component.spec.ts
+++ b/ui/admin-portal/src/app/shared/components/dropdown/dropdown-item/tc-dropdown-item.component.spec.ts
@@ -8,7 +8,7 @@ describe('TcDropdownItemComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [TcDropdownItemComponent]
+      imports: [TcDropdownItemComponent]
     });
     fixture = TestBed.createComponent(TcDropdownItemComponent);
     component = fixture.componentInstance;

--- a/ui/admin-portal/src/app/shared/components/dropdown/dropdown-item/tc-dropdown-item.component.ts
+++ b/ui/admin-portal/src/app/shared/components/dropdown/dropdown-item/tc-dropdown-item.component.ts
@@ -1,4 +1,7 @@
 import {Component, EventEmitter, Input, Output} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {RouterLink} from '@angular/router';
+import {NgbDropdownItem} from '@ng-bootstrap/ng-bootstrap';
 
 /**
  * @component TcDropdownItemComponent
@@ -37,6 +40,8 @@ import {Component, EventEmitter, Input, Output} from '@angular/core';
 @Component({
   selector: 'tc-dropdown-item',
   templateUrl: './tc-dropdown-item.component.html',
+  standalone: true,
+  imports: [CommonModule, RouterLink, NgbDropdownItem]
 })
 export class TcDropdownItemComponent {
   @Input() href?: string;

--- a/ui/admin-portal/src/app/shared/components/dropdown/dropdown-menu/tc-dropdown-menu.component.spec.ts
+++ b/ui/admin-portal/src/app/shared/components/dropdown/dropdown-menu/tc-dropdown-menu.component.spec.ts
@@ -8,7 +8,7 @@ describe('TcDropdownMenuComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [TcDropdownMenuComponent]
+      imports: [TcDropdownMenuComponent]
     });
     fixture = TestBed.createComponent(TcDropdownMenuComponent);
     component = fixture.componentInstance;

--- a/ui/admin-portal/src/app/shared/components/dropdown/dropdown-menu/tc-dropdown-menu.component.ts
+++ b/ui/admin-portal/src/app/shared/components/dropdown/dropdown-menu/tc-dropdown-menu.component.ts
@@ -49,7 +49,9 @@ import {Component, Input} from '@angular/core';
 @Component({
   selector: 'tc-dropdown-menu',
   templateUrl: './tc-dropdown-menu.component.html',
-  styleUrls: ['./tc-dropdown-menu.component.scss']
+  styleUrls: ['./tc-dropdown-menu.component.scss'],
+  standalone: true,
+  imports: []
 })
 export class TcDropdownMenuComponent {
   @Input() menuClass: string | string[] = '';

--- a/ui/admin-portal/src/app/shared/components/dropdown/tc-dropdown.component.spec.ts
+++ b/ui/admin-portal/src/app/shared/components/dropdown/tc-dropdown.component.spec.ts
@@ -8,7 +8,7 @@ describe('DropdownComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [TcDropdownComponent]
+      imports: [TcDropdownComponent]
     });
     fixture = TestBed.createComponent(TcDropdownComponent);
     component = fixture.componentInstance;

--- a/ui/admin-portal/src/app/shared/components/dropdown/tc-dropdown.component.ts
+++ b/ui/admin-portal/src/app/shared/components/dropdown/tc-dropdown.component.ts
@@ -1,5 +1,6 @@
 import {Component, Input} from '@angular/core';
-import {Placement} from '@ng-bootstrap/ng-bootstrap';
+import {CommonModule} from '@angular/common';
+import {NgbDropdown, NgbDropdownMenu, NgbDropdownToggle, Placement} from '@ng-bootstrap/ng-bootstrap';
 
 /**
  * @component TcDropdownComponent
@@ -48,6 +49,8 @@ import {Placement} from '@ng-bootstrap/ng-bootstrap';
   selector: 'tc-dropdown',
   templateUrl: './tc-dropdown.component.html',
   styleUrls: ['./tc-dropdown.component.scss'],
+  standalone: true,
+  imports: [CommonModule, NgbDropdown, NgbDropdownToggle, NgbDropdownMenu]
 })
 export class TcDropdownComponent {
   @Input() placement: Placement = 'bottom-start';

--- a/ui/admin-portal/src/app/shared/components/fieldset/description/description.component.spec.ts
+++ b/ui/admin-portal/src/app/shared/components/fieldset/description/description.component.spec.ts
@@ -8,7 +8,7 @@ describe('DescriptionComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [DescriptionComponent]
+      imports: [DescriptionComponent]
     });
     fixture = TestBed.createComponent(DescriptionComponent);
     component = fixture.componentInstance;

--- a/ui/admin-portal/src/app/shared/components/fieldset/description/description.component.ts
+++ b/ui/admin-portal/src/app/shared/components/fieldset/description/description.component.ts
@@ -39,7 +39,8 @@ import {Component} from '@angular/core';
 @Component({
   selector: 'tc-description',
   templateUrl: './description.component.html',
-  styleUrls: ['./description.component.scss']
+  styleUrls: ['./description.component.scss'],
+  standalone: true
 })
 export class DescriptionComponent {
 

--- a/ui/admin-portal/src/app/shared/components/fieldset/error-message/error-message.component.spec.ts
+++ b/ui/admin-portal/src/app/shared/components/fieldset/error-message/error-message.component.spec.ts
@@ -8,7 +8,7 @@ describe('ErrorMessageComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [ErrorMessageComponent]
+      imports: [ErrorMessageComponent]
     });
     fixture = TestBed.createComponent(ErrorMessageComponent);
     component = fixture.componentInstance;

--- a/ui/admin-portal/src/app/shared/components/fieldset/error-message/error-message.component.ts
+++ b/ui/admin-portal/src/app/shared/components/fieldset/error-message/error-message.component.ts
@@ -40,7 +40,8 @@ import {Component} from '@angular/core';
 @Component({
   selector: 'tc-error-message',
   templateUrl: './error-message.component.html',
-  styleUrls: ['./error-message.component.scss']
+  styleUrls: ['./error-message.component.scss'],
+  standalone: true
 })
 export class ErrorMessageComponent {
 }

--- a/ui/admin-portal/src/app/shared/components/fieldset/field/field.component.spec.ts
+++ b/ui/admin-portal/src/app/shared/components/fieldset/field/field.component.spec.ts
@@ -8,7 +8,7 @@ describe('FieldComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [FieldComponent]
+      imports: [FieldComponent]
     });
     fixture = TestBed.createComponent(FieldComponent);
     component = fixture.componentInstance;

--- a/ui/admin-portal/src/app/shared/components/fieldset/field/field.component.ts
+++ b/ui/admin-portal/src/app/shared/components/fieldset/field/field.component.ts
@@ -32,7 +32,8 @@ import {Component, HostBinding, Input} from '@angular/core';
 @Component({
   selector: 'tc-field',
   templateUrl: './field.component.html',
-  styleUrls: ['./field.component.scss']
+  styleUrls: ['./field.component.scss'],
+  standalone: true
 })
 export class FieldComponent {
   @Input() checkbox = false;

--- a/ui/admin-portal/src/app/shared/components/fieldset/fieldset.component.spec.ts
+++ b/ui/admin-portal/src/app/shared/components/fieldset/fieldset.component.spec.ts
@@ -8,7 +8,7 @@ describe('FieldsetComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [FieldsetComponent]
+      imports: [FieldsetComponent]
     });
     fixture = TestBed.createComponent(FieldsetComponent);
     component = fixture.componentInstance;

--- a/ui/admin-portal/src/app/shared/components/fieldset/fieldset.component.ts
+++ b/ui/admin-portal/src/app/shared/components/fieldset/fieldset.component.ts
@@ -28,7 +28,8 @@ import {Component, Input} from '@angular/core';
 @Component({
   selector: 'tc-fieldset',
   templateUrl: './fieldset.component.html',
-  styleUrls: ['./fieldset.component.scss']
+  styleUrls: ['./fieldset.component.scss'],
+  standalone: true
 })
 export class FieldsetComponent {
   @Input() disabled = false;

--- a/ui/admin-portal/src/app/shared/components/fieldset/label/label.component.spec.ts
+++ b/ui/admin-portal/src/app/shared/components/fieldset/label/label.component.spec.ts
@@ -8,7 +8,7 @@ describe('LabelComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [LabelComponent]
+      imports: [LabelComponent]
     });
     fixture = TestBed.createComponent(LabelComponent);
     component = fixture.componentInstance;

--- a/ui/admin-portal/src/app/shared/components/fieldset/label/label.component.ts
+++ b/ui/admin-portal/src/app/shared/components/fieldset/label/label.component.ts
@@ -1,4 +1,5 @@
 import {Component, Input} from '@angular/core';
+import {CommonModule} from '@angular/common';
 
 /**
  * @component LabelComponent
@@ -28,7 +29,9 @@ import {Component, Input} from '@angular/core';
 @Component({
   selector: 'tc-label',
   templateUrl: './label.component.html',
-  styleUrls: ['./label.component.scss']
+  styleUrls: ['./label.component.scss'],
+  standalone: true,
+  imports: [CommonModule]
 })
 export class LabelComponent {
   @Input() for?: string; // to associate with input by id

--- a/ui/admin-portal/src/app/shared/components/icon-component/tc-icon.component.spec.ts
+++ b/ui/admin-portal/src/app/shared/components/icon-component/tc-icon.component.spec.ts
@@ -8,7 +8,7 @@ describe('TcIconComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [TcIconComponent]
+      imports: [TcIconComponent]
     });
     fixture = TestBed.createComponent(TcIconComponent);
     component = fixture.componentInstance;

--- a/ui/admin-portal/src/app/shared/components/icon-component/tc-icon.component.ts
+++ b/ui/admin-portal/src/app/shared/components/icon-component/tc-icon.component.ts
@@ -1,4 +1,6 @@
 import {Component, Input} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {RouterLink} from '@angular/router';
 
 /**
  * @component IconComponent
@@ -72,7 +74,9 @@ import {Component, Input} from '@angular/core';
 @Component({
   selector: 'tc-icon',
   templateUrl: './tc-icon.component.html',
-  styleUrls: ['./tc-icon.component.scss']
+  styleUrls: ['./tc-icon.component.scss'],
+  standalone: true,
+  imports: [CommonModule, RouterLink]
 })
 export class TcIconComponent {
   @Input() size: 'sm' | 'md' | 'lg' | 'xl' | 'inherit' = 'inherit';

--- a/ui/admin-portal/src/app/shared/components/input/input.component.spec.ts
+++ b/ui/admin-portal/src/app/shared/components/input/input.component.spec.ts
@@ -8,7 +8,7 @@ describe('InputComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [InputComponent]
+      imports: [InputComponent]
     });
     fixture = TestBed.createComponent(InputComponent);
     component = fixture.componentInstance;

--- a/ui/admin-portal/src/app/shared/components/input/input.component.ts
+++ b/ui/admin-portal/src/app/shared/components/input/input.component.ts
@@ -10,7 +10,7 @@ import {
   ViewChild
 } from '@angular/core';
 import {Observable} from "rxjs";
-import {NgbTypeaheadSelectItemEvent} from "@ng-bootstrap/ng-bootstrap";
+import {NgbTypeahead, NgbTypeaheadSelectItemEvent} from "@ng-bootstrap/ng-bootstrap";
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
 
 /**
@@ -77,6 +77,8 @@ import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
   selector: 'tc-input',
   templateUrl: './input.component.html',
   styleUrls: ['./input.component.scss'],
+  standalone: true,
+  imports: [NgbTypeahead],
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,

--- a/ui/admin-portal/src/app/shared/components/loading/tc-loading.component.spec.ts
+++ b/ui/admin-portal/src/app/shared/components/loading/tc-loading.component.spec.ts
@@ -8,7 +8,7 @@ describe('TcLoadingComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [TcLoadingComponent]
+      imports: [TcLoadingComponent]
     });
     fixture = TestBed.createComponent(TcLoadingComponent);
     component = fixture.componentInstance;

--- a/ui/admin-portal/src/app/shared/components/loading/tc-loading.component.ts
+++ b/ui/admin-portal/src/app/shared/components/loading/tc-loading.component.ts
@@ -1,4 +1,5 @@
 import {Component, Input} from '@angular/core';
+import {CommonModule} from '@angular/common';
 
 /**
  * @component LoadingComponent
@@ -36,7 +37,9 @@ import {Component, Input} from '@angular/core';
 @Component({
   selector: 'tc-loading',
   templateUrl: './tc-loading.component.html',
-  styleUrls: ['./tc-loading.component.scss']
+  styleUrls: ['./tc-loading.component.scss'],
+  standalone: true,
+  imports: [CommonModule]
 })
 export class TcLoadingComponent {
   @Input() loading: boolean = false;

--- a/ui/admin-portal/src/app/shared/components/modal/tc-modal.component.spec.ts
+++ b/ui/admin-portal/src/app/shared/components/modal/tc-modal.component.spec.ts
@@ -6,6 +6,7 @@ import {By} from "@angular/platform-browser";
 import {ButtonComponent} from "../button/button.component";
 import {Component} from "@angular/core";
 import {TcIconComponent} from "../icon-component/tc-icon.component";
+import {RouterTestingModule} from '@angular/router/testing';
 
 @Component({
   template: `
@@ -43,7 +44,8 @@ describe('TcModalComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [TcModalComponent, TestHostComponent, ButtonComponent, TcIconComponent],
+      declarations: [TestHostComponent],
+      imports: [TcModalComponent, ButtonComponent, TcIconComponent, RouterTestingModule],
       providers: [NgbActiveModal],
     }).compileComponents();
 

--- a/ui/admin-portal/src/app/shared/components/modal/tc-modal.component.ts
+++ b/ui/admin-portal/src/app/shared/components/modal/tc-modal.component.ts
@@ -1,5 +1,8 @@
 import {Component, EventEmitter, Input, Output} from '@angular/core';
 import {NgbActiveModal} from "@ng-bootstrap/ng-bootstrap";
+import {CommonModule} from '@angular/common';
+import {TcIconComponent} from "../icon-component/tc-icon.component";
+import {ButtonComponent} from "../button/button.component";
 
 /**
  * @component TcModalComponent
@@ -91,7 +94,9 @@ import {NgbActiveModal} from "@ng-bootstrap/ng-bootstrap";
 @Component({
   selector: 'tc-modal',
   templateUrl: './tc-modal.component.html',
-  styleUrls: ['./tc-modal.component.scss']
+  styleUrls: ['./tc-modal.component.scss'],
+  standalone: true,
+  imports: [CommonModule, TcIconComponent, ButtonComponent]
 })
 export class TcModalComponent {
   /** Appears as the title of the modal (note: reason the input isn't called title is that the

--- a/ui/admin-portal/src/app/shared/components/pagination/tc-pagination.component.spec.ts
+++ b/ui/admin-portal/src/app/shared/components/pagination/tc-pagination.component.spec.ts
@@ -9,8 +9,7 @@ describe('TcPaginationComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [TcPaginationComponent],
-      imports: [NgbPaginationModule]
+      imports: [TcPaginationComponent, NgbPaginationModule]
     }).compileComponents();
 
     fixture = TestBed.createComponent(TcPaginationComponent);

--- a/ui/admin-portal/src/app/shared/components/pagination/tc-pagination.component.ts
+++ b/ui/admin-portal/src/app/shared/components/pagination/tc-pagination.component.ts
@@ -1,4 +1,6 @@
 import {Component, EventEmitter, Input, Output, ViewEncapsulation} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {NgbPaginationModule} from '@ng-bootstrap/ng-bootstrap';
 
 /**
  * @component TcPaginationComponent
@@ -38,7 +40,9 @@ import {Component, EventEmitter, Input, Output, ViewEncapsulation} from '@angula
   selector: 'tc-pagination',
   templateUrl: './tc-pagination.component.html',
   styleUrls: ['./tc-pagination.component.scss'],
-  encapsulation: ViewEncapsulation.None
+  encapsulation: ViewEncapsulation.None,
+  standalone: true,
+  imports: [CommonModule, NgbPaginationModule]
 })
 export class TcPaginationComponent {
   /** Total number of results to be paged */

--- a/ui/admin-portal/src/app/shared/components/radio/tc-radio.component.spec.ts
+++ b/ui/admin-portal/src/app/shared/components/radio/tc-radio.component.spec.ts
@@ -26,8 +26,7 @@ describe('TcRadioComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [TcRadioComponent],
-      imports: [FormsModule, ReactiveFormsModule]
+      imports: [TcRadioComponent, FormsModule, ReactiveFormsModule]
     }).compileComponents();
   });
 

--- a/ui/admin-portal/src/app/shared/components/radio/tc-radio.component.ts
+++ b/ui/admin-portal/src/app/shared/components/radio/tc-radio.component.ts
@@ -30,6 +30,7 @@ import {ControlValueAccessor, NG_VALUE_ACCESSOR} from "@angular/forms";
 @Component({
   selector: 'tc-radio',
   templateUrl: './tc-radio.component.html',
+  standalone: true,
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,

--- a/ui/admin-portal/src/app/shared/components/table/tc-table.component.spec.ts
+++ b/ui/admin-portal/src/app/shared/components/table/tc-table.component.spec.ts
@@ -8,7 +8,7 @@ describe('TcTableComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [TcTableComponent]
+      imports: [TcTableComponent]
     });
     fixture = TestBed.createComponent(TcTableComponent);
     component = fixture.componentInstance;

--- a/ui/admin-portal/src/app/shared/components/table/tc-table.component.ts
+++ b/ui/admin-portal/src/app/shared/components/table/tc-table.component.ts
@@ -1,5 +1,9 @@
 import {Component, EventEmitter, Input, Output, ViewEncapsulation} from '@angular/core';
+import {CommonModule} from '@angular/common';
 import {SearchResults} from "../../../model/search-results";
+import {AlertComponent} from "../alert/alert.component";
+import {TcLoadingComponent} from "../loading/tc-loading.component";
+import {TcPaginationComponent} from "../pagination/tc-pagination.component";
 
 /**
  * @component TcTableComponent
@@ -46,7 +50,9 @@ import {SearchResults} from "../../../model/search-results";
   // Setting to None means the tc-table scss style only applies styles to <table> elements within the tc-table component,
   // avoids styles bleeding out to the other <table> components not wrapped by <tc-table>. Also overrides any
   // existing <table> styles from bootstrap.
-  encapsulation: ViewEncapsulation.None
+  encapsulation: ViewEncapsulation.None,
+  standalone: true,
+  imports: [CommonModule, AlertComponent, TcLoadingComponent, TcPaginationComponent]
 })
 export class TcTableComponent {
   // Required inputs

--- a/ui/admin-portal/src/app/shared/components/tabs/tab/content/tc-tab-content.component.spec.ts
+++ b/ui/admin-portal/src/app/shared/components/tabs/tab/content/tc-tab-content.component.spec.ts
@@ -8,7 +8,7 @@ describe('TcTabContentComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [TcTabContentComponent]
+      imports: [TcTabContentComponent]
     });
     fixture = TestBed.createComponent(TcTabContentComponent);
     component = fixture.componentInstance;

--- a/ui/admin-portal/src/app/shared/components/tabs/tab/content/tc-tab-content.component.ts
+++ b/ui/admin-portal/src/app/shared/components/tabs/tab/content/tc-tab-content.component.ts
@@ -31,7 +31,9 @@ import {Component, TemplateRef, ViewChild} from '@angular/core';
 @Component({
   selector: 'tc-tab-content',
   templateUrl: './tc-tab-content.component.html',
-  styleUrls: ['./tc-tab-content.component.scss']
+  styleUrls: ['./tc-tab-content.component.scss'],
+  standalone: true,
+  imports: []
 })
 export class TcTabContentComponent {
   @ViewChild(TemplateRef, { static: true }) template!: TemplateRef<any>;

--- a/ui/admin-portal/src/app/shared/components/tabs/tab/header/tc-tab-header.component.spec.ts
+++ b/ui/admin-portal/src/app/shared/components/tabs/tab/header/tc-tab-header.component.spec.ts
@@ -8,7 +8,7 @@ describe('TcTabHeaderComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [TcTabHeaderComponent]
+      imports: [TcTabHeaderComponent]
     });
     fixture = TestBed.createComponent(TcTabHeaderComponent);
     component = fixture.componentInstance;

--- a/ui/admin-portal/src/app/shared/components/tabs/tab/header/tc-tab-header.component.ts
+++ b/ui/admin-portal/src/app/shared/components/tabs/tab/header/tc-tab-header.component.ts
@@ -47,7 +47,9 @@ import {Component, TemplateRef, ViewChild} from '@angular/core';
 @Component({
   selector: 'tc-tab-header',
   templateUrl: './tc-tab-header.component.html',
-  styleUrls: ['./tc-tab-header.component.scss']
+  styleUrls: ['./tc-tab-header.component.scss'],
+  standalone: true,
+  imports: []
 })
 export class TcTabHeaderComponent {
   @ViewChild(TemplateRef, { static: true }) template!: TemplateRef<any>;

--- a/ui/admin-portal/src/app/shared/components/tabs/tab/tc-tab.component.spec.ts
+++ b/ui/admin-portal/src/app/shared/components/tabs/tab/tc-tab.component.spec.ts
@@ -8,7 +8,7 @@ describe('TcTabComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [TcTabComponent]
+      imports: [TcTabComponent]
     });
     fixture = TestBed.createComponent(TcTabComponent);
     component = fixture.componentInstance;

--- a/ui/admin-portal/src/app/shared/components/tabs/tab/tc-tab.component.ts
+++ b/ui/admin-portal/src/app/shared/components/tabs/tab/tc-tab.component.ts
@@ -36,7 +36,9 @@ import {TcTabContentComponent} from "./content/tc-tab-content.component";
 @Component({
   selector: 'tc-tab',
   templateUrl: './tc-tab.component.html',
-  styleUrls: ['./tc-tab.component.scss']
+  styleUrls: ['./tc-tab.component.scss'],
+  standalone: true,
+  imports: []
 })
 export class TcTabComponent implements AfterContentInit {
   @Input() id: string;

--- a/ui/admin-portal/src/app/shared/components/tabs/tc-tabs.component.spec.ts
+++ b/ui/admin-portal/src/app/shared/components/tabs/tc-tabs.component.spec.ts
@@ -34,7 +34,8 @@ describe('TcTabsComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [TcTabsComponent, TcTabComponent, TcTabHeaderComponent, TcTabContentComponent, TestHostComponent],
+      declarations: [TestHostComponent],
+      imports: [TcTabsComponent, TcTabComponent, TcTabHeaderComponent, TcTabContentComponent],
     }).compileComponents();
 
     fixture = TestBed.createComponent(TestHostComponent);

--- a/ui/admin-portal/src/app/shared/components/tabs/tc-tabs.component.ts
+++ b/ui/admin-portal/src/app/shared/components/tabs/tc-tabs.component.ts
@@ -10,6 +10,7 @@ import {
   SimpleChanges,
   TemplateRef
 } from '@angular/core';
+import {CommonModule} from '@angular/common';
 import {TcTabComponent} from "./tab/tc-tab.component";
 
 export interface Tab {
@@ -58,7 +59,9 @@ export interface Tab {
 @Component({
   selector: 'tc-tabs',
   templateUrl: './tc-tabs.component.html',
-  styleUrls: ['./tc-tabs.component.scss']
+  styleUrls: ['./tc-tabs.component.scss'],
+  standalone: true,
+  imports: [CommonModule]
 })
 export class TcTabsComponent implements AfterContentInit, OnChanges {
   /** Optional input to set the active tab - if not provided, uses default tab or first tab */

--- a/ui/admin-portal/src/app/shared/components/textarea/textarea.component.spec.ts
+++ b/ui/admin-portal/src/app/shared/components/textarea/textarea.component.spec.ts
@@ -8,7 +8,7 @@ describe('TextareaComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [TextareaComponent]
+      imports: [TextareaComponent]
     });
     fixture = TestBed.createComponent(TextareaComponent);
     component = fixture.componentInstance;

--- a/ui/admin-portal/src/app/shared/components/textarea/textarea.component.ts
+++ b/ui/admin-portal/src/app/shared/components/textarea/textarea.component.ts
@@ -76,6 +76,7 @@ import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
   selector: 'tc-textarea',
   templateUrl: './textarea.component.html',
   styleUrls: ['./textarea.component.scss'],
+  standalone: true,
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,

--- a/ui/admin-portal/src/app/shared/shared.module.ts
+++ b/ui/admin-portal/src/app/shared/shared.module.ts
@@ -15,16 +15,7 @@
  */
 
 import {NgModule} from '@angular/core';
-import {CommonModule} from '@angular/common';
 import {ButtonComponent} from './components/button/button.component';
-import {
-  NgbAlert,
-  NgbDropdownModule,
-  NgbInputDatepicker,
-  NgbNavModule,
-  NgbPaginationModule,
-  NgbTypeahead
-} from "@ng-bootstrap/ng-bootstrap";
 import {TcTableComponent} from "./components/table/tc-table.component";
 import {TcPaginationComponent} from './components/pagination/tc-pagination.component';
 import {TcTabsComponent} from './components/tabs/tc-tabs.component';
@@ -61,7 +52,6 @@ import {
 import {
   TcDropdownDividerComponent
 } from './components/dropdown/dropdown-divider/tc-dropdown-divider.component';
-import {RouterLink} from "@angular/router";
 import {
   TcDateRangePickerComponent
 } from './components/date-range-picker/tc-date-range-picker.component'
@@ -74,17 +64,16 @@ import {TcCardComponent} from './components/card/tc-card.component';
 import {TcCardHeaderComponent} from './components/card/card-header/tc-card-header.component';
 import {TcLoadingComponent} from './components/loading/tc-loading.component';
 import {TcDatePickerComponent} from './components/date-picker/tc-date-picker.component';
-import {FormsModule, ReactiveFormsModule} from "@angular/forms";
 import {TcRadioComponent} from "./components/radio/tc-radio.component";
 
 @NgModule({
-  declarations: [
+  imports: [
     ButtonComponent,
     TcTableComponent,
     TcPaginationComponent,
     InputComponent,
-    FieldsetComponent,
     FieldComponent,
+    FieldsetComponent,
     LabelComponent,
     DescriptionComponent,
     ErrorMessageComponent,
@@ -112,19 +101,6 @@ import {TcRadioComponent} from "./components/radio/tc-radio.component";
     TcLoadingComponent,
     TcDatePickerComponent,
     TcRadioComponent
-  ],
-  imports: [
-    CommonModule,
-    NgbPaginationModule,
-    NgbNavModule,
-    NgbAlert,
-    NgbDropdownModule,
-    RouterLink,
-    NgbInputDatepicker,
-    ReactiveFormsModule,
-    FormsModule,
-    NgbInputDatepicker,
-    NgbTypeahead
   ],
   exports: [
     ButtonComponent,

--- a/ui/admin-portal/src/test-global-custom-elements.ts
+++ b/ui/admin-portal/src/test-global-custom-elements.ts
@@ -418,7 +418,8 @@ const REAL_COMPONENTS = new Set([
 
 const originalConfigure = TestBed.configureTestingModule.bind(TestBed);
 (TestBed.configureTestingModule as any) = (meta: TestModuleMetadata = {}) => {
-  const hasReal = (meta.declarations ?? []).some(d => REAL_COMPONENTS.has(d?.name));
+  const hasReal = [...(meta.declarations ?? []), ...(meta.imports ?? [])]
+    .some(d => REAL_COMPONENTS.has((d as any)?.name));
   if (!hasReal) {
     meta.imports = [...(meta.imports ?? []), GlobalCustomStubsModule];
   }

--- a/ui/candidate-portal/src/app/shared/components/accordion/accordion-item/tc-accordion-item.component.spec.ts
+++ b/ui/candidate-portal/src/app/shared/components/accordion/accordion-item/tc-accordion-item.component.spec.ts
@@ -9,7 +9,7 @@ describe('TcAccordionItemComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [TcAccordionItemComponent],
+      imports: [TcAccordionItemComponent],
       providers: [
         {
           provide: TcAccordionComponent,

--- a/ui/candidate-portal/src/app/shared/components/accordion/accordion-item/tc-accordion-item.component.ts
+++ b/ui/candidate-portal/src/app/shared/components/accordion/accordion-item/tc-accordion-item.component.ts
@@ -1,5 +1,7 @@
 import {Component, ContentChild, ElementRef, Input} from '@angular/core';
+import {CommonModule} from '@angular/common';
 import {TcAccordionComponent} from "../tc-accordion.component";
+import {TcIconComponent} from "../../icon-component/tc-icon.component";
 
 /**
  * @component TcAccordionItemComponent
@@ -48,7 +50,9 @@ import {TcAccordionComponent} from "../tc-accordion.component";
 @Component({
   selector: 'tc-accordion-item',
   templateUrl: './tc-accordion-item.component.html',
-  styleUrls: ['./tc-accordion-item.component.scss']
+  styleUrls: ['./tc-accordion-item.component.scss'],
+  standalone: true,
+  imports: [CommonModule, TcIconComponent]
 })
 export class TcAccordionItemComponent {
   /** The text displayed in the accordion header */

--- a/ui/candidate-portal/src/app/shared/components/accordion/tc-accordion.component.spec.ts
+++ b/ui/candidate-portal/src/app/shared/components/accordion/tc-accordion.component.spec.ts
@@ -15,9 +15,10 @@
  */
 
 import {CommonModule} from '@angular/common';
-import {NO_ERRORS_SCHEMA, QueryList} from '@angular/core';
+import {QueryList} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
+import {RouterTestingModule} from '@angular/router/testing';
 
 import {TcAccordionItemComponent} from './accordion-item/tc-accordion-item.component';
 import {TcAccordionComponent} from './tc-accordion.component';
@@ -256,9 +257,7 @@ describe('TcAccordionComponent template', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [CommonModule],
-      declarations: [TcAccordionComponent],
-      schemas: [NO_ERRORS_SCHEMA]
+      imports: [CommonModule, RouterTestingModule, TcAccordionComponent]
     }).compileComponents();
 
     fixture = TestBed.createComponent(

--- a/ui/candidate-portal/src/app/shared/components/accordion/tc-accordion.component.ts
+++ b/ui/candidate-portal/src/app/shared/components/accordion/tc-accordion.component.ts
@@ -7,7 +7,9 @@ import {
   Output,
   QueryList
 } from '@angular/core';
+import {CommonModule} from '@angular/common';
 import {TcAccordionItemComponent} from "./accordion-item/tc-accordion-item.component";
+import {ButtonComponent} from "../button/button.component";
 
 /**
  * @component TcAccordionComponent
@@ -84,7 +86,9 @@ import {TcAccordionItemComponent} from "./accordion-item/tc-accordion-item.compo
 @Component({
   selector: 'tc-accordion',
   templateUrl: './tc-accordion.component.html',
-  styleUrls: ['./tc-accordion.component.scss']
+  styleUrls: ['./tc-accordion.component.scss'],
+  standalone: true,
+  imports: [CommonModule, ButtonComponent]
 })
 export class TcAccordionComponent implements AfterContentInit {
   /** Initialise with all panels opened - default false */

--- a/ui/candidate-portal/src/app/shared/components/alert/alert.component.spec.ts
+++ b/ui/candidate-portal/src/app/shared/components/alert/alert.component.spec.ts
@@ -8,7 +8,7 @@ describe('AlertComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [AlertComponent]
+      imports: [AlertComponent]
     });
     fixture = TestBed.createComponent(AlertComponent);
     component = fixture.componentInstance;

--- a/ui/candidate-portal/src/app/shared/components/alert/alert.component.ts
+++ b/ui/candidate-portal/src/app/shared/components/alert/alert.component.ts
@@ -1,4 +1,6 @@
 import {Component, EventEmitter, Input, Output} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {NgbAlert} from '@ng-bootstrap/ng-bootstrap';
 
 /**
  * @component AlertComponent
@@ -77,6 +79,8 @@ import {Component, EventEmitter, Input, Output} from '@angular/core';
   selector: 'tc-alert',
   templateUrl: './alert.component.html',
   styleUrls: ['./alert.component.scss'],
+  standalone: true,
+  imports: [CommonModule, NgbAlert]
 })
 export class AlertComponent {
   @Input() type: 'success' | 'info' | 'warning' | 'danger' | 'primary' | 'secondary' | 'light' | 'dark' = 'warning';

--- a/ui/candidate-portal/src/app/shared/components/badge/badge.component.spec.ts
+++ b/ui/candidate-portal/src/app/shared/components/badge/badge.component.spec.ts
@@ -8,7 +8,7 @@ describe('BadgeComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [BadgeComponent]
+      imports: [BadgeComponent]
     });
     fixture = TestBed.createComponent(BadgeComponent);
     component = fixture.componentInstance;

--- a/ui/candidate-portal/src/app/shared/components/badge/badge.component.ts
+++ b/ui/candidate-portal/src/app/shared/components/badge/badge.component.ts
@@ -1,4 +1,5 @@
 import {Component, Input} from '@angular/core';
+import {CommonModule} from '@angular/common';
 
 /**
  * @component BadgeComponent
@@ -52,7 +53,9 @@ export type BadgeColor = 'red' | 'orange' | 'yellow' | 'green' | 'blue' | 'purpl
 @Component({
   selector: 'tc-badge',
   templateUrl: './badge.component.html',
-  styleUrls: ['./badge.component.scss']
+  styleUrls: ['./badge.component.scss'],
+  standalone: true,
+  imports: [CommonModule]
 })
 export class BadgeComponent {
   @Input() color: BadgeColor = 'gray';

--- a/ui/candidate-portal/src/app/shared/components/button/button.component.spec.ts
+++ b/ui/candidate-portal/src/app/shared/components/button/button.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ButtonComponent } from './button.component';
 import { By } from '@angular/platform-browser';
+import { RouterTestingModule } from '@angular/router/testing';
 
 describe('ButtonComponent', () => {
   let component: ButtonComponent;
@@ -8,7 +9,7 @@ describe('ButtonComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [ButtonComponent]
+      imports: [ButtonComponent, RouterTestingModule]
     });
     fixture = TestBed.createComponent(ButtonComponent);
     component = fixture.componentInstance;

--- a/ui/candidate-portal/src/app/shared/components/button/button.component.ts
+++ b/ui/candidate-portal/src/app/shared/components/button/button.component.ts
@@ -1,5 +1,6 @@
 import {Component, EventEmitter, HostBinding, Input, Output} from '@angular/core';
-import {QueryParamsHandling} from '@angular/router';
+import {QueryParamsHandling, RouterLink} from '@angular/router';
+import {CommonModule} from '@angular/common';
 
 /**
  * @component ButtonComponent
@@ -84,6 +85,8 @@ import {QueryParamsHandling} from '@angular/router';
   selector: 'tc-button',
   templateUrl: './button.component.html',
   styleUrls: ['./button.component.scss'],
+  standalone: true,
+  imports: [CommonModule, RouterLink]
 })
 export class ButtonComponent {
   @Input() size: 'xs' | 'sm' | 'default' | 'lg' | 'xl'  = 'default';

--- a/ui/candidate-portal/src/app/shared/components/card/card-header/tc-card-header.component.spec.ts
+++ b/ui/candidate-portal/src/app/shared/components/card/card-header/tc-card-header.component.spec.ts
@@ -8,7 +8,7 @@ describe('TcCardHeaderComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [TcCardHeaderComponent]
+      imports: [TcCardHeaderComponent]
     });
     fixture = TestBed.createComponent(TcCardHeaderComponent);
     component = fixture.componentInstance;

--- a/ui/candidate-portal/src/app/shared/components/card/card-header/tc-card-header.component.ts
+++ b/ui/candidate-portal/src/app/shared/components/card/card-header/tc-card-header.component.ts
@@ -50,7 +50,9 @@ import {Component} from '@angular/core';
 @Component({
   selector: 'tc-card-header',
   templateUrl: './tc-card-header.component.html',
-  styleUrls: ['./tc-card-header.component.scss']
+  styleUrls: ['./tc-card-header.component.scss'],
+  standalone: true,
+  imports: []
 })
 export class TcCardHeaderComponent {
 

--- a/ui/candidate-portal/src/app/shared/components/card/tc-card.component.spec.ts
+++ b/ui/candidate-portal/src/app/shared/components/card/tc-card.component.spec.ts
@@ -8,7 +8,7 @@ describe('TcCardComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [TcCardComponent]
+      imports: [TcCardComponent]
     });
     fixture = TestBed.createComponent(TcCardComponent);
     component = fixture.componentInstance;

--- a/ui/candidate-portal/src/app/shared/components/card/tc-card.component.ts
+++ b/ui/candidate-portal/src/app/shared/components/card/tc-card.component.ts
@@ -1,4 +1,5 @@
 import {Component, Input} from '@angular/core';
+import {CommonModule} from '@angular/common';
 
 /**
  * @component CardComponent
@@ -44,7 +45,9 @@ import {Component, Input} from '@angular/core';
 @Component({
   selector: 'tc-card',
   templateUrl: './tc-card.component.html',
-  styleUrls: ['./tc-card.component.scss']
+  styleUrls: ['./tc-card.component.scss'],
+  standalone: true,
+  imports: [CommonModule]
 })
 export class TcCardComponent {
   @Input() header: boolean = true;

--- a/ui/candidate-portal/src/app/shared/components/date-picker/tc-date-picker.component.spec.ts
+++ b/ui/candidate-portal/src/app/shared/components/date-picker/tc-date-picker.component.spec.ts
@@ -8,10 +8,11 @@ import {
   ReactiveFormsModule,
   UntypedFormControl
 } from "@angular/forms";
-import {DebugElement, NO_ERRORS_SCHEMA} from "@angular/core";
+import {DebugElement} from "@angular/core";
 import {By} from "@angular/platform-browser";
 import {LanguageService} from "../../../services/language.service";
 import {of} from "rxjs";
+import {RouterTestingModule} from "@angular/router/testing";
 
 describe('TcDatePickerComponent', () => {
   let component: TcDatePickerComponent;
@@ -20,15 +21,19 @@ describe('TcDatePickerComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [TcDatePickerComponent],
-      imports: [FormsModule, ReactiveFormsModule, NgbDatepickerModule],
+      imports: [
+        TcDatePickerComponent,
+        FormsModule,
+        ReactiveFormsModule,
+        NgbDatepickerModule,
+        RouterTestingModule
+      ],
       providers: [
         {
           provide: LanguageService,
           useValue: { loadDatePickerLanguageData: () => of(null) }
         }
-      ],
-      schemas: [NO_ERRORS_SCHEMA]
+      ]
     }).compileComponents();
 
     fixture = TestBed.createComponent(TcDatePickerComponent);

--- a/ui/candidate-portal/src/app/shared/components/date-picker/tc-date-picker.component.ts
+++ b/ui/candidate-portal/src/app/shared/components/date-picker/tc-date-picker.component.ts
@@ -1,7 +1,11 @@
 import {Component, Input, OnInit} from '@angular/core';
-import {AbstractControl, UntypedFormControl} from "@angular/forms";
-import {NgbDate, NgbDateStruct} from "@ng-bootstrap/ng-bootstrap";
+import {AbstractControl, FormsModule, UntypedFormControl} from "@angular/forms";
+import {CommonModule} from "@angular/common";
+import {NgbDate, NgbDateStruct, NgbInputDatepicker} from "@ng-bootstrap/ng-bootstrap";
 import {LanguageService} from "../../../services/language.service";
+import {ButtonComponent} from "../button/button.component";
+import {TcIconComponent} from "../icon-component/tc-icon.component";
+import {AlertComponent} from "../alert/alert.component";
 
 /**
  * @component TcDatePickerComponent
@@ -67,7 +71,16 @@ import {LanguageService} from "../../../services/language.service";
 @Component({
   selector: 'tc-date-picker',
   templateUrl: './tc-date-picker.component.html',
-  styleUrls: ['./tc-date-picker.component.scss']
+  styleUrls: ['./tc-date-picker.component.scss'],
+  standalone: true,
+  imports: [
+    CommonModule,
+    FormsModule,
+    NgbInputDatepicker,
+    ButtonComponent,
+    TcIconComponent,
+    AlertComponent
+  ]
 })
 export class TcDatePickerComponent implements OnInit {
   @Input() control: AbstractControl;

--- a/ui/candidate-portal/src/app/shared/components/date-range-picker/tc-date-range-picker.component.spec.ts
+++ b/ui/candidate-portal/src/app/shared/components/date-range-picker/tc-date-range-picker.component.spec.ts
@@ -14,13 +14,13 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-import {NO_ERRORS_SCHEMA} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {NgbDate, NgbDatepickerModule} from '@ng-bootstrap/ng-bootstrap';
 import {of} from 'rxjs';
 
 import {LanguageService} from '../../../services/language.service';
 import {TcDateRangePickerComponent} from './tc-date-range-picker.component';
+import {RouterTestingModule} from "@angular/router/testing";
 
 describe('TcDateRangePickerComponent', () => {
   let component: TcDateRangePickerComponent;
@@ -39,20 +39,16 @@ describe('TcDateRangePickerComponent', () => {
     .and.returnValue(of(null));
 
     TestBed.configureTestingModule({
-      declarations: [
-        TcDateRangePickerComponent
-      ],
       imports: [
-        NgbDatepickerModule
+        TcDateRangePickerComponent,
+        NgbDatepickerModule,
+        RouterTestingModule
       ],
       providers: [
         {
           provide: LanguageService,
           useValue: languageServiceSpy
         }
-      ],
-      schemas: [
-        NO_ERRORS_SCHEMA
       ]
     });
 

--- a/ui/candidate-portal/src/app/shared/components/date-range-picker/tc-date-range-picker.component.ts
+++ b/ui/candidate-portal/src/app/shared/components/date-range-picker/tc-date-range-picker.component.ts
@@ -15,8 +15,10 @@
  */
 
 import {Component, EventEmitter, Input, OnInit, Output} from '@angular/core';
-import {NgbDate, NgbDateStruct} from "@ng-bootstrap/ng-bootstrap";
+import {NgbDate, NgbDateStruct, NgbInputDatepicker} from "@ng-bootstrap/ng-bootstrap";
 import {LanguageService} from "../../../services/language.service";
+import {ButtonComponent} from "../button/button.component";
+import {TcIconComponent} from "../icon-component/tc-icon.component";
 
 /**
  * @component TcDateRangePickerComponent
@@ -72,7 +74,13 @@ import {LanguageService} from "../../../services/language.service";
 @Component({
   selector: 'tc-date-range-picker',
   templateUrl: './tc-date-range-picker.component.html',
-  styleUrls: ['./tc-date-range-picker.component.scss']
+  styleUrls: ['./tc-date-range-picker.component.scss'],
+  standalone: true,
+  imports: [
+    NgbInputDatepicker,
+    ButtonComponent,
+    TcIconComponent
+  ]
 })
 export class TcDateRangePickerComponent implements OnInit {
 

--- a/ui/candidate-portal/src/app/shared/components/description-list/description-item/description-item.component.spec.ts
+++ b/ui/candidate-portal/src/app/shared/components/description-list/description-item/description-item.component.spec.ts
@@ -8,7 +8,7 @@ describe('DescriptionItemComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [DescriptionItemComponent]
+      imports: [DescriptionItemComponent]
     });
     fixture = TestBed.createComponent(DescriptionItemComponent);
     component = fixture.componentInstance;

--- a/ui/candidate-portal/src/app/shared/components/description-list/description-item/description-item.component.ts
+++ b/ui/candidate-portal/src/app/shared/components/description-list/description-item/description-item.component.ts
@@ -1,4 +1,5 @@
 import {Component, Input} from '@angular/core';
+import {CommonModule} from '@angular/common';
 
 /**
  * @component DescriptionItemComponent
@@ -34,7 +35,9 @@ import {Component, Input} from '@angular/core';
 @Component({
   selector: 'tc-description-item',
   templateUrl: './description-item.component.html',
-  styleUrls: ['./description-item.component.scss']
+  styleUrls: ['./description-item.component.scss'],
+  standalone: true,
+  imports: [CommonModule]
 })
 export class DescriptionItemComponent {
   @Input() label!: string;

--- a/ui/candidate-portal/src/app/shared/components/description-list/description-list.component.spec.ts
+++ b/ui/candidate-portal/src/app/shared/components/description-list/description-list.component.spec.ts
@@ -8,7 +8,7 @@ describe('DescriptionListComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [DescriptionListComponent]
+      imports: [DescriptionListComponent]
     });
     fixture = TestBed.createComponent(DescriptionListComponent);
     component = fixture.componentInstance;

--- a/ui/candidate-portal/src/app/shared/components/description-list/description-list.component.ts
+++ b/ui/candidate-portal/src/app/shared/components/description-list/description-list.component.ts
@@ -1,4 +1,5 @@
 import {Component, Input} from '@angular/core';
+import {CommonModule} from '@angular/common';
 
 /**
  * @component DescriptionListComponent
@@ -59,7 +60,9 @@ import {Component, Input} from '@angular/core';
 @Component({
   selector: 'tc-description-list',
   templateUrl: './description-list.component.html',
-  styleUrls: ['./description-list.component.scss']
+  styleUrls: ['./description-list.component.scss'],
+  standalone: true,
+  imports: [CommonModule]
 })
 export class DescriptionListComponent {
   /** Direction of single item and all items */

--- a/ui/candidate-portal/src/app/shared/components/dropdown/dropdown-button/tc-dropdown-button.component.spec.ts
+++ b/ui/candidate-portal/src/app/shared/components/dropdown/dropdown-button/tc-dropdown-button.component.spec.ts
@@ -1,4 +1,5 @@
 import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {RouterTestingModule} from '@angular/router/testing';
 
 import {TcDropdownButtonComponent} from './tc-dropdown-button.component';
 
@@ -8,7 +9,7 @@ describe('TcDropdownButtonComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [TcDropdownButtonComponent]
+      imports: [TcDropdownButtonComponent, RouterTestingModule]
     });
     fixture = TestBed.createComponent(TcDropdownButtonComponent);
     component = fixture.componentInstance;

--- a/ui/candidate-portal/src/app/shared/components/dropdown/dropdown-button/tc-dropdown-button.component.ts
+++ b/ui/candidate-portal/src/app/shared/components/dropdown/dropdown-button/tc-dropdown-button.component.ts
@@ -1,4 +1,5 @@
 import {Component, Input} from '@angular/core';
+import {ButtonComponent} from "../../button/button.component";
 
 /**
  * @component TcDropdownButtonComponent
@@ -53,7 +54,9 @@ import {Component, Input} from '@angular/core';
 @Component({
   selector: 'tc-dropdown-button',
   templateUrl: './tc-dropdown-button.component.html',
-  styleUrls: ['./tc-dropdown-button.component.scss']
+  styleUrls: ['./tc-dropdown-button.component.scss'],
+  standalone: true,
+  imports: [ButtonComponent]
 })
 export class TcDropdownButtonComponent {
   @Input() type: 'solid' | 'outline' | 'plain' = 'plain';

--- a/ui/candidate-portal/src/app/shared/components/dropdown/dropdown-divider/tc-dropdown-divider.component.spec.ts
+++ b/ui/candidate-portal/src/app/shared/components/dropdown/dropdown-divider/tc-dropdown-divider.component.spec.ts
@@ -8,7 +8,7 @@ describe('TcDropdownDividerComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [TcDropdownDividerComponent]
+      imports: [TcDropdownDividerComponent]
     });
     fixture = TestBed.createComponent(TcDropdownDividerComponent);
     component = fixture.componentInstance;

--- a/ui/candidate-portal/src/app/shared/components/dropdown/dropdown-divider/tc-dropdown-divider.component.ts
+++ b/ui/candidate-portal/src/app/shared/components/dropdown/dropdown-divider/tc-dropdown-divider.component.ts
@@ -37,7 +37,9 @@ import {Component} from '@angular/core';
 @Component({
   selector: 'tc-dropdown-divider',
   templateUrl: './tc-dropdown-divider.component.html',
-  styleUrls: ['./tc-dropdown-divider.component.scss']
+  styleUrls: ['./tc-dropdown-divider.component.scss'],
+  standalone: true,
+  imports: []
 })
 export class TcDropdownDividerComponent {
 

--- a/ui/candidate-portal/src/app/shared/components/dropdown/dropdown-item/tc-dropdown-item.component.spec.ts
+++ b/ui/candidate-portal/src/app/shared/components/dropdown/dropdown-item/tc-dropdown-item.component.spec.ts
@@ -8,7 +8,7 @@ describe('TcDropdownItemComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [TcDropdownItemComponent]
+      imports: [TcDropdownItemComponent]
     });
     fixture = TestBed.createComponent(TcDropdownItemComponent);
     component = fixture.componentInstance;

--- a/ui/candidate-portal/src/app/shared/components/dropdown/dropdown-item/tc-dropdown-item.component.ts
+++ b/ui/candidate-portal/src/app/shared/components/dropdown/dropdown-item/tc-dropdown-item.component.ts
@@ -1,4 +1,7 @@
 import {Component, EventEmitter, Input, Output} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {RouterLink} from '@angular/router';
+import {NgbDropdownItem} from '@ng-bootstrap/ng-bootstrap';
 
 /**
  * @component TcDropdownItemComponent
@@ -37,6 +40,8 @@ import {Component, EventEmitter, Input, Output} from '@angular/core';
 @Component({
   selector: 'tc-dropdown-item',
   templateUrl: './tc-dropdown-item.component.html',
+  standalone: true,
+  imports: [CommonModule, RouterLink, NgbDropdownItem]
 })
 export class TcDropdownItemComponent {
   @Input() href?: string;

--- a/ui/candidate-portal/src/app/shared/components/dropdown/dropdown-menu/tc-dropdown-menu.component.spec.ts
+++ b/ui/candidate-portal/src/app/shared/components/dropdown/dropdown-menu/tc-dropdown-menu.component.spec.ts
@@ -8,7 +8,7 @@ describe('TcDropdownMenuComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [TcDropdownMenuComponent]
+      imports: [TcDropdownMenuComponent]
     });
     fixture = TestBed.createComponent(TcDropdownMenuComponent);
     component = fixture.componentInstance;

--- a/ui/candidate-portal/src/app/shared/components/dropdown/dropdown-menu/tc-dropdown-menu.component.ts
+++ b/ui/candidate-portal/src/app/shared/components/dropdown/dropdown-menu/tc-dropdown-menu.component.ts
@@ -49,7 +49,9 @@ import {Component, Input} from '@angular/core';
 @Component({
   selector: 'tc-dropdown-menu',
   templateUrl: './tc-dropdown-menu.component.html',
-  styleUrls: ['./tc-dropdown-menu.component.scss']
+  styleUrls: ['./tc-dropdown-menu.component.scss'],
+  standalone: true,
+  imports: []
 })
 export class TcDropdownMenuComponent {
   @Input() menuClass: string | string[] = '';

--- a/ui/candidate-portal/src/app/shared/components/dropdown/tc-dropdown.component.spec.ts
+++ b/ui/candidate-portal/src/app/shared/components/dropdown/tc-dropdown.component.spec.ts
@@ -8,7 +8,7 @@ describe('DropdownComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [TcDropdownComponent]
+      imports: [TcDropdownComponent]
     });
     fixture = TestBed.createComponent(TcDropdownComponent);
     component = fixture.componentInstance;

--- a/ui/candidate-portal/src/app/shared/components/dropdown/tc-dropdown.component.ts
+++ b/ui/candidate-portal/src/app/shared/components/dropdown/tc-dropdown.component.ts
@@ -1,5 +1,6 @@
 import {Component, Input} from '@angular/core';
-import {Placement} from '@ng-bootstrap/ng-bootstrap';
+import {CommonModule} from '@angular/common';
+import {NgbDropdown, NgbDropdownMenu, NgbDropdownToggle, Placement} from '@ng-bootstrap/ng-bootstrap';
 
 /**
  * @component TcDropdownComponent
@@ -48,6 +49,8 @@ import {Placement} from '@ng-bootstrap/ng-bootstrap';
   selector: 'tc-dropdown',
   templateUrl: './tc-dropdown.component.html',
   styleUrls: ['./tc-dropdown.component.scss'],
+  standalone: true,
+  imports: [CommonModule, NgbDropdown, NgbDropdownToggle, NgbDropdownMenu]
 })
 export class TcDropdownComponent {
   @Input() placement: Placement = 'bottom-start';

--- a/ui/candidate-portal/src/app/shared/components/fieldset/description/description.component.spec.ts
+++ b/ui/candidate-portal/src/app/shared/components/fieldset/description/description.component.spec.ts
@@ -8,7 +8,7 @@ describe('DescriptionComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [DescriptionComponent]
+      imports: [DescriptionComponent]
     });
     fixture = TestBed.createComponent(DescriptionComponent);
     component = fixture.componentInstance;

--- a/ui/candidate-portal/src/app/shared/components/fieldset/description/description.component.ts
+++ b/ui/candidate-portal/src/app/shared/components/fieldset/description/description.component.ts
@@ -39,7 +39,8 @@ import {Component} from '@angular/core';
 @Component({
   selector: 'tc-description',
   templateUrl: './description.component.html',
-  styleUrls: ['./description.component.scss']
+  styleUrls: ['./description.component.scss'],
+  standalone: true
 })
 export class DescriptionComponent {
 

--- a/ui/candidate-portal/src/app/shared/components/fieldset/error-message/error-message.component.spec.ts
+++ b/ui/candidate-portal/src/app/shared/components/fieldset/error-message/error-message.component.spec.ts
@@ -8,7 +8,7 @@ describe('ErrorMessageComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [ErrorMessageComponent]
+      imports: [ErrorMessageComponent]
     });
     fixture = TestBed.createComponent(ErrorMessageComponent);
     component = fixture.componentInstance;

--- a/ui/candidate-portal/src/app/shared/components/fieldset/error-message/error-message.component.ts
+++ b/ui/candidate-portal/src/app/shared/components/fieldset/error-message/error-message.component.ts
@@ -40,7 +40,8 @@ import {Component} from '@angular/core';
 @Component({
   selector: 'tc-error-message',
   templateUrl: './error-message.component.html',
-  styleUrls: ['./error-message.component.scss']
+  styleUrls: ['./error-message.component.scss'],
+  standalone: true
 })
 export class ErrorMessageComponent {
 }

--- a/ui/candidate-portal/src/app/shared/components/fieldset/field/field.component.spec.ts
+++ b/ui/candidate-portal/src/app/shared/components/fieldset/field/field.component.spec.ts
@@ -8,7 +8,7 @@ describe('FieldComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [FieldComponent]
+      imports: [FieldComponent]
     });
     fixture = TestBed.createComponent(FieldComponent);
     component = fixture.componentInstance;

--- a/ui/candidate-portal/src/app/shared/components/fieldset/field/field.component.ts
+++ b/ui/candidate-portal/src/app/shared/components/fieldset/field/field.component.ts
@@ -32,7 +32,8 @@ import {Component, HostBinding, Input} from '@angular/core';
 @Component({
   selector: 'tc-field',
   templateUrl: './field.component.html',
-  styleUrls: ['./field.component.scss']
+  styleUrls: ['./field.component.scss'],
+  standalone: true
 })
 export class FieldComponent {
   @Input() checkbox = false;

--- a/ui/candidate-portal/src/app/shared/components/fieldset/fieldset.component.spec.ts
+++ b/ui/candidate-portal/src/app/shared/components/fieldset/fieldset.component.spec.ts
@@ -8,7 +8,7 @@ describe('FieldsetComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [FieldsetComponent]
+      imports: [FieldsetComponent]
     });
     fixture = TestBed.createComponent(FieldsetComponent);
     component = fixture.componentInstance;

--- a/ui/candidate-portal/src/app/shared/components/fieldset/fieldset.component.ts
+++ b/ui/candidate-portal/src/app/shared/components/fieldset/fieldset.component.ts
@@ -28,7 +28,8 @@ import {Component, Input} from '@angular/core';
 @Component({
   selector: 'tc-fieldset',
   templateUrl: './fieldset.component.html',
-  styleUrls: ['./fieldset.component.scss']
+  styleUrls: ['./fieldset.component.scss'],
+  standalone: true
 })
 export class FieldsetComponent {
   @Input() disabled = false;

--- a/ui/candidate-portal/src/app/shared/components/fieldset/label/label.component.spec.ts
+++ b/ui/candidate-portal/src/app/shared/components/fieldset/label/label.component.spec.ts
@@ -8,7 +8,7 @@ describe('LabelComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [LabelComponent]
+      imports: [LabelComponent]
     });
     fixture = TestBed.createComponent(LabelComponent);
     component = fixture.componentInstance;

--- a/ui/candidate-portal/src/app/shared/components/fieldset/label/label.component.ts
+++ b/ui/candidate-portal/src/app/shared/components/fieldset/label/label.component.ts
@@ -1,4 +1,5 @@
 import {Component, Input} from '@angular/core';
+import {CommonModule} from '@angular/common';
 
 /**
  * @component LabelComponent
@@ -28,7 +29,9 @@ import {Component, Input} from '@angular/core';
 @Component({
   selector: 'tc-label',
   templateUrl: './label.component.html',
-  styleUrls: ['./label.component.scss']
+  styleUrls: ['./label.component.scss'],
+  standalone: true,
+  imports: [CommonModule]
 })
 export class LabelComponent {
   @Input() for?: string; // to associate with input by id

--- a/ui/candidate-portal/src/app/shared/components/icon-component/tc-icon.component.spec.ts
+++ b/ui/candidate-portal/src/app/shared/components/icon-component/tc-icon.component.spec.ts
@@ -8,7 +8,7 @@ describe('TcIconComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [TcIconComponent]
+      imports: [TcIconComponent]
     });
     fixture = TestBed.createComponent(TcIconComponent);
     component = fixture.componentInstance;

--- a/ui/candidate-portal/src/app/shared/components/icon-component/tc-icon.component.ts
+++ b/ui/candidate-portal/src/app/shared/components/icon-component/tc-icon.component.ts
@@ -1,4 +1,6 @@
 import {Component, Input} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {RouterLink} from '@angular/router';
 
 /**
  * @component IconComponent
@@ -72,7 +74,9 @@ import {Component, Input} from '@angular/core';
 @Component({
   selector: 'tc-icon',
   templateUrl: './tc-icon.component.html',
-  styleUrls: ['./tc-icon.component.scss']
+  styleUrls: ['./tc-icon.component.scss'],
+  standalone: true,
+  imports: [CommonModule, RouterLink]
 })
 export class TcIconComponent {
   @Input() size: 'sm' | 'md' | 'lg' | 'xl' | 'inherit' = 'inherit';

--- a/ui/candidate-portal/src/app/shared/components/input/input.component.spec.ts
+++ b/ui/candidate-portal/src/app/shared/components/input/input.component.spec.ts
@@ -8,7 +8,7 @@ describe('InputComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [InputComponent]
+      imports: [InputComponent]
     });
     fixture = TestBed.createComponent(InputComponent);
     component = fixture.componentInstance;

--- a/ui/candidate-portal/src/app/shared/components/input/input.component.ts
+++ b/ui/candidate-portal/src/app/shared/components/input/input.component.ts
@@ -10,7 +10,7 @@ import {
   ViewChild
 } from '@angular/core';
 import {Observable} from "rxjs";
-import {NgbTypeaheadSelectItemEvent} from "@ng-bootstrap/ng-bootstrap";
+import {NgbTypeahead, NgbTypeaheadSelectItemEvent} from "@ng-bootstrap/ng-bootstrap";
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
 
 /**
@@ -75,6 +75,8 @@ import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
   selector: 'tc-input',
   templateUrl: './input.component.html',
   styleUrls: ['./input.component.scss'],
+  standalone: true,
+  imports: [NgbTypeahead],
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,

--- a/ui/candidate-portal/src/app/shared/components/loading/tc-loading.component.spec.ts
+++ b/ui/candidate-portal/src/app/shared/components/loading/tc-loading.component.spec.ts
@@ -8,7 +8,7 @@ describe('TcLoadingComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [TcLoadingComponent]
+      imports: [TcLoadingComponent]
     });
     fixture = TestBed.createComponent(TcLoadingComponent);
     component = fixture.componentInstance;

--- a/ui/candidate-portal/src/app/shared/components/loading/tc-loading.component.ts
+++ b/ui/candidate-portal/src/app/shared/components/loading/tc-loading.component.ts
@@ -1,4 +1,5 @@
 import {Component, Input} from '@angular/core';
+import {CommonModule} from '@angular/common';
 
 /**
  * @component LoadingComponent
@@ -36,7 +37,9 @@ import {Component, Input} from '@angular/core';
 @Component({
   selector: 'tc-loading',
   templateUrl: './tc-loading.component.html',
-  styleUrls: ['./tc-loading.component.scss']
+  styleUrls: ['./tc-loading.component.scss'],
+  standalone: true,
+  imports: [CommonModule]
 })
 export class TcLoadingComponent {
   @Input() loading: boolean = false;

--- a/ui/candidate-portal/src/app/shared/components/modal/tc-modal.component.spec.ts
+++ b/ui/candidate-portal/src/app/shared/components/modal/tc-modal.component.spec.ts
@@ -5,6 +5,7 @@ import {NgbActiveModal} from "@ng-bootstrap/ng-bootstrap";
 import {By} from "@angular/platform-browser";
 import {ButtonComponent} from "../button/button.component";
 import {Component} from "@angular/core";
+import {RouterTestingModule} from '@angular/router/testing';
 
 @Component({
   template: `
@@ -40,7 +41,8 @@ describe('TcModalComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [TcModalComponent, TestHostComponent, ButtonComponent],
+      declarations: [TestHostComponent],
+      imports: [TcModalComponent, ButtonComponent, RouterTestingModule],
       providers: [NgbActiveModal],
     }).compileComponents();
 

--- a/ui/candidate-portal/src/app/shared/components/modal/tc-modal.component.ts
+++ b/ui/candidate-portal/src/app/shared/components/modal/tc-modal.component.ts
@@ -1,5 +1,8 @@
 import {Component, EventEmitter, Input, Output} from '@angular/core';
+import {CommonModule} from '@angular/common';
 import {NgbActiveModal} from "@ng-bootstrap/ng-bootstrap";
+import {ButtonComponent} from "../button/button.component";
+import {TcIconComponent} from "../icon-component/tc-icon.component";
 
 /**
  * @component TcModalComponent
@@ -90,7 +93,9 @@ import {NgbActiveModal} from "@ng-bootstrap/ng-bootstrap";
 @Component({
   selector: 'tc-modal',
   templateUrl: './tc-modal.component.html',
-  styleUrls: ['./tc-modal.component.scss']
+  styleUrls: ['./tc-modal.component.scss'],
+  standalone: true,
+  imports: [CommonModule, ButtonComponent, TcIconComponent]
 })
 export class TcModalComponent {
   /** Appears as the title of the modal (note: reason the input isn't called title is that the

--- a/ui/candidate-portal/src/app/shared/components/pagination/tc-pagination.component.spec.ts
+++ b/ui/candidate-portal/src/app/shared/components/pagination/tc-pagination.component.spec.ts
@@ -9,8 +9,7 @@ describe('TcPaginationComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [TcPaginationComponent],
-      imports: [NgbPaginationModule]
+      imports: [TcPaginationComponent, NgbPaginationModule]
     }).compileComponents();
 
     fixture = TestBed.createComponent(TcPaginationComponent);

--- a/ui/candidate-portal/src/app/shared/components/pagination/tc-pagination.component.ts
+++ b/ui/candidate-portal/src/app/shared/components/pagination/tc-pagination.component.ts
@@ -1,4 +1,6 @@
 import {Component, EventEmitter, Input, Output, ViewEncapsulation} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {NgbPaginationModule} from '@ng-bootstrap/ng-bootstrap';
 
 /**
  * @component TcPaginationComponent
@@ -38,7 +40,9 @@ import {Component, EventEmitter, Input, Output, ViewEncapsulation} from '@angula
   selector: 'tc-pagination',
   templateUrl: './tc-pagination.component.html',
   styleUrls: ['./tc-pagination.component.scss'],
-  encapsulation: ViewEncapsulation.None
+  encapsulation: ViewEncapsulation.None,
+  standalone: true,
+  imports: [CommonModule, NgbPaginationModule]
 })
 export class TcPaginationComponent {
   /** Total number of results to be paged */

--- a/ui/candidate-portal/src/app/shared/components/radio/tc-radio.component.spec.ts
+++ b/ui/candidate-portal/src/app/shared/components/radio/tc-radio.component.spec.ts
@@ -26,8 +26,7 @@ describe('TcRadioComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [TcRadioComponent],
-      imports: [FormsModule, ReactiveFormsModule]
+      imports: [TcRadioComponent, FormsModule, ReactiveFormsModule]
     }).compileComponents();
   });
 

--- a/ui/candidate-portal/src/app/shared/components/radio/tc-radio.component.ts
+++ b/ui/candidate-portal/src/app/shared/components/radio/tc-radio.component.ts
@@ -30,6 +30,7 @@ import {ControlValueAccessor, NG_VALUE_ACCESSOR} from "@angular/forms";
 @Component({
   selector: 'tc-radio',
   templateUrl: './tc-radio.component.html',
+  standalone: true,
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,

--- a/ui/candidate-portal/src/app/shared/components/table/tc-table.component.spec.ts
+++ b/ui/candidate-portal/src/app/shared/components/table/tc-table.component.spec.ts
@@ -8,7 +8,7 @@ describe('TcTableComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [TcTableComponent]
+      imports: [TcTableComponent]
     });
     fixture = TestBed.createComponent(TcTableComponent);
     component = fixture.componentInstance;

--- a/ui/candidate-portal/src/app/shared/components/table/tc-table.component.ts
+++ b/ui/candidate-portal/src/app/shared/components/table/tc-table.component.ts
@@ -1,5 +1,9 @@
 import {Component, EventEmitter, Input, Output, ViewEncapsulation} from '@angular/core';
+import {CommonModule} from '@angular/common';
 import {SearchResults} from "../../../model/search-results";
+import {AlertComponent} from "../alert/alert.component";
+import {TcLoadingComponent} from "../loading/tc-loading.component";
+import {TcPaginationComponent} from "../pagination/tc-pagination.component";
 
 /**
  * @component TcTableComponent
@@ -46,7 +50,9 @@ import {SearchResults} from "../../../model/search-results";
   // Setting to None means the tc-table scss style only applies styles to <table> elements within the tc-table component,
   // avoids styles bleeding out to the other <table> components not wrapped by <tc-table>. Also overrides any
   // existing <table> styles from bootstrap.
-  encapsulation: ViewEncapsulation.None
+  encapsulation: ViewEncapsulation.None,
+  standalone: true,
+  imports: [CommonModule, AlertComponent, TcLoadingComponent, TcPaginationComponent]
 })
 export class TcTableComponent {
   // Required inputs

--- a/ui/candidate-portal/src/app/shared/components/tabs/tab/content/tc-tab-content.component.spec.ts
+++ b/ui/candidate-portal/src/app/shared/components/tabs/tab/content/tc-tab-content.component.spec.ts
@@ -8,7 +8,7 @@ describe('TcTabContentComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [TcTabContentComponent]
+      imports: [TcTabContentComponent]
     });
     fixture = TestBed.createComponent(TcTabContentComponent);
     component = fixture.componentInstance;

--- a/ui/candidate-portal/src/app/shared/components/tabs/tab/content/tc-tab-content.component.ts
+++ b/ui/candidate-portal/src/app/shared/components/tabs/tab/content/tc-tab-content.component.ts
@@ -31,7 +31,9 @@ import {Component, TemplateRef, ViewChild} from '@angular/core';
 @Component({
   selector: 'tc-tab-content',
   templateUrl: './tc-tab-content.component.html',
-  styleUrls: ['./tc-tab-content.component.scss']
+  styleUrls: ['./tc-tab-content.component.scss'],
+  standalone: true,
+  imports: []
 })
 export class TcTabContentComponent {
   @ViewChild(TemplateRef, { static: true }) template!: TemplateRef<any>;

--- a/ui/candidate-portal/src/app/shared/components/tabs/tab/header/tc-tab-header.component.spec.ts
+++ b/ui/candidate-portal/src/app/shared/components/tabs/tab/header/tc-tab-header.component.spec.ts
@@ -8,7 +8,7 @@ describe('TcTabHeaderComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [TcTabHeaderComponent]
+      imports: [TcTabHeaderComponent]
     });
     fixture = TestBed.createComponent(TcTabHeaderComponent);
     component = fixture.componentInstance;

--- a/ui/candidate-portal/src/app/shared/components/tabs/tab/header/tc-tab-header.component.ts
+++ b/ui/candidate-portal/src/app/shared/components/tabs/tab/header/tc-tab-header.component.ts
@@ -47,7 +47,9 @@ import {Component, TemplateRef, ViewChild} from '@angular/core';
 @Component({
   selector: 'tc-tab-header',
   templateUrl: './tc-tab-header.component.html',
-  styleUrls: ['./tc-tab-header.component.scss']
+  styleUrls: ['./tc-tab-header.component.scss'],
+  standalone: true,
+  imports: []
 })
 export class TcTabHeaderComponent {
   @ViewChild(TemplateRef, { static: true }) template!: TemplateRef<any>;

--- a/ui/candidate-portal/src/app/shared/components/tabs/tab/tc-tab.component.spec.ts
+++ b/ui/candidate-portal/src/app/shared/components/tabs/tab/tc-tab.component.spec.ts
@@ -8,7 +8,7 @@ describe('TcTabComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [TcTabComponent]
+      imports: [TcTabComponent]
     });
     fixture = TestBed.createComponent(TcTabComponent);
     component = fixture.componentInstance;

--- a/ui/candidate-portal/src/app/shared/components/tabs/tab/tc-tab.component.ts
+++ b/ui/candidate-portal/src/app/shared/components/tabs/tab/tc-tab.component.ts
@@ -36,7 +36,9 @@ import {TcTabContentComponent} from "./content/tc-tab-content.component";
 @Component({
   selector: 'tc-tab',
   templateUrl: './tc-tab.component.html',
-  styleUrls: ['./tc-tab.component.scss']
+  styleUrls: ['./tc-tab.component.scss'],
+  standalone: true,
+  imports: []
 })
 export class TcTabComponent implements AfterContentInit {
   @Input() id: string;

--- a/ui/candidate-portal/src/app/shared/components/tabs/tc-tabs.component.spec.ts
+++ b/ui/candidate-portal/src/app/shared/components/tabs/tc-tabs.component.spec.ts
@@ -34,7 +34,8 @@ describe('TcTabsComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [TcTabsComponent, TcTabComponent, TcTabHeaderComponent, TcTabContentComponent, TestHostComponent],
+      declarations: [TestHostComponent],
+      imports: [TcTabsComponent, TcTabComponent, TcTabHeaderComponent, TcTabContentComponent],
     }).compileComponents();
 
     fixture = TestBed.createComponent(TestHostComponent);

--- a/ui/candidate-portal/src/app/shared/components/tabs/tc-tabs.component.ts
+++ b/ui/candidate-portal/src/app/shared/components/tabs/tc-tabs.component.ts
@@ -10,6 +10,7 @@ import {
   SimpleChanges,
   TemplateRef
 } from '@angular/core';
+import {CommonModule} from '@angular/common';
 import {TcTabComponent} from "./tab/tc-tab.component";
 
 export interface Tab {
@@ -58,7 +59,9 @@ export interface Tab {
 @Component({
   selector: 'tc-tabs',
   templateUrl: './tc-tabs.component.html',
-  styleUrls: ['./tc-tabs.component.scss']
+  styleUrls: ['./tc-tabs.component.scss'],
+  standalone: true,
+  imports: [CommonModule]
 })
 export class TcTabsComponent implements AfterContentInit, OnChanges {
   /** Optional input to set the active tab - if not provided, uses default tab or first tab */

--- a/ui/candidate-portal/src/app/shared/components/textarea/textarea.component.spec.ts
+++ b/ui/candidate-portal/src/app/shared/components/textarea/textarea.component.spec.ts
@@ -8,7 +8,7 @@ describe('TextareaComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [TextareaComponent]
+      imports: [TextareaComponent]
     });
     fixture = TestBed.createComponent(TextareaComponent);
     component = fixture.componentInstance;

--- a/ui/candidate-portal/src/app/shared/components/textarea/textarea.component.ts
+++ b/ui/candidate-portal/src/app/shared/components/textarea/textarea.component.ts
@@ -76,6 +76,7 @@ import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
   selector: 'tc-textarea',
   templateUrl: './textarea.component.html',
   styleUrls: ['./textarea.component.scss'],
+  standalone: true,
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,

--- a/ui/candidate-portal/src/app/shared/shared.module.ts
+++ b/ui/candidate-portal/src/app/shared/shared.module.ts
@@ -15,18 +15,6 @@
  */
 
 import {NgModule} from '@angular/core';
-import {CommonModule} from '@angular/common';
-import {RouterLink} from '@angular/router';
-import {FormsModule, ReactiveFormsModule} from '@angular/forms';
-
-import {
-  NgbAlert,
-  NgbDropdownModule,
-  NgbInputDatepicker,
-  NgbNavModule,
-  NgbPaginationModule,
-  NgbTypeahead
-} from '@ng-bootstrap/ng-bootstrap';
 
 import {ButtonComponent} from './components/button/button.component';
 
@@ -90,7 +78,7 @@ import {
 } from './components/date-range-picker/tc-date-range-picker.component';
 
 @NgModule({
-  declarations: [
+  imports: [
     ButtonComponent,
 
     TcTableComponent,
@@ -137,22 +125,6 @@ import {
     TcRadioComponent,
     TcDatePickerComponent,
     TcDateRangePickerComponent
-  ],
-  imports: [
-    CommonModule,
-    RouterLink,
-
-    // forms
-    ReactiveFormsModule,
-    FormsModule,
-
-    // ng-bootstrap
-    NgbPaginationModule,
-    NgbNavModule,
-    NgbAlert,
-    NgbDropdownModule,
-    NgbInputDatepicker,
-    NgbTypeahead
   ],
   exports: [
     ButtonComponent,


### PR DESCRIPTION
Converts the standard shared UI components in the admin and candidate portals to Angular standalone components.

The existing SharedModule files remain as temporary compatibility layers, importing and re-exporting the standalone components so current consumers continue to work unchanged.

- Converted all 33 shared UI components in each portal to standalone components.
- Updated the associated tests to support standalone components.