### PR TITLE
Sadat/tc 1375 verify plus translations

### DIFF
--- a/docs/ops/patches/verify-plus-1.4-translations.patch.json
+++ b/docs/ops/patches/verify-plus-1.4-translations.patch.json
@@ -1,0 +1,841 @@
+{
+  "version": 1,
+  "description": "Verify+ 1.4 localization (#3618)",
+  "languages": [
+    "en",
+    "ar",
+    "fa",
+    "ps",
+    "es",
+    "fr",
+    "tr",
+    "ru",
+    "uk",
+    "nl",
+    "pt"
+  ],
+  "entries": [
+    {
+      "key": "REGISTRATION.HEADER.TITLE.VERIFYPLUS",
+      "values": {
+        "en": "Scan your Verify+ card (optional)"
+      }
+    },
+    {
+      "key": "REGISTRATION.VERIFY_PLUS.DESCRIPTION",
+      "values": {
+        "en": "Scan your Verify+ card now to pre-fill your UNHCR registration number.",
+        "ar": "قم بمسح بطاقة Verify+ ضوئيًا الآن لملء رقم التسجيل UNHCR الخاص بك مسبقًا.",
+        "fa": "اکنون کارت Verify+ خود را اسکن کنید تا شماره ثبت نام UNHCR خود را از قبل پر کنید.",
+        "ps": "همدا اوس خپل Verify+ کارت سکین کړئ ترڅو خپل UNHCR د ثبت شمیره دمخه ډک کړئ.",
+        "es": "Escanee su tarjeta Verify+ ahora para completar previamente su número de registro UNHCR.",
+        "fr": "Scannez dès maintenant votre carte Verify+ pour pré-remplir votre numéro d'enregistrement UNHCR.",
+        "tr": "UNHCR kayıt numaranızı önceden doldurmak için Verify+ kartınızı şimdi tarayın.",
+        "ru": "Отсканируйте свою карту Verify+ сейчас, чтобы предварительно заполнить свой регистрационный номер UNHCR.",
+        "uk": "Відскануйте картку Verify+ зараз, щоб попередньо заповнити реєстраційний номер UNHCR.",
+        "nl": "Scan nu uw Verify+-kaart om uw UNHCR-registratienummer vooraf in te vullen.",
+        "pt": "Digitalize seu cartão Verify+ agora para preencher previamente seu número de registro UNHCR."
+      }
+    },
+    {
+      "key": "REGISTRATION.VERIFY_PLUS.DUPLICATE_BODY",
+      "values": {
+        "en": "We submitted your scan, but this UNHCR number already exists on another active candidate:",
+        "ar": "لقد أرسلنا الفحص الخاص بك، ولكن هذا الرقم UNHCR موجود بالفعل على مرشح نشط آخر:",
+        "fa": "ما اسکن شما را ارسال کردیم، اما این شماره UNHCR از قبل در یک نامزد فعال دیگر وجود دارد:",
+        "ps": "موږ ستاسو سکین سپارلی، مګر دا UNHCR شمیره دمخه په بل فعال نوماند کې شتون لري:",
+        "es": "Enviamos su escaneo, pero este número UNHCR ya existe en otro candidato activo:",
+        "fr": "Nous avons soumis votre scan, mais ce numéro UNHCR existe déjà sur un autre candidat actif :",
+        "tr": "Taramanızı gönderdik ancak bu UNHCR numarası başka bir aktif adayda zaten mevcut:",
+        "ru": "Мы отправили ваш скан, но этот номер UNHCR уже существует у другого активного кандидата:",
+        "uk": "Ми надіслали ваш скан, але цей номер UNHCR вже існує на іншому активному кандидаті:",
+        "nl": "We hebben uw scan ingediend, maar dit UNHCR-nummer bestaat al op een andere actieve kandidaat:",
+        "pt": "Enviamos sua digitalização, mas este número UNHCR já existe em outro candidato ativo:"
+      }
+    },
+    {
+      "key": "REGISTRATION.VERIFY_PLUS.SKIP_HINT",
+      "values": {
+        "en": "You can skip this step for now and continue registration.",
+        "ar": "يمكنك تخطي هذه الخطوة في الوقت الحالي ومتابعة التسجيل.",
+        "fa": "می توانید فعلا از این مرحله صرف نظر کرده و ثبت نام را ادامه دهید.",
+        "ps": "تاسو کولی شئ دا مرحله د اوس لپاره پریږدئ او راجسټریشن ته دوام ورکړئ.",
+        "es": "Puede omitir este paso por ahora y continuar con el registro.",
+        "fr": "Vous pouvez ignorer cette étape pour le moment et poursuivre l'inscription.",
+        "tr": "Şimdilik bu adımı atlayıp kayıt işlemine devam edebilirsiniz.",
+        "ru": "Вы можете пока пропустить этот шаг и продолжить регистрацию.",
+        "uk": "Ви можете поки що пропустити цей крок і продовжити реєстрацію.",
+        "nl": "U kunt deze stap voorlopig overslaan en doorgaan met de registratie.",
+        "pt": "Você pode pular esta etapa por enquanto e continuar o registro."
+      }
+    },
+    {
+      "key": "REGISTRATION.VERIFY_PLUS.SUCCESS_BODY",
+      "values": {
+        "en": "Your scan was submitted successfully:",
+        "ar": "تم إرسال الفحص الخاص بك بنجاح:",
+        "fa": "اسکن شما با موفقیت ارسال شد:",
+        "ps": "ستاسو سکین په بریالیتوب سره سپارل شوی:",
+        "es": "Su escaneo fue enviado exitosamente:",
+        "fr": "Votre analyse a été soumise avec succès :",
+        "tr": "Taramanız başarıyla gönderildi:",
+        "ru": "Ваш скан успешно отправлен:",
+        "uk": "Ваше сканування успішно надіслано:",
+        "nl": "Uw scan is succesvol verzonden:",
+        "pt": "Sua verificação foi enviada com sucesso:"
+      }
+    },
+    {
+      "key": "REGISTRATION.VERIFY_PLUS.SUCCESS_TITLE",
+      "values": {
+        "en": "UNHCR number captured",
+        "ar": "UNHCR الرقم الذي تم التقاطه",
+        "fa": "شماره UNHCR گرفته شد",
+        "ps": "UNHCR شمیره نیول شوې",
+        "es": "UNHCR número capturado",
+        "fr": "Numéro UNHCR capturé",
+        "tr": "UNHCR numara yakalandı",
+        "ru": "Номер UNHCR захвачен",
+        "uk": "UNHCR номер захоплено",
+        "nl": "UNHCR nummer vastgelegd",
+        "pt": "UNHCR número capturado"
+      }
+    },
+    {
+      "key": "REGISTRATION.VERIFY_PLUS.TITLE",
+      "values": {
+        "en": "UNHCR Verify+ (optional)",
+        "ar": "UNHCR Verify+ (اختياري)",
+        "fa": "UNHCR Verify+ (اختیاری)",
+        "ps": "UNHCR Verify+ (اختیاري)",
+        "es": "UNHCR Verify+ (opcional)",
+        "fr": "UNHCR Verify+ (facultatif)",
+        "tr": "UNHCR Verify+ (isteğe bağlı)",
+        "ru": "UNHCR Verify+ (необязательный)",
+        "uk": "UNHCR Verify+ (необов'язковий)",
+        "nl": "UNHCR Verify+ (optioneel)",
+        "pt": "UNHCR Verify+ (opcional)"
+      }
+    },
+    {
+      "key": "SERVICES.REFERENCE.ACCEPT_TERMS",
+      "values": {
+        "en": "Accept Terms",
+        "ar": "قبول الشروط",
+        "fa": "شرایط را بپذیرید",
+        "ps": "شرایط ومنئ",
+        "es": "Aceptar términos",
+        "fr": "Accepter les conditions",
+        "tr": "Şartları Kabul Et",
+        "ru": "Принять Условия",
+        "uk": "Прийняти умови",
+        "nl": "Accepteer voorwaarden",
+        "pt": "Aceitar os Termos"
+      }
+    },
+    {
+      "key": "SERVICES.REFERENCE.ACKNOWLEDGE_OPC_DPA",
+      "values": {
+        "en": "Acknowledge OPC DPA",
+        "ar": "شكر وتقدير OPC DPA",
+        "fa": "تصدیق OPC DPA",
+        "ps": "اعتراف OPC DPA",
+        "es": "Reconocer OPC DPA",
+        "fr": "Reconnaître OPC DPA",
+        "tr": "Teşekkür ederim OPC DPA",
+        "ru": "Подтвердить OPC DPA",
+        "uk": "Підтвердити OPC DPA",
+        "nl": "Erken OPC DPA",
+        "pt": "Reconhecer OPC DPA"
+      }
+    },
+    {
+      "key": "SERVICES.REFERENCE.ASSIGN_INTRO",
+      "values": {
+        "en": "Assign your reference voucher to start the flow.",
+        "ar": "قم بتعيين قسيمتك المرجعية لبدء التدفق.",
+        "fa": "کوپن مرجع خود را برای شروع جریان اختصاص دهید.",
+        "ps": "د جریان پیل کولو لپاره خپل د حوالې واؤچر وټاکئ.",
+        "es": "Asigna tu bono de referencia para iniciar el flujo.",
+        "fr": "Attribuez votre bon de référence pour démarrer le flux.",
+        "tr": "Akışı başlatmak için referans kuponunuzu atayın.",
+        "ru": "Назначьте свой справочный ваучер, чтобы начать поток.",
+        "uk": "Призначте свій довідковий ваучер, щоб розпочати потік.",
+        "nl": "Wijs uw referentievoucher toe om de stroom op gang te brengen.",
+        "pt": "Atribua o seu voucher de referência para iniciar o fluxo."
+      }
+    },
+    {
+      "key": "SERVICES.REFERENCE.ASSIGN_VOUCHER",
+      "values": {
+        "en": "Assign Voucher",
+        "ar": "تعيين قسيمة",
+        "fa": "کوپن اختصاص دهید",
+        "ps": "واؤچر واستوئ",
+        "es": "Asignar comprobante",
+        "fr": "Attribuer un bon",
+        "tr": "Kupon Ata",
+        "ru": "Назначить ваучер",
+        "uk": "Призначити ваучер",
+        "nl": "Voucher toewijzen",
+        "pt": "Atribuir voucher"
+      }
+    },
+    {
+      "key": "SERVICES.REFERENCE.BACK",
+      "values": {
+        "en": "Back",
+        "ar": "خلف",
+        "fa": "برگشت",
+        "ps": "شاته",
+        "es": "Atrás",
+        "fr": "Dos",
+        "tr": "Geri",
+        "ru": "Назад",
+        "uk": "Назад",
+        "nl": "Rug",
+        "pt": "Voltar"
+      }
+    },
+    {
+      "key": "SERVICES.REFERENCE.DESCRIPTION",
+      "values": {
+        "en": "Minimal CASI lifecycle test service.",
+        "ar": "الحد الأدنى من خدمة اختبار دورة الحياة CASI.",
+        "fa": "سرویس تست چرخه عمر حداقل CASI.",
+        "ps": "لږترلږه CASI د ژوند دورې ازموینې خدمت.",
+        "es": "Servicio mínimo de prueba de ciclo de vida CASI.",
+        "fr": "Service de test de cycle de vie minimal CASI.",
+        "tr": "Minimum CASI yaşam döngüsü testi hizmeti.",
+        "ru": "Минимальная услуга по тестированию жизненного цикла CASI.",
+        "uk": "Мінімальна послуга тестування життєвого циклу CASI.",
+        "nl": "Minimale CASI levenscyclustestservice.",
+        "pt": "Serviço mínimo de teste de ciclo de vida CASI."
+      }
+    },
+    {
+      "key": "SERVICES.REFERENCE.DETAIL_DESCRIPTION",
+      "values": {
+        "en": "Canonical CASI reference provider for voucher assignment.",
+        "ar": "مزود مرجعي CASI Canonical لتعيين القسيمة.",
+        "fa": "ارائه دهنده مرجع CASI متعارف برای تخصیص کوپن.",
+        "ps": "د واؤچر دندې لپاره کینونیکي CASI حواله ورکوونکی.",
+        "es": "Proveedor de referencia canónico CASI para la asignación de cupones.",
+        "fr": "Fournisseur de référence canonique CASI pour l'attribution des bons.",
+        "tr": "Kupon ataması için Canonical CASI referans sağlayıcısı.",
+        "ru": "Справочный поставщик Canonical CASI для назначения ваучеров.",
+        "uk": "Canonical CASI довідковий постачальник для призначення ваучерів.",
+        "nl": "Canonieke CASI referentieprovider voor vouchertoewijzing.",
+        "pt": "Provedor de referência canônico CASI para atribuição de vouchers."
+      }
+    },
+    {
+      "key": "SERVICES.REFERENCE.DETAIL_TITLE",
+      "values": {
+        "en": "Reference Service",
+        "ar": "الخدمة المرجعية",
+        "fa": "خدمات مرجع",
+        "ps": "د حوالې خدمت",
+        "es": "Servicio de referencia",
+        "fr": "Service de référence",
+        "tr": "Referans Hizmeti",
+        "ru": "Справочная служба",
+        "uk": "Довідкова служба",
+        "nl": "Referentiedienst",
+        "pt": "Serviço de referência"
+      }
+    },
+    {
+      "key": "SERVICES.REFERENCE.MARK_REDEEMED",
+      "values": {
+        "en": "Mark Redeemed",
+        "ar": "مارك خلاص",
+        "fa": "مارک ریدیمد",
+        "ps": "مارک خلاص شو",
+        "es": "Marca canjeada",
+        "fr": "Marque rachetée",
+        "tr": "Kullanıldı Olarak İşaretle",
+        "ru": "Марк искуплен",
+        "uk": "Марк Викуплений",
+        "nl": "Markeer verlost",
+        "pt": "Marca resgatada"
+      }
+    },
+    {
+      "key": "SERVICES.REFERENCE.NOT_ELIGIBLE",
+      "values": {
+        "en": "You are not currently eligible for this service.",
+        "ar": "أنت غير مؤهل حاليًا لهذه الخدمة.",
+        "fa": "شما در حال حاضر واجد شرایط این سرویس نیستید.",
+        "ps": "تاسو اوس مهال د دې خدمت وړ نه یاست.",
+        "es": "Actualmente no eres elegible para este servicio.",
+        "fr": "Vous n'êtes actuellement pas éligible à ce service.",
+        "tr": "Şu anda bu hizmetten yararlanmaya uygun değilsiniz.",
+        "ru": "В настоящее время вы не имеете права на эту услугу.",
+        "uk": "Зараз ви не маєте права на цю послугу.",
+        "nl": "U komt momenteel niet in aanmerking voor deze service.",
+        "pt": "No momento, você não está qualificado para este serviço."
+      }
+    },
+    {
+      "key": "SERVICES.REFERENCE.OPC_DPA_ALERT",
+      "values": {
+        "en": "Please review and acknowledge the OPC Data Processing Agreement before using this service.",
+        "ar": "يرجى مراجعة اتفاقية معالجة البيانات OPC والإقرار بها قبل استخدام هذه الخدمة.",
+        "fa": "لطفاً قبل از استفاده از این سرویس، قرارداد پردازش داده OPC را بررسی کرده و تأیید کنید.",
+        "ps": "مهرباني وکړئ د دې خدمت کارولو دمخه د OPC ډیټا پروسس کولو تړون بیاکتنه او اعتراف وکړئ.",
+        "es": "Revise y reconozca el Acuerdo de procesamiento de datos OPC antes de utilizar este servicio.",
+        "fr": "Veuillez lire et accepter l'accord de traitement des données OPC avant d'utiliser ce service.",
+        "tr": "Lütfen bu hizmeti kullanmadan önce OPC Veri İşleme Sözleşmesini inceleyin ve kabul edin.",
+        "ru": "Пожалуйста, ознакомьтесь и подтвердите Соглашение об обработке данных OPC перед использованием этой услуги.",
+        "uk": "Перед використанням цієї послуги перегляньте та підтвердьте Угоду про обробку даних OPC.",
+        "nl": "Lees en accepteer de OPC Gegevensverwerkingsovereenkomst voordat u deze service gebruikt.",
+        "pt": "Revise e confirme o Contrato de Processamento de Dados OPC antes de usar este serviço."
+      }
+    },
+    {
+      "key": "SERVICES.REFERENCE.STATUS",
+      "values": {
+        "en": "Status:",
+        "ar": "حالة:",
+        "fa": "وضعیت:",
+        "ps": "حالت:",
+        "es": "Estado:",
+        "fr": "Statut:",
+        "tr": "Durum:",
+        "ru": "Статус:",
+        "uk": "Статус:",
+        "nl": "Status:",
+        "pt": "Status:"
+      }
+    },
+    {
+      "key": "SERVICES.REFERENCE.TAG",
+      "values": {
+        "en": "Reference",
+        "ar": "مرجع",
+        "fa": "مرجع",
+        "ps": "حواله",
+        "es": "Referencia",
+        "fr": "Référence",
+        "tr": "Referans",
+        "ru": "Ссылка",
+        "uk": "довідка",
+        "nl": "Referentie",
+        "pt": "Referência"
+      }
+    },
+    {
+      "key": "SERVICES.REFERENCE.TERMS_ALERT",
+      "values": {
+        "en": "Please review and accept the latest terms before using this service.",
+        "ar": "يرجى مراجعة وقبول أحدث الشروط قبل استخدام هذه الخدمة.",
+        "fa": "لطفاً قبل از استفاده از این سرویس آخرین شرایط را بررسی کرده و بپذیرید.",
+        "ps": "مهرباني وکړئ د دې خدمت کارولو دمخه وروستي شرایط بیاکتنه او ومنئ.",
+        "es": "Revise y acepte los términos más recientes antes de utilizar este servicio.",
+        "fr": "Veuillez lire et accepter les dernières conditions avant d'utiliser ce service.",
+        "tr": "Lütfen bu hizmeti kullanmadan önce en son şartları inceleyin ve kabul edin.",
+        "ru": "Пожалуйста, просмотрите и примите последние условия перед использованием этой услуги.",
+        "uk": "Будь ласка, перегляньте та прийміть останні умови перед використанням цієї послуги.",
+        "nl": "Lees en accepteer de nieuwste voorwaarden voordat u deze service gebruikt.",
+        "pt": "Revise e aceite os termos mais recentes antes de usar este serviço."
+      }
+    },
+    {
+      "key": "SERVICES.REFERENCE.TITLE",
+      "values": {
+        "en": "Reference Service",
+        "ar": "الخدمة المرجعية",
+        "fa": "خدمات مرجع",
+        "ps": "د حوالې خدمت",
+        "es": "Servicio de referencia",
+        "fr": "Service de référence",
+        "tr": "Referans Hizmeti",
+        "ru": "Справочная служба",
+        "uk": "Довідкова служба",
+        "nl": "Referentiedienst",
+        "pt": "Serviço de referência"
+      }
+    },
+    {
+      "key": "SERVICES.REFERENCE.VOUCHER_CODE",
+      "values": {
+        "en": "Voucher code:",
+        "ar": "رمز القسيمة:",
+        "fa": "کد کوپن:",
+        "ps": "واؤچر کوډ:",
+        "es": "Código de cupón:",
+        "fr": "Code du bon :",
+        "tr": "Kupon kodu:",
+        "ru": "Код ваучера:",
+        "uk": "Код ваучера:",
+        "nl": "Vouchercode:",
+        "pt": "Código do voucher:"
+      }
+    },
+    {
+      "key": "SERVICES.UNHCR.BACK",
+      "values": {
+        "en": "Back",
+        "ar": "خلف",
+        "fa": "برگشت",
+        "ps": "شاته",
+        "es": "Atrás",
+        "fr": "Dos",
+        "tr": "Geri",
+        "ru": "Назад",
+        "uk": "Назад",
+        "nl": "Rug",
+        "pt": "Voltar"
+      }
+    },
+    {
+      "key": "SERVICES.UNHCR.DESCRIPTION",
+      "values": {
+        "en": "Country-specific refugee support resources from UNHCR.",
+        "ar": "موارد دعم اللاجئين الخاصة بكل بلد من UNHCR.",
+        "fa": "منابع حمایت از پناهندگان خاص کشور از UNHCR.",
+        "ps": "د UNHCR څخه د هیواد ځانګړي کډوال مالتړ سرچینې.",
+        "es": "Recursos de apoyo a refugiados específicos de cada país de UNHCR.",
+        "fr": "Ressources de soutien aux réfugiés spécifiques à chaque pays de UNHCR.",
+        "tr": "UNHCR'dan ülkeye özgü mülteci destek kaynakları.",
+        "ru": "Ресурсы поддержки беженцев для конкретных стран из UNHCR.",
+        "uk": "Ресурси підтримки біженців для окремих країн від UNHCR.",
+        "nl": "Landspecifieke hulpmiddelen voor vluchtelingenondersteuning uit UNHCR.",
+        "pt": "Recursos de apoio a refugiados específicos do país de UNHCR."
+      }
+    },
+    {
+      "key": "SERVICES.UNHCR.DETAIL_SUBTITLE",
+      "values": {
+        "en": "Official refugee help resources for {{countryName}}.",
+        "ar": "موارد مساعدة اللاجئين الرسمية لـ {{countryName}}.",
+        "fa": "منابع رسمی کمک به پناهندگان برای {{countryName}}.",
+        "ps": "د {{countryName}} لپاره د کډوالو رسمي مرستې سرچینې.",
+        "es": "Recursos oficiales de ayuda a refugiados para {{countryName}}.",
+        "fr": "Ressources officielles d'aide aux réfugiés pour {{countryName}}.",
+        "tr": "{{countryName}} için resmi mülteci yardım kaynakları.",
+        "ru": "Официальные ресурсы помощи беженцам для {{countryName}}.",
+        "uk": "Офіційні ресурси допомоги біженцям для {{countryName}}.",
+        "nl": "Officiële hulpbronnen voor vluchtelingen voor {{countryName}}.",
+        "pt": "Recursos oficiais de ajuda aos refugiados para {{countryName}}."
+      }
+    },
+    {
+      "key": "SERVICES.UNHCR.DETAIL_TITLE",
+      "values": {
+        "en": "UNHCR {{countryName}}",
+        "ar": "UNHCR {{countryName}}",
+        "fa": "UNHCR {{countryName}}",
+        "ps": "UNHCR {{countryName}}",
+        "es": "UNHCR {{countryName}}",
+        "fr": "UNHCR {{countryName}}",
+        "tr": "UNHCR {{countryName}}",
+        "ru": "UNHCR {{countryName}}",
+        "uk": "UNHCR {{countryName}}",
+        "nl": "UNHCR {{countryName}}",
+        "pt": "UNHCR {{countryName}}"
+      }
+    },
+    {
+      "key": "SERVICES.UNHCR.HELP_INTRO",
+      "values": {
+        "en": "Visit UNHCR Help for up-to-date guidance and support information specific to {{countryName}}.",
+        "ar": "تفضل بزيارة UNHCR مساعدة للحصول على إرشادات محدثة ومعلومات الدعم الخاصة بـ {{countryName}}.",
+        "fa": "برای راهنمایی به روز و اطلاعات پشتیبانی مخصوص {{countryName}} از راهنمای UNHCR دیدن کنید.",
+        "ps": "UNHCR ته مراجعه وکړئ د تازه لارښوونې او مالتړ معلوماتو لپاره ځانګړي {{countryName}} لپاره مرسته.",
+        "es": "Visite UNHCR Ayuda para obtener orientación actualizada e información de soporte específica para {{countryName}}.",
+        "fr": "Consultez l'aide UNHCR pour obtenir des conseils à jour et des informations d'assistance spécifiques à {{countryName}}.",
+        "tr": "{{countryName}}'ye özel güncel rehberlik ve destek bilgileri için UNHCR Yardım'ı ziyaret edin.",
+        "ru": "Посетите раздел «Справка» UNHCR для получения актуальных рекомендаций и вспомогательной информации, относящейся к {{countryName}}.",
+        "uk": "Відвідайте довідку UNHCR, щоб отримати актуальні вказівки та інформацію щодо підтримки, що стосується {{countryName}}.",
+        "nl": "Bezoek UNHCR Help voor actuele begeleiding en ondersteuningsinformatie specifiek voor {{countryName}}.",
+        "pt": "Visite a Ajuda do UNHCR para obter orientações atualizadas e informações de suporte específicas para {{countryName}}."
+      }
+    },
+    {
+      "key": "SERVICES.UNHCR.TAG",
+      "values": {
+        "en": "UNHCR",
+        "ar": "UNHCR",
+        "fa": "UNHCR",
+        "ps": "UNHCR",
+        "es": "UNHCR",
+        "fr": "UNHCR",
+        "tr": "UNHCR",
+        "ru": "UNHCR",
+        "uk": "UNHCR",
+        "nl": "UNHCR",
+        "pt": "UNHCR"
+      }
+    },
+    {
+      "key": "SERVICES.UNHCR.TITLE",
+      "values": {
+        "en": "UNHCR Help",
+        "ar": "UNHCR مساعدة",
+        "fa": "UNHCR کمک کنید",
+        "ps": "UNHCR مرسته",
+        "es": "UNHCR Ayuda",
+        "fr": "UNHCR Aide",
+        "tr": "UNHCR Yardım",
+        "ru": "UNHCR Помощь",
+        "uk": "UNHCR Довідка",
+        "nl": "UNHCR Hulp",
+        "pt": "UNHCR Ajuda"
+      }
+    },
+    {
+      "key": "SERVICES.VERIFY_PLUS.BACK",
+      "values": {
+        "en": "Back",
+        "ar": "خلف",
+        "fa": "برگشت",
+        "ps": "شاته",
+        "es": "Atrás",
+        "fr": "Dos",
+        "tr": "Geri",
+        "ru": "Назад",
+        "uk": "Назад",
+        "nl": "Rug",
+        "pt": "Voltar"
+      }
+    },
+    {
+      "key": "SERVICES.VERIFY_PLUS.CONFIRM",
+      "values": {
+        "en": "Confirm",
+        "ar": "يتأكد",
+        "fa": "تایید کنید",
+        "ps": "تایید کړه",
+        "es": "Confirmar",
+        "fr": "Confirmer",
+        "tr": "Onaylamak",
+        "ru": "Подтверждать",
+        "uk": "Підтвердити",
+        "nl": "Bevestigen",
+        "pt": "Confirmar"
+      }
+    },
+    {
+      "key": "SERVICES.VERIFY_PLUS.DESCRIPTION",
+      "values": {
+        "en": "Scan your UNHCR Verify+ QR code to capture data from your card.",
+        "ar": "قم بمسح الرمز UNHCR Verify+ QR لالتقاط البيانات من بطاقتك.",
+        "fa": "کد UNHCR Verify+ QR خود را اسکن کنید تا داده ها را از کارت خود بگیرید.",
+        "ps": "خپل UNHCR Verify+ QR کوډ سکین کړئ ترڅو له خپل کارت څخه ډیټا ترلاسه کړئ.",
+        "es": "Escanee su código UNHCR Verify+ QR para capturar datos de su tarjeta.",
+        "fr": "Scannez votre code UNHCR Verify+ QR pour capturer les données de votre carte.",
+        "tr": "Kartınızdan veri yakalamak için UNHCR Verify+ QR kodunuzu tarayın.",
+        "ru": "Отсканируйте свой код UNHCR Verify+ QR, чтобы получить данные с вашей карты.",
+        "uk": "Відскануйте свій код UNHCR Verify+ QR, щоб отримати дані з вашої картки.",
+        "nl": "Scan uw UNHCR Verify+ QR code om gegevens van uw kaart vast te leggen.",
+        "pt": "Digitalize seu código UNHCR Verify+ QR para capturar dados do seu cartão."
+      }
+    },
+    {
+      "key": "SERVICES.VERIFY_PLUS.DUPLICATE_BODY",
+      "values": {
+        "en": "We submitted your scan, but this UNHCR number already exists on another active candidate:",
+        "ar": "لقد أرسلنا الفحص الخاص بك، ولكن هذا الرقم UNHCR موجود بالفعل على مرشح نشط آخر:",
+        "fa": "ما اسکن شما را ارسال کردیم، اما این شماره UNHCR از قبل در یک نامزد فعال دیگر وجود دارد:",
+        "ps": "موږ ستاسو سکین سپارلی، مګر دا UNHCR شمیره دمخه په بل فعال نوماند کې شتون لري:",
+        "es": "Enviamos su escaneo, pero este número UNHCR ya existe en otro candidato activo:",
+        "fr": "Nous avons soumis votre scan, mais ce numéro UNHCR existe déjà sur un autre candidat actif :",
+        "tr": "Taramanızı gönderdik ancak bu UNHCR numarası başka bir aktif adayda zaten mevcut:",
+        "ru": "Мы отправили ваш скан, но этот номер UNHCR уже существует у другого активного кандидата:",
+        "uk": "Ми надіслали ваш скан, але цей номер UNHCR вже існує на іншому активному кандидаті:",
+        "nl": "We hebben uw scan ingediend, maar dit UNHCR-nummer bestaat al op een andere actieve kandidaat:",
+        "pt": "Enviamos sua digitalização, mas este número UNHCR já existe em outro candidato ativo:"
+      }
+    },
+    {
+      "key": "SERVICES.VERIFY_PLUS.DUPLICATE_RESCAN_HINT",
+      "values": {
+        "en": "You can rescan if needed.",
+        "ar": "يمكنك إعادة المسح إذا لزم الأمر.",
+        "fa": "در صورت نیاز می توانید دوباره اسکن کنید.",
+        "ps": "د اړتیا په صورت کې تاسو بیا سکین کولی شئ.",
+        "es": "Puede volver a escanear si es necesario.",
+        "fr": "Vous pouvez réanalyser si nécessaire.",
+        "tr": "Gerekirse yeniden tarayabilirsiniz.",
+        "ru": "При необходимости можно выполнить повторное сканирование.",
+        "uk": "За потреби можна повторно сканувати.",
+        "nl": "Indien nodig kunt u opnieuw scannen.",
+        "pt": "Você pode digitalizar novamente, se necessário."
+      }
+    },
+    {
+      "key": "SERVICES.VERIFY_PLUS.DUPLICATE_TITLE",
+      "values": {
+        "en": "Duplicate UNHCR number found",
+        "ar": "تم العثور على رقم UNHCR مكرر",
+        "fa": "شماره تکراری UNHCR پیدا شد",
+        "ps": "نقل UNHCR شمیره وموندل شوه",
+        "es": "Número duplicado UNHCR encontrado",
+        "fr": "Numéro UNHCR en double trouvé",
+        "tr": "Yinelenen UNHCR numarası bulundu",
+        "ru": "Обнаружен повторяющийся номер UNHCR.",
+        "uk": "Знайдено повторюваний номер UNHCR",
+        "nl": "Dubbel UNHCR nummer gevonden",
+        "pt": "Número UNHCR duplicado encontrado"
+      }
+    },
+    {
+      "key": "SERVICES.VERIFY_PLUS.RESCAN",
+      "values": {
+        "en": "Rescan",
+        "ar": "إعادة المسح",
+        "fa": "اسکن مجدد",
+        "ps": "بیا سکین",
+        "es": "Volver a escanear",
+        "fr": "Nouvelle analyse",
+        "tr": "Yeniden tara",
+        "ru": "Повторное сканирование",
+        "uk": "Повторне сканування",
+        "nl": "Opnieuw scannen",
+        "pt": "Digitalizar novamente"
+      }
+    },
+    {
+      "key": "SERVICES.VERIFY_PLUS.REVIEW_TITLE",
+      "values": {
+        "en": "Review scanned payload",
+        "ar": "مراجعة الحمولة الممسوحة ضوئيًا",
+        "fa": "محموله اسکن شده را مرور کنید",
+        "ps": "د سکین شوي تادیاتو بیاکتنه",
+        "es": "Revisar la carga útil escaneada",
+        "fr": "Examiner la charge utile numérisée",
+        "tr": "Taranan veriyi inceleyin",
+        "ru": "Просмотрите отсканированную полезную нагрузку",
+        "uk": "Перегляньте скановане корисне навантаження",
+        "nl": "Gescande lading bekijken",
+        "pt": "Revise a carga verificada"
+      }
+    },
+    {
+      "key": "SERVICES.VERIFY_PLUS.SCANNER.ENABLE_CAMERA",
+      "values": {
+        "en": "Enable camera",
+        "ar": "تمكين الكاميرا",
+        "fa": "دوربین را فعال کنید",
+        "ps": "کیمره فعاله کړئ",
+        "es": "Habilitar cámara",
+        "fr": "Activer la caméra",
+        "tr": "Kamerayı etkinleştir",
+        "ru": "Включить камеру",
+        "uk": "Увімкнути камеру",
+        "nl": "Camera inschakelen",
+        "pt": "Ativar câmera"
+      }
+    },
+    {
+      "key": "SERVICES.VERIFY_PLUS.SCANNER.NOT_DETECTED",
+      "values": {
+        "en": "A QR code has not been detected yet. Try moving closer and improving lighting.",
+        "ar": "لم يتم اكتشاف رمز QR بعد. حاول الاقتراب وتحسين الإضاءة.",
+        "fa": "کد QR هنوز شناسایی نشده است. سعی کنید نزدیک تر شوید و نور را بهبود بخشید.",
+        "ps": "A QR کوډ تراوسه ندی موندل شوی. هڅه وکړئ نږدې حرکت وکړئ او روښنايي ښه کړئ.",
+        "es": "Aún no se ha detectado un código QR. Intente acercarse y mejorar la iluminación.",
+        "fr": "Un code QR n'a pas encore été détecté. Essayez de vous rapprocher et d’améliorer l’éclairage.",
+        "tr": "Henüz QR kodu tespit edilmedi. Yaklaşmaya ve aydınlatmayı iyileştirmeye çalışın.",
+        "ru": "Код QR пока не обнаружен. Попробуйте подойти ближе и улучшить освещение.",
+        "uk": "Код QR ще не виявлено. Спробуйте підійти ближче та покращити освітлення.",
+        "nl": "Er is nog geen QR-code gedetecteerd. Probeer dichterbij te komen en de verlichting te verbeteren.",
+        "pt": "Um código QR ainda não foi detectado. Tente se aproximar e melhorar a iluminação."
+      }
+    },
+    {
+      "key": "SERVICES.VERIFY_PLUS.SCANNER.NO_CAMERA",
+      "values": {
+        "en": "No camera was detected on this device.",
+        "ar": "لم يتم اكتشاف أي كاميرا على هذا الجهاز.",
+        "fa": "هیچ دوربینی در این دستگاه شناسایی نشد.",
+        "ps": "په دې وسیله هیڅ کیمره ونه موندل شوه.",
+        "es": "No se detectó ninguna cámara en este dispositivo.",
+        "fr": "Aucune caméra n'a été détectée sur cet appareil.",
+        "tr": "Bu cihazda kamera algılanmadı.",
+        "ru": "На этом устройстве не обнаружена камера.",
+        "uk": "На цьому пристрої не виявлено жодної камери.",
+        "nl": "Er is geen camera gedetecteerd op dit apparaat.",
+        "pt": "Nenhuma câmera foi detectada neste dispositivo."
+      }
+    },
+    {
+      "key": "SERVICES.VERIFY_PLUS.SCANNER.PERMISSION_DENIED",
+      "values": {
+        "en": "Camera access was denied. Please enable camera permission and try again.",
+        "ar": "تم رفض الوصول إلى الكاميرا. يرجى تمكين إذن الكاميرا والمحاولة مرة أخرى.",
+        "fa": "دسترسی به دوربین ممنوع شد. لطفاً مجوز دوربین را فعال کنید و دوباره امتحان کنید.",
+        "ps": "کیمرې ته لاسرسی رد شو. مهرباني وکړئ د کیمرې اجازه فعاله کړئ او بیا هڅه وکړئ.",
+        "es": "Se negó el acceso a la cámara. Habilite el permiso de la cámara e inténtelo nuevamente.",
+        "fr": "L'accès à la caméra a été refusé. Veuillez activer l'autorisation de la caméra et réessayer.",
+        "tr": "Kamera erişimi reddedildi. Lütfen kamera iznini etkinleştirin ve tekrar deneyin.",
+        "ru": "Доступ к камере запрещен. Пожалуйста, включите разрешение камеры и повторите попытку.",
+        "uk": "У доступі до камери відмовлено. Увімкніть дозвіл камери та повторіть спробу.",
+        "nl": "Toegang tot de camera is geweigerd. Schakel cameratoestemming in en probeer het opnieuw.",
+        "pt": "O acesso à câmera foi negado. Ative a permissão da câmera e tente novamente."
+      }
+    },
+    {
+      "key": "SERVICES.VERIFY_PLUS.SCANNER.SCAN_AGAIN",
+      "values": {
+        "en": "Scan again",
+        "ar": "مسح مرة أخرى",
+        "fa": "دوباره اسکن کنید",
+        "ps": "بیا سکین کړئ",
+        "es": "Escanear de nuevo",
+        "fr": "Scannez à nouveau",
+        "tr": "Tekrar tarayın",
+        "ru": "Сканировать еще раз",
+        "uk": "Повторне сканування",
+        "nl": "Opnieuw scannen",
+        "pt": "Digitalize novamente"
+      }
+    },
+    {
+      "key": "SERVICES.VERIFY_PLUS.SCANNER.TRY_AGAIN",
+      "values": {
+        "en": "Try again",
+        "ar": "حاول ثانية",
+        "fa": "دوباره امتحان کنید",
+        "ps": "بیا هڅه وکړئ",
+        "es": "Intentar otra vez",
+        "fr": "Essayer à nouveau",
+        "tr": "Tekrar deneyin",
+        "ru": "Попробуйте еще раз",
+        "uk": "Спробуйте знову",
+        "nl": "Probeer het opnieuw",
+        "pt": "Tente novamente"
+      }
+    },
+    {
+      "key": "SERVICES.VERIFY_PLUS.SCANNER_ERROR",
+      "values": {
+        "en": "A camera or scanner error occurred. Please refresh and try again.",
+        "ar": "حدث خطأ في الكاميرا أو الماسح الضوئي. يرجى التحديث والمحاولة مرة أخرى.",
+        "fa": "یک خطای دوربین یا اسکنر رخ داده است. لطفاً بازخوانی کنید و دوباره امتحان کنید.",
+        "ps": "د کیمرې یا سکینر تېروتنه رامنځته شوه. مهرباني وکړئ تازه کړئ او بیا هڅه وکړئ.",
+        "es": "Se produjo un error de cámara o escáner. Actualice e inténtelo de nuevo.",
+        "fr": "Une erreur d'appareil photo ou de scanner s'est produite. Veuillez actualiser et réessayer.",
+        "tr": "Bir kamera veya tarayıcı hatası oluştu. Lütfen yenileyin ve tekrar deneyin.",
+        "ru": "Произошла ошибка камеры или сканера. Пожалуйста, обновите и повторите попытку.",
+        "uk": "Сталася помилка камери або сканера. Оновіть і повторіть спробу.",
+        "nl": "Er is een camera- of scannerfout opgetreden. Vernieuw de pagina en probeer het opnieuw.",
+        "pt": "Ocorreu um erro na câmera ou no scanner. Atualize e tente novamente."
+      }
+    },
+    {
+      "key": "SERVICES.VERIFY_PLUS.SCAN_INTRO",
+      "values": {
+        "en": "Scan your UNHCR Verify+ card QR code to capture the encoded payload.",
+        "ar": "امسح رمز UNHCR Verify+ الخاص ببطاقة QR لالتقاط الحمولة المشفرة.",
+        "fa": "کد UNHCR Verify+ کارت QR خود را اسکن کنید تا محموله رمزگذاری شده را بگیرید.",
+        "ps": "خپل UNHCR Verify+ کارت QR کوډ سکین کړئ ترڅو د کوډ شوي تادیې ترلاسه کولو لپاره.",
+        "es": "Escanee el código QR de su tarjeta UNHCR Verify+ para capturar la carga útil codificada.",
+        "fr": "Scannez le code UNHCR Verify+ de votre carte QR pour capturer la charge utile encodée.",
+        "tr": "Kodlanmış veriyi yakalamak için UNHCR Verify+ kartı QR kodunuzu tarayın.",
+        "ru": "Отсканируйте код UNHCR Verify+ карты QR, чтобы получить закодированную полезную нагрузку.",
+        "uk": "Відскануйте код своєї картки UNHCR Verify+ QR, щоб отримати закодований корисний вміст.",
+        "nl": "Scan uw UNHCR Verify+ kaart QR code om de gecodeerde lading vast te leggen.",
+        "pt": "Digitalize o código UNHCR Verify+ do cartão QR para capturar a carga útil codificada."
+      }
+    },
+    {
+      "key": "SERVICES.VERIFY_PLUS.SUBMIT_ERROR_FALLBACK",
+      "values": {
+        "en": "We couldn't submit this scan. Please check your connection and try again.",
+        "ar": "لم نتمكن من إرسال هذا الفحص. يرجى التحقق من اتصالك والمحاولة مرة أخرى.",
+        "fa": "ما نتوانستیم این اسکن را ارسال کنیم. لطفاً اتصال خود را بررسی کنید و دوباره امتحان کنید.",
+        "ps": "موږ نشو کولی دا سکین وسپاري. مهرباني وکړئ خپل پیوستون وګورئ او بیا هڅه وکړئ.",
+        "es": "No pudimos enviar este escaneo. Por favor verifique su conexión e inténtelo nuevamente.",
+        "fr": "Nous n'avons pas pu soumettre cette analyse. Veuillez vérifier votre connexion et réessayer.",
+        "tr": "Bu taramayı gönderemedik. Lütfen bağlantınızı kontrol edip tekrar deneyin.",
+        "ru": "Мы не смогли отправить это сканирование. Пожалуйста, проверьте подключение и повторите попытку.",
+        "uk": "Не вдалося надіслати цей скан. Перевірте підключення та повторіть спробу.",
+        "nl": "We konden deze scan niet verzenden. Controleer uw verbinding en probeer het opnieuw.",
+        "pt": "Não foi possível enviar esta verificação. Verifique sua conexão e tente novamente."
+      }
+    },
+    {
+      "key": "SERVICES.VERIFY_PLUS.SUBMIT_ERROR_HINT",
+      "values": {
+        "en": "If this QR code is a valid UNHCR Verify+ code, please rescan.",
+        "ar": "إذا كان رمز QR هذا رمز UNHCR Verify+ صالحًا، فيرجى إعادة المسح ضوئيًا.",
+        "fa": "اگر این کد QR یک کد UNHCR Verify+ معتبر است، لطفاً دوباره اسکن کنید.",
+        "ps": "که دا QR کوډ د اعتبار وړ UNHCR Verify+ کوډ وي، مهرباني وکړئ بیا سکین کړئ.",
+        "es": "Si este código QR es un código UNHCR Verify+ válido, vuelva a escanearlo.",
+        "fr": "Si ce code QR est un code UNHCR Verify+ valide, veuillez effectuer une nouvelle analyse.",
+        "tr": "Bu QR kodu geçerli bir UNHCR Verify+ koduysa lütfen yeniden tarayın.",
+        "ru": "Если этот код QR является действительным кодом UNHCR Verify+, повторите сканирование.",
+        "uk": "Якщо цей код QR є дійсним кодом UNHCR Verify+, повторіть сканування.",
+        "nl": "Als deze QR-code een geldige UNHCR Verify+-code is, scan dan opnieuw.",
+        "pt": "Se este código QR for um código UNHCR Verify+ válido, verifique novamente."
+      }
+    },
+    {
+      "key": "SERVICES.VERIFY_PLUS.SUCCESS_BODY",
+      "values": {
+        "en": "Your UNHCR number was captured successfully:",
+        "ar": "تم التقاط رقم UNHCR الخاص بك بنجاح:",
+        "fa": "شماره UNHCR شما با موفقیت ثبت شد:",
+        "ps": "ستاسو UNHCR شمیره په بریالیتوب سره ونیول شوه:",
+        "es": "Su número UNHCR fue capturado exitosamente:",
+        "fr": "Votre numéro UNHCR a été capturé avec succès :",
+        "tr": "UNHCR numaranız başarıyla alındı:",
+        "ru": "Ваш номер UNHCR успешно захвачен:",
+        "uk": "Ваш номер UNHCR було успішно захоплено:",
+        "nl": "Uw UNHCR-nummer is succesvol vastgelegd:",
+        "pt": "Seu número UNHCR foi capturado com sucesso:"
+      }
+    },
+    {
+      "key": "SERVICES.VERIFY_PLUS.SUCCESS_TITLE",
+      "values": {
+        "en": "Verification submitted",
+        "ar": "تم إرسال التحقق",
+        "fa": "تأیید ارسال شد",
+        "ps": "تایید سپارل شوی",
+        "es": "Verificación enviada",
+        "fr": "Vérification soumise",
+        "tr": "Doğrulama gönderildi",
+        "ru": "Подтверждение отправлено",
+        "uk": "Підтвердження надіслано",
+        "nl": "Verificatie ingediend",
+        "pt": "Verificação enviada"
+      }
+    },
+    {
+      "key": "SERVICES.VERIFY_PLUS.TAG",
+      "values": {
+        "en": "Verify+",
+        "ar": "Verify+",
+        "fa": "Verify+",
+        "ps": "Verify+",
+        "es": "Verify+",
+        "fr": "Verify+",
+        "tr": "Verify+",
+        "ru": "Verify+",
+        "uk": "Verify+",
+        "nl": "Verify+",
+        "pt": "Verify+"
+      }
+    },
+    {
+      "key": "SERVICES.VERIFY_PLUS.TITLE",
+      "values": {
+        "en": "UNHCR Verify+",
+        "ar": "UNHCR Verify+",
+        "fa": "UNHCR Verify+",
+        "ps": "UNHCR Verify+",
+        "es": "UNHCR Verify+",
+        "fr": "UNHCR Verify+",
+        "tr": "UNHCR Verify+",
+        "ru": "UNHCR Verify+",
+        "uk": "UNHCR Verify+",
+        "nl": "UNHCR Verify+",
+        "pt": "UNHCR Verify+"
+      }
+    }
+  ]
+}

--- a/docs/ops/translation_patch_import.md
+++ b/docs/ops/translation_patch_import.md
@@ -1,0 +1,106 @@
+# Translation Patch Import/Export Runbook
+
+## Purpose
+
+Use this runbook to move a scoped set of translation changes between environments without
+overwriting unrelated translation keys in each environment's language files.
+
+This process applies to both GRN and TBB instances.
+
+## Scope and Safety Rules
+
+- Import/export is **prefix/key scoped**. It never exports a full language file unless you ask
+  for every key.
+- Import uses deep merge:
+  - object nodes merge recursively
+  - leaf strings overwrite the same leaf in target
+  - keys not present in the patch remain untouched
+- Missing or `null` values in patch entries are skipped (not treated as delete).
+- Do not use `migrate-translations` for scoped translation releases; it is a broader copy tool.
+
+## Access
+
+- API endpoints and Admin UI controls are available to `SYSTEMADMIN` users only.
+- Read-only users cannot import or export patches.
+
+## Patch Format (Canonical)
+
+```json
+{
+  "version": 1,
+  "description": "Verify+ 1.4 localization (#3618)",
+  "languages": ["en", "ar", "fa", "ps", "es", "fr", "tr", "ru", "uk", "nl", "pt"],
+  "entries": [
+    {
+      "key": "SERVICES.VERIFY_PLUS.TAG",
+      "values": {
+        "en": "Verify+",
+        "ar": "Verify+"
+      }
+    }
+  ]
+}
+```
+
+## API Endpoints
+
+- Import:
+  - `POST /api/admin/translation/patch/import?dryRun=true|false&strictLanguages=true|false`
+  - Body: patch JSON
+- Export:
+  - `POST /api/admin/translation/patch/export`
+  - Body:
+    - `prefixes`: list of dotted prefixes
+    - `keys`: list of exact dotted keys
+    - `languages`: list of languages
+
+### Export Scoping
+
+Export does not detect "recently changed" keys automatically.
+You must explicitly provide:
+
+- one or more `prefixes`
+- and/or one or more exact `keys`
+- one or more `languages`
+
+## Admin UI Flow
+
+Location: `Settings -> Translations`
+
+- Import patch:
+  1. Click `Import patch`.
+  2. Select patch `.json`.
+  3. System runs dry-run import and shows summary.
+  4. Confirm apply to execute real import.
+- Export patch:
+  1. Click `Export patch`.
+  2. Enter prefixes and/or exact keys (one per line).
+  3. Select languages.
+  4. Download the generated patch file.
+
+## Release Flow (GRN -> TBB, staging -> prod)
+
+```mermaid
+flowchart LR
+  grnStaging[GRN_staging_finalize]
+  exportPatch[Export_patch]
+  tbbStaging[Import_TBB_staging]
+  prodGrn[Import_prod_GRN]
+  prodTbb[Import_prod_TBB]
+  grnStaging --> exportPatch --> tbbStaging --> prodGrn --> prodTbb
+```
+
+1. Finalize translation updates on GRN staging.
+2. Export scoped patch for the feature subtree/keys.
+3. Dry-run and import on TBB staging.
+4. At release go-live:
+   - dry-run + import on prod GRN
+   - dry-run + import on prod TBB
+5. Spot-check candidate portal translation surfaces on each host.
+
+## Verify+ 1.4 Artifact
+
+The Verify+ patch artifact is versioned at:
+
+- `docs/ops/patches/verify-plus-1.4-translations.patch.json`
+

--- a/docs/ops/translation_patch_import.md
+++ b/docs/ops/translation_patch_import.md
@@ -18,6 +18,14 @@ This process applies to both GRN and TBB instances.
 - Missing or `null` values in patch entries are skipped (not treated as delete).
 - Do not use `migrate-translations` for scoped translation releases; it is a broader copy tool.
 
+### When to Use This for Releases
+
+Use patch import/export whenever you need to promote only a feature's translation subtree between
+environments (for example Verify+, UNHCR help, and CASI reference texts).
+
+This avoids overwriting older keys that may already differ between GRN and TBB environments.
+A full-file copy is not recommended for this release path.
+
 ## Access
 
 - API endpoints and Admin UI controls are available to `SYSTEMADMIN` users only.
@@ -63,6 +71,20 @@ You must explicitly provide:
 - and/or one or more exact `keys`
 - one or more `languages`
 
+### Export Field Guidance
+
+| Field | What to provide | Example |
+| --- | --- | --- |
+| `languages` | Languages to read from and include in output patch | `en`, `ar`, `fa` |
+| `prefixes` | Dotted uppercase subtree paths; includes every leaf key under each path | `SERVICES.VERIFY_PLUS` |
+| `keys` | Exact dotted leaf paths for keys outside selected prefixes | `REGISTRATION.HEADER.TITLE.VERIFYPLUS` |
+
+Rules:
+
+- At least one of `prefixes` or `keys` is required.
+- Missing keys in a language file are omitted for that language and may appear as warnings.
+- Avoid exporting entire files; keep export scoped to the release feature.
+
 ## Admin UI Flow
 
 Location: `Settings -> Translations`
@@ -70,13 +92,29 @@ Location: `Settings -> Translations`
 - Import patch:
   1. Click `Import patch`.
   2. Select patch `.json`.
-  3. System runs dry-run import and shows summary.
-  4. Confirm apply to execute real import.
+  3. System runs dry-run import and shows an in-tab review panel.
+  4. `Confirm` applies the patch (`dryRun=false`).
+  5. `Cancel` clears the pending review without writing anything.
 - Export patch:
   1. Click `Export patch`.
   2. Enter prefixes and/or exact keys (one per line).
   3. Select languages.
   4. Download the generated patch file.
+
+### Verify+ 1.4 Export Scope Example
+
+Use the following scope to generate the Verify+ release patch:
+
+Prefixes:
+
+- `SERVICES.VERIFY_PLUS`
+- `SERVICES.UNHCR`
+- `SERVICES.REFERENCE`
+- `REGISTRATION.VERIFY_PLUS`
+
+Exact keys:
+
+- `REGISTRATION.HEADER.TITLE.VERIFYPLUS`
 
 ## Release Flow (GRN -> TBB, staging -> prod)
 

--- a/server/src/main/java/org/tctalent/server/api/admin/TranslationAdminApi.java
+++ b/server/src/main/java/org/tctalent/server/api/admin/TranslationAdminApi.java
@@ -27,6 +27,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.tctalent.server.exception.EntityExistsException;
 import org.tctalent.server.model.db.Country;
@@ -46,6 +47,8 @@ import org.tctalent.server.request.language.level.SearchLanguageLevelRequest;
 import org.tctalent.server.request.occupation.SearchOccupationRequest;
 import org.tctalent.server.request.survey.SearchSurveyTypeRequest;
 import org.tctalent.server.request.translation.CreateTranslationRequest;
+import org.tctalent.server.request.translation.ExportTranslationPatchRequest;
+import org.tctalent.server.request.translation.TranslationPatchRequest;
 import org.tctalent.server.request.translation.UpdateTranslationRequest;
 import org.tctalent.server.security.AuthService;
 import org.tctalent.server.service.db.CountryService;
@@ -165,6 +168,20 @@ public class TranslationAdminApi {
         Map<String, Object> result = new HashMap<>();
         result.put("status", "success");
         return result;
+    }
+
+    @PostMapping("patch/import")
+    public Map<String, Object> importTranslationPatch(
+        @Valid @RequestBody TranslationPatchRequest request,
+        @RequestParam(value = "dryRun", defaultValue = "false") boolean dryRun,
+        @RequestParam(value = "strictLanguages", defaultValue = "false") boolean strictLanguages) {
+        return this.translationService.importTranslationPatch(request, dryRun, strictLanguages);
+    }
+
+    @PostMapping("patch/export")
+    public Map<String, Object> exportTranslationPatch(
+        @Valid @RequestBody ExportTranslationPatchRequest request) {
+        return this.translationService.exportTranslationPatch(request);
     }
 
     private DtoBuilder translatedObjectDto() {

--- a/server/src/main/java/org/tctalent/server/configuration/SecurityConfiguration.java
+++ b/server/src/main/java/org/tctalent/server/configuration/SecurityConfiguration.java
@@ -378,6 +378,11 @@ public class SecurityConfiguration {
                 // POST: SEARCH LISTS BY IDS
                 .requestMatchers(HttpMethod.POST, "/api/admin/saved-list/search-ids").hasAnyRole( "SYSTEMADMIN", "ADMIN", "PARTNERADMIN", "SEMILIMITED", "LIMITED", "RESTRICTED")
 
+                // POST: TRANSLATION PATCH IMPORT/EXPORT (SYSTEM ADMIN ONLY)
+                .requestMatchers(HttpMethod.POST,
+                    "/api/admin/translation/patch/import",
+                    "/api/admin/translation/patch/export").hasRole("SYSTEMADMIN")
+
                 // POST: VIEW TRANSLATIONS
                 .requestMatchers(HttpMethod.POST, "/api/admin/translation/*").hasAnyRole( "SYSTEMADMIN", "ADMIN", "PARTNERADMIN", "SEMILIMITED", "LIMITED", "RESTRICTED")
 

--- a/server/src/main/java/org/tctalent/server/request/translation/ExportTranslationPatchRequest.java
+++ b/server/src/main/java/org/tctalent/server/request/translation/ExportTranslationPatchRequest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.request.translation;
+
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Request object for exporting translation patches. This class encapsulates the parameters required
+ * to specify which translations to export, including prefixes, keys, and languages.
+ *
+ * @author sadatmalik
+ */
+@Setter
+@Getter
+public class ExportTranslationPatchRequest {
+
+    private List<String> prefixes;
+    private List<String> keys;
+    private List<String> languages;
+
+}

--- a/server/src/main/java/org/tctalent/server/request/translation/TranslationPatchEntry.java
+++ b/server/src/main/java/org/tctalent/server/request/translation/TranslationPatchEntry.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.request.translation;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.util.Map;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Represents a translation patch entry, which contains a key and a map of language codes to their
+ * corresponding translation values. This class is used to facilitate the updating of translations
+ * in different languages.
+ *
+ * @author sadatmalik
+ */
+@Setter
+@Getter
+public class TranslationPatchEntry {
+
+    @NotBlank
+    private String key;
+
+    @NotNull
+    private Map<String, String> values;
+
+}

--- a/server/src/main/java/org/tctalent/server/request/translation/TranslationPatchRequest.java
+++ b/server/src/main/java/org/tctalent/server/request/translation/TranslationPatchRequest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.request.translation;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Represents a request to patch translations. This class encapsulates the version of the translation,
+ * an optional description, a list of languages to be updated, and a list of translation entries
+ * that contain the keys and their corresponding translations.
+ *
+ * @author sadatmalik
+ */
+@Setter
+@Getter
+public class TranslationPatchRequest {
+
+    @NotNull
+    private Integer version;
+
+    private String description;
+
+    private List<String> languages;
+
+    @NotNull
+    @Valid
+    private List<TranslationPatchEntry> entries;
+
+}

--- a/server/src/main/java/org/tctalent/server/service/db/TranslationService.java
+++ b/server/src/main/java/org/tctalent/server/service/db/TranslationService.java
@@ -24,11 +24,13 @@ import org.tctalent.server.model.db.Country;
 import org.tctalent.server.model.db.Translation;
 import org.tctalent.server.model.db.User;
 import org.tctalent.server.request.translation.CreateTranslationRequest;
+import org.tctalent.server.request.translation.ExportTranslationPatchRequest;
+import org.tctalent.server.request.translation.TranslationPatchRequest;
 import org.tctalent.server.request.translation.UpdateTranslationRequest;
 import org.tctalent.server.util.dto.DtoBuilder;
 
 /**
- * THere are two different ways of doing translations:
+ * There are two different ways of doing translations:
  * <ol>
  *     <li>Translations of english values stored in the database/entities. These translations are
  *     stored in the translation table/entity - see {@link Translation}</li>
@@ -138,4 +140,24 @@ public interface TranslationService {
      * @param translations Nested key/values
      */
     void updateTranslationFile(String language, Map<String, Object> translations);
+
+    /**
+     * Imports a translation patch into language translation files.
+     * <p>
+     * This merges only keys supplied in the patch and leaves all other translation keys untouched.
+     * </p>
+     * @param request Patch payload
+     * @param dryRun If true, compute and return results without writing to S3
+     * @param strictLanguages If true, fail when entries miss one of the languages listed in request
+     * @return Summary report
+     */
+    Map<String, Object> importTranslationPatch(
+        TranslationPatchRequest request, boolean dryRun, boolean strictLanguages);
+
+    /**
+     * Exports a scoped patch containing only requested prefixes and/or keys for requested languages.
+     * @param request Export request
+     * @return Patch payload
+     */
+    Map<String, Object> exportTranslationPatch(ExportTranslationPatchRequest request);
 }

--- a/server/src/main/java/org/tctalent/server/service/db/impl/TranslationPatchUtils.java
+++ b/server/src/main/java/org/tctalent/server/service/db/impl/TranslationPatchUtils.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2026 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.service.db.impl;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.TreeSet;
+import java.util.regex.Pattern;
+import lombok.NoArgsConstructor;
+import org.springframework.lang.Nullable;
+
+@NoArgsConstructor
+final class TranslationPatchUtils {
+
+    private static final Pattern VALID_KEY_PATTERN = Pattern.compile("^[A-Z0-9_\\-/]+(\\.[A-Z0-9_\\-/]+)+$");
+
+    static boolean isValidPatchKey(String key) {
+        if (key == null) {
+            return false;
+        }
+        return VALID_KEY_PATTERN.matcher(key).matches();
+    }
+
+    static Map<String, Object> deepMerge(Map<String, Object> target, Map<String, Object> patch) {
+        for (Map.Entry<String, Object> entry : patch.entrySet()) {
+            String key = entry.getKey();
+            Object patchValue = entry.getValue();
+            Object targetValue = target.get(key);
+
+            if (patchValue instanceof Map<?, ?> patchMap && targetValue instanceof Map<?, ?> targetMap) {
+                Map<String, Object> mergedChild = deepMerge(
+                    new LinkedHashMap<>((Map<String, Object>) targetMap),
+                    (Map<String, Object>) patchMap
+                );
+                target.put(key, mergedChild);
+            } else {
+                target.put(key, patchValue);
+            }
+        }
+        return target;
+    }
+
+    static Map<String, Object> nestedMapFromFlatEntries(Map<String, String> flatEntries) {
+        Map<String, Object> nested = new LinkedHashMap<>();
+
+        for (Map.Entry<String, String> entry : flatEntries.entrySet()) {
+            setNestedValue(nested, entry.getKey(), entry.getValue());
+        }
+
+        return nested;
+    }
+
+    static void setNestedValue(Map<String, Object> root, String dotPath, String value) {
+        String[] keys = dotPath.split("\\.");
+        Map<String, Object> node = root;
+        for (int i = 0; i < keys.length - 1; i++) {
+            String key = keys[i].toUpperCase(Locale.ROOT);
+            Object nextNode = node.get(key);
+            if (!(nextNode instanceof Map<?, ?>)) {
+                nextNode = new LinkedHashMap<String, Object>();
+                node.put(key, nextNode);
+            }
+            node = (Map<String, Object>) nextNode;
+        }
+        node.put(keys[keys.length - 1].toUpperCase(Locale.ROOT), value);
+    }
+
+    static void collectFlattened(
+        Map<String, Object> source,
+        String prefix,
+        Map<String, String> flattened
+    ) {
+        for (Map.Entry<String, Object> entry : source.entrySet()) {
+            String key = entry.getKey();
+            Object value = entry.getValue();
+            String path = prefix == null || prefix.isBlank() ? key : prefix + "." + key;
+            if (value instanceof Map<?, ?> child) {
+                collectFlattened((Map<String, Object>) child, path, flattened);
+            } else if (value instanceof String textValue) {
+                flattened.put(path.toUpperCase(Locale.ROOT), textValue);
+            }
+        }
+    }
+
+    static void collectFlattenedAtPrefix(
+        Map<String, Object> source,
+        String prefix,
+        Map<String, String> flattened
+    ) {
+        String normalizedPrefix = prefix.toUpperCase(Locale.ROOT);
+        String[] keys = normalizedPrefix.split("\\.");
+        Object node = source;
+        for (String key : keys) {
+            if (!(node instanceof Map<?, ?> currentMap)) {
+                return;
+            }
+            node = ((Map<String, Object>) currentMap).get(key);
+            if (node == null) {
+                return;
+            }
+        }
+
+        if (node instanceof Map<?, ?> childMap) {
+            collectFlattened((Map<String, Object>) childMap, normalizedPrefix, flattened);
+            return;
+        }
+
+        if (node instanceof String textValue) {
+            flattened.put(normalizedPrefix, textValue);
+        }
+    }
+
+    @Nullable
+    static String getFlattenedValue(Map<String, Object> source, String keyPath) {
+        String[] keys = keyPath.toUpperCase(Locale.ROOT).split("\\.");
+        Object node = source;
+        for (String key : keys) {
+            if (!(node instanceof Map<?, ?> mapNode)) {
+                return null;
+            }
+            node = ((Map<String, Object>) mapNode).get(key);
+            if (node == null) {
+                return null;
+            }
+        }
+        return node instanceof String textValue ? textValue : null;
+    }
+
+    static List<String> sortedDistinctNonBlank(List<String> values) {
+        if (values == null) {
+            return List.of();
+        }
+        TreeSet<String> normalized = new TreeSet<>();
+        for (String value : values) {
+            if (value == null) {
+                continue;
+            }
+            String trimmed = value.trim();
+            if (!trimmed.isEmpty()) {
+                normalized.add(trimmed);
+            }
+        }
+        return new ArrayList<>(normalized);
+    }
+
+    static boolean hasAnyNonNullValues(Map<String, String> valuesByLanguage) {
+        return valuesByLanguage != null && valuesByLanguage.values().stream().anyMatch(Objects::nonNull);
+    }
+}

--- a/server/src/main/java/org/tctalent/server/service/db/impl/TranslationPatchUtils.java
+++ b/server/src/main/java/org/tctalent/server/service/db/impl/TranslationPatchUtils.java
@@ -27,11 +27,28 @@ import java.util.regex.Pattern;
 import lombok.NoArgsConstructor;
 import org.springframework.lang.Nullable;
 
+/**
+ * Utility helpers used by translation patch import/export operations.
+ * <p>
+ * Supports patch key validation, conversion between flat dotted key/value structures and nested
+ * map structures, deep merge semantics for import, and scoped flattening for export.
+ * </p>
+ * <p>
+ * Import semantics are additive/overwrite only for provided paths and never delete keys that are
+ * absent from a patch.
+ * </p>
+ * This can be removed when all translations are managed and stored in database.
+ *
+ * @author sadatmalik
+ */
 @NoArgsConstructor
 final class TranslationPatchUtils {
 
     private static final Pattern VALID_KEY_PATTERN = Pattern.compile("^[A-Z0-9_\\-/]+(\\.[A-Z0-9_\\-/]+)+$");
 
+    /**
+     * Checks whether a patch key is a valid dotted uppercase path.
+     */
     static boolean isValidPatchKey(String key) {
         if (key == null) {
             return false;
@@ -39,6 +56,14 @@ final class TranslationPatchUtils {
         return VALID_KEY_PATTERN.matcher(key).matches();
     }
 
+    /**
+     * Deep-merges {@code patch} into {@code target}.
+     * <p>
+     * If both source and patch values are maps they are merged recursively; otherwise the patch
+     * value replaces the target value for that key.
+     * </p>
+     */
+    @SuppressWarnings("unchecked")
     static Map<String, Object> deepMerge(Map<String, Object> target, Map<String, Object> patch) {
         for (Map.Entry<String, Object> entry : patch.entrySet()) {
             String key = entry.getKey();
@@ -58,6 +83,9 @@ final class TranslationPatchUtils {
         return target;
     }
 
+    /**
+     * Builds a nested map tree from flat dotted key/value entries.
+     */
     static Map<String, Object> nestedMapFromFlatEntries(Map<String, String> flatEntries) {
         Map<String, Object> nested = new LinkedHashMap<>();
 
@@ -68,6 +96,11 @@ final class TranslationPatchUtils {
         return nested;
     }
 
+    /**
+     * Writes a leaf string value into a nested map using a dotted path.
+     * Intermediate maps are created as needed.
+     */
+    @SuppressWarnings("unchecked")
     static void setNestedValue(Map<String, Object> root, String dotPath, String value) {
         String[] keys = dotPath.split("\\.");
         Map<String, Object> node = root;
@@ -83,6 +116,10 @@ final class TranslationPatchUtils {
         node.put(keys[keys.length - 1].toUpperCase(Locale.ROOT), value);
     }
 
+    /**
+     * Flattens all leaf string values in the supplied nested map.
+     */
+    @SuppressWarnings("unchecked")
     static void collectFlattened(
         Map<String, Object> source,
         String prefix,
@@ -100,6 +137,10 @@ final class TranslationPatchUtils {
         }
     }
 
+    /**
+     * Flattens only the subtree under the given dotted prefix.
+     */
+    @SuppressWarnings("unchecked")
     static void collectFlattenedAtPrefix(
         Map<String, Object> source,
         String prefix,
@@ -128,6 +169,10 @@ final class TranslationPatchUtils {
         }
     }
 
+    /**
+     * Returns a leaf string value at a dotted path, or null when missing/non-string.
+     */
+    @SuppressWarnings("unchecked")
     @Nullable
     static String getFlattenedValue(Map<String, Object> source, String keyPath) {
         String[] keys = keyPath.toUpperCase(Locale.ROOT).split("\\.");
@@ -144,6 +189,9 @@ final class TranslationPatchUtils {
         return node instanceof String textValue ? textValue : null;
     }
 
+    /**
+     * Returns sorted distinct non-blank values.
+     */
     static List<String> sortedDistinctNonBlank(List<String> values) {
         if (values == null) {
             return List.of();
@@ -161,6 +209,9 @@ final class TranslationPatchUtils {
         return new ArrayList<>(normalized);
     }
 
+    /**
+     * Checks whether at least one language value is non-null.
+     */
     static boolean hasAnyNonNullValues(Map<String, String> valuesByLanguage) {
         return valuesByLanguage != null && valuesByLanguage.values().stream().anyMatch(Objects::nonNull);
     }

--- a/server/src/main/java/org/tctalent/server/service/db/impl/TranslationServiceImpl.java
+++ b/server/src/main/java/org/tctalent/server/service/db/impl/TranslationServiceImpl.java
@@ -210,7 +210,7 @@ public class TranslationServiceImpl implements TranslationService {
                 }
             }
 
-            if (!dryRun && (updatedCount > 0 || unchangedCount > 0)) {
+            if (!dryRun && updatedCount > 0) {
                 updateTranslationFile(language, merged);
             }
 
@@ -218,7 +218,7 @@ public class TranslationServiceImpl implements TranslationService {
             languageReport.put("totalKeys", flatEntries.size());
             languageReport.put("updatedKeys", updatedCount);
             languageReport.put("unchangedKeys", unchangedCount);
-            languageReport.put("wroteFile", !dryRun && (updatedCount > 0 || unchangedCount > 0));
+            languageReport.put("wroteFile", !dryRun && updatedCount > 0);
             languageReports.put(language, languageReport);
         }
 

--- a/server/src/main/java/org/tctalent/server/service/db/impl/TranslationServiceImpl.java
+++ b/server/src/main/java/org/tctalent/server/service/db/impl/TranslationServiceImpl.java
@@ -156,7 +156,12 @@ public class TranslationServiceImpl implements TranslationService {
 
         validateImportPatchRequest(request, strictLanguages);
 
-        List<String> configuredLanguages = TranslationPatchUtils.sortedDistinctNonBlank(request.getLanguages());
+        List<String> configuredLanguages = TranslationPatchUtils.sortedDistinctNonBlank(request.getLanguages()).stream()
+            .map(TranslationServiceImpl::normalizeLanguageCode)
+            .filter(Objects::nonNull)
+            .distinct()
+            .sorted()
+            .toList();
         Map<String, Map<String, String>> languageToFlatEntries = new LinkedHashMap<>();
         List<String> warnings = new ArrayList<>();
 

--- a/server/src/main/java/org/tctalent/server/service/db/impl/TranslationServiceImpl.java
+++ b/server/src/main/java/org/tctalent/server/service/db/impl/TranslationServiceImpl.java
@@ -17,7 +17,14 @@
 package org.tctalent.server.service.db.impl;
 
 import java.util.List;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.commons.collections.CollectionUtils;
@@ -27,12 +34,16 @@ import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.tctalent.server.exception.EntityExistsException;
+import org.tctalent.server.exception.InvalidRequestException;
 import org.tctalent.server.exception.NoSuchObjectException;
 import org.tctalent.server.model.db.AbstractTranslatableDomainObject;
 import org.tctalent.server.model.db.Translation;
 import org.tctalent.server.model.db.User;
 import org.tctalent.server.repository.db.TranslationRepository;
 import org.tctalent.server.request.translation.CreateTranslationRequest;
+import org.tctalent.server.request.translation.ExportTranslationPatchRequest;
+import org.tctalent.server.request.translation.TranslationPatchEntry;
+import org.tctalent.server.request.translation.TranslationPatchRequest;
 import org.tctalent.server.request.translation.UpdateTranslationRequest;
 import org.tctalent.server.security.AuthService;
 import org.tctalent.server.service.db.TranslationService;
@@ -140,6 +151,163 @@ public class TranslationServiceImpl implements TranslationService {
     }
 
     @Override
+    public Map<String, Object> importTranslationPatch(
+        TranslationPatchRequest request, boolean dryRun, boolean strictLanguages) {
+
+        validateImportPatchRequest(request, strictLanguages);
+
+        List<String> configuredLanguages = TranslationPatchUtils.sortedDistinctNonBlank(request.getLanguages());
+        Map<String, Map<String, String>> languageToFlatEntries = new LinkedHashMap<>();
+        List<String> warnings = new ArrayList<>();
+
+        for (TranslationPatchEntry entry : request.getEntries()) {
+            String key = entry.getKey().trim().toUpperCase(Locale.ROOT);
+            for (Map.Entry<String, String> languageValue : entry.getValues().entrySet()) {
+                String language = normalizeLanguageCode(languageValue.getKey());
+                String value = languageValue.getValue();
+                if (language == null || value == null) {
+                    continue;
+                }
+                languageToFlatEntries
+                    .computeIfAbsent(language, ignored -> new LinkedHashMap<>())
+                    .put(key, value);
+            }
+
+            if (!configuredLanguages.isEmpty()) {
+                Set<String> provided = entry.getValues() == null
+                    ? Set.of()
+                    : entry.getValues().entrySet().stream()
+                        .filter(v -> v.getValue() != null)
+                        .map(Map.Entry::getKey)
+                        .map(TranslationServiceImpl::normalizeLanguageCode)
+                        .filter(Objects::nonNull)
+                        .collect(Collectors.toSet());
+                for (String language : configuredLanguages) {
+                    if (!provided.contains(language)) {
+                        warnings.add("Missing value for key " + key + " language " + language);
+                    }
+                }
+            }
+        }
+
+        Map<String, Object> languageReports = new LinkedHashMap<>();
+        for (Map.Entry<String, Map<String, String>> languageEntries : languageToFlatEntries.entrySet()) {
+            String language = languageEntries.getKey();
+            Map<String, String> flatEntries = languageEntries.getValue();
+
+            Map<String, Object> current = new LinkedHashMap<>(getTranslationFile(language));
+            Map<String, Object> patch = TranslationPatchUtils.nestedMapFromFlatEntries(flatEntries);
+            Map<String, Object> merged = TranslationPatchUtils.deepMerge(new LinkedHashMap<>(current), patch);
+
+            int updatedCount = 0;
+            int unchangedCount = 0;
+            for (Map.Entry<String, String> patchEntry : flatEntries.entrySet()) {
+                String oldValue = TranslationPatchUtils.getFlattenedValue(current, patchEntry.getKey());
+                if (Objects.equals(oldValue, patchEntry.getValue())) {
+                    unchangedCount++;
+                } else {
+                    updatedCount++;
+                }
+            }
+
+            if (!dryRun && (updatedCount > 0 || unchangedCount > 0)) {
+                updateTranslationFile(language, merged);
+            }
+
+            Map<String, Object> languageReport = new LinkedHashMap<>();
+            languageReport.put("totalKeys", flatEntries.size());
+            languageReport.put("updatedKeys", updatedCount);
+            languageReport.put("unchangedKeys", unchangedCount);
+            languageReport.put("wroteFile", !dryRun && (updatedCount > 0 || unchangedCount > 0));
+            languageReports.put(language, languageReport);
+        }
+
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("status", "success");
+        result.put("version", request.getVersion());
+        result.put("description", request.getDescription());
+        result.put("dryRun", dryRun);
+        result.put("strictLanguages", strictLanguages);
+        result.put("bucket", s3TranslationStorageService.getActiveTranslationsBucket());
+        result.put("languages", languageReports);
+        result.put("warnings", warnings);
+        return result;
+    }
+
+    @Override
+    public Map<String, Object> exportTranslationPatch(ExportTranslationPatchRequest request) {
+        List<String> prefixes = TranslationPatchUtils.sortedDistinctNonBlank(request.getPrefixes()).stream()
+            .map(value -> value.toUpperCase(Locale.ROOT))
+            .toList();
+        List<String> keys = TranslationPatchUtils.sortedDistinctNonBlank(request.getKeys()).stream()
+            .map(value -> value.toUpperCase(Locale.ROOT))
+            .toList();
+        List<String> languages = TranslationPatchUtils.sortedDistinctNonBlank(request.getLanguages()).stream()
+            .map(value -> value.toLowerCase(Locale.ROOT))
+            .toList();
+
+        if (prefixes.isEmpty() && keys.isEmpty()) {
+            throw new InvalidRequestException("At least one of prefixes or keys must be supplied.");
+        }
+        if (languages.isEmpty()) {
+            throw new InvalidRequestException("At least one language must be supplied.");
+        }
+
+        List<String> warnings = new ArrayList<>();
+        Map<String, Map<String, String>> valuesByKey = new HashMap<>();
+        Set<String> discoveredKeys = new TreeSet<>();
+
+        for (String language : languages) {
+            Map<String, Object> translationFile = getTranslationFile(language);
+            Map<String, String> flattenedForLanguage = new LinkedHashMap<>();
+
+            for (String prefix : prefixes) {
+                if (!TranslationPatchUtils.isValidPatchKey(prefix + ".X")) {
+                    throw new InvalidRequestException("Invalid prefix format: " + prefix);
+                }
+                TranslationPatchUtils.collectFlattenedAtPrefix(
+                    translationFile, prefix, flattenedForLanguage);
+            }
+
+            for (String key : keys) {
+                if (!TranslationPatchUtils.isValidPatchKey(key)) {
+                    throw new InvalidRequestException("Invalid key format: " + key);
+                }
+                String value = TranslationPatchUtils.getFlattenedValue(translationFile, key);
+                if (value == null) {
+                    warnings.add("Missing key " + key + " for language " + language);
+                    continue;
+                }
+                flattenedForLanguage.put(key, value);
+            }
+
+            for (Map.Entry<String, String> valueEntry : flattenedForLanguage.entrySet()) {
+                discoveredKeys.add(valueEntry.getKey());
+                valuesByKey
+                    .computeIfAbsent(valueEntry.getKey(), ignored -> new LinkedHashMap<>())
+                    .put(language, valueEntry.getValue());
+            }
+        }
+
+        List<Map<String, Object>> entries = new ArrayList<>();
+        for (String key : discoveredKeys) {
+            Map<String, Object> entry = new LinkedHashMap<>();
+            entry.put("key", key);
+            entry.put("values", valuesByKey.getOrDefault(key, Map.of()));
+            entries.add(entry);
+        }
+
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("version", 1);
+        result.put("description", "Exported translation patch");
+        result.put("languages", languages);
+        result.put("entries", entries);
+        result.put("bucket", s3TranslationStorageService.getActiveTranslationsBucket());
+        result.put("warnings", warnings);
+        return result;
+    }
+
+    @Override
     public String translateToEnglish(String... keys) {
       // Skip S3 call in test profile
       if (!List.of(environment.getActiveProfiles()).contains("test") && englishS3Translations == null) {
@@ -166,6 +334,56 @@ public class TranslationServiceImpl implements TranslationService {
         }
 
         return value;
+    }
+
+    private static String normalizeLanguageCode(String code) {
+        if (code == null) {
+            return null;
+        }
+        String normalized = code.trim().toLowerCase(Locale.ROOT);
+        return normalized.isBlank() ? null : normalized;
+    }
+
+    private static void validateImportPatchRequest(TranslationPatchRequest request, boolean strictLanguages) {
+        if (request == null) {
+            throw new InvalidRequestException("Patch request is required.");
+        }
+        if (request.getEntries() == null || request.getEntries().isEmpty()) {
+            throw new InvalidRequestException("Patch entries are required.");
+        }
+
+        List<String> configuredLanguages = TranslationPatchUtils.sortedDistinctNonBlank(request.getLanguages())
+            .stream().map(value -> value.toLowerCase(Locale.ROOT)).toList();
+        for (TranslationPatchEntry entry : request.getEntries()) {
+            if (entry == null || entry.getKey() == null || entry.getKey().isBlank()) {
+                throw new InvalidRequestException("Patch entry key is required.");
+            }
+            String key = entry.getKey().trim().toUpperCase(Locale.ROOT);
+            if (!TranslationPatchUtils.isValidPatchKey(key)) {
+                throw new InvalidRequestException("Invalid patch key format: " + key);
+            }
+            if (entry.getValues() == null || entry.getValues().isEmpty()) {
+                throw new InvalidRequestException("Patch entry values are required for key: " + key);
+            }
+            if (!TranslationPatchUtils.hasAnyNonNullValues(entry.getValues())) {
+                throw new InvalidRequestException("Patch entry has no non-null values for key: " + key);
+            }
+
+            if (strictLanguages && !configuredLanguages.isEmpty()) {
+                Set<String> provided = entry.getValues().entrySet().stream()
+                    .filter(value -> value.getValue() != null)
+                    .map(Map.Entry::getKey)
+                    .map(TranslationServiceImpl::normalizeLanguageCode)
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toSet());
+                for (String language : configuredLanguages) {
+                    if (!provided.contains(language)) {
+                        throw new InvalidRequestException(
+                            "Missing language " + language + " for key " + key);
+                    }
+                }
+            }
+        }
     }
 
 }

--- a/server/src/main/java/org/tctalent/server/storage/S3TranslationStorageService.java
+++ b/server/src/main/java/org/tctalent/server/storage/S3TranslationStorageService.java
@@ -155,6 +155,10 @@ public class S3TranslationStorageService {
         }
     }
 
+    public String getActiveTranslationsBucket() {
+        return getTranslationsBucket();
+    }
+
     private String getTranslationsBucket() {
         String configuredTranslationsBucket = s3Properties.getTranslationsBucket();
         if (StringUtils.hasText(configuredTranslationsBucket)) {

--- a/server/src/test/java/org/tctalent/server/api/admin/TranslationAdminApiTest.java
+++ b/server/src/test/java/org/tctalent/server/api/admin/TranslationAdminApiTest.java
@@ -23,6 +23,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
@@ -45,6 +46,7 @@ import static org.tctalent.server.data.LanguageTestData.getTranslationFile;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -77,6 +79,9 @@ import org.tctalent.server.request.language.level.SearchLanguageLevelRequest;
 import org.tctalent.server.request.occupation.SearchOccupationRequest;
 import org.tctalent.server.request.survey.SearchSurveyTypeRequest;
 import org.tctalent.server.request.translation.CreateTranslationRequest;
+import org.tctalent.server.request.translation.ExportTranslationPatchRequest;
+import org.tctalent.server.request.translation.TranslationPatchEntry;
+import org.tctalent.server.request.translation.TranslationPatchRequest;
 import org.tctalent.server.request.translation.UpdateTranslationRequest;
 import org.tctalent.server.security.AuthService;
 import org.tctalent.server.service.db.CountryService;
@@ -106,6 +111,8 @@ class TranslationAdminApiTest extends ApiTestBase {
   private static final String EDUCATION_MAJOR_PATH = "/education_major";
   private static final String SURVEY_TYPE_PATH = "/survey_type";
   private static final String TRANSLATION_PATH = "/file/{language}";
+  private static final String PATCH_IMPORT_PATH = "/patch/import";
+  private static final String PATCH_EXPORT_PATH = "/patch/export";
 
   private static final Translation translation = getTranslation();
   private final Page<Country> countryPage = new PageImpl<>(
@@ -524,5 +531,67 @@ class TranslationAdminApiTest extends ApiTestBase {
             .andExpect(jsonPath("$", notNullValue()));
 
     verify(translationService).updateTranslationFile(anyString(), anyMap());
+  }
+
+  @Test
+  @DisplayName("import translation patch succeeds")
+  void importTranslationPatchSucceeds() throws Exception {
+    TranslationPatchEntry entry = new TranslationPatchEntry();
+    entry.setKey("SERVICES.VERIFY_PLUS.TAG");
+    entry.setValues(Map.of("en", "Verify+"));
+
+    TranslationPatchRequest request = new TranslationPatchRequest();
+    request.setVersion(1);
+    request.setLanguages(List.of("en"));
+    request.setEntries(List.of(entry));
+
+    given(translationService.importTranslationPatch(
+        any(TranslationPatchRequest.class), eq(true), eq(true)))
+        .willReturn(Map.of("status", "success"));
+
+    mockMvc.perform(post(BASE_PATH + PATCH_IMPORT_PATH)
+            .with(csrf())
+            .param("dryRun", "true")
+            .param("strictLanguages", "true")
+            .header("Authorization", "Bearer " + "jwt-token")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request))
+            .accept(MediaType.APPLICATION_JSON))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.status", is("success")));
+
+    verify(translationService).importTranslationPatch(
+        any(TranslationPatchRequest.class), eq(true), eq(true));
+  }
+
+  @Test
+  @DisplayName("export translation patch succeeds")
+  void exportTranslationPatchSucceeds() throws Exception {
+    ExportTranslationPatchRequest request = new ExportTranslationPatchRequest();
+    request.setLanguages(List.of("en"));
+    request.setPrefixes(List.of("SERVICES.VERIFY_PLUS"));
+    request.setKeys(List.of("REGISTRATION.HEADER.TITLE.VERIFYPLUS"));
+
+    given(translationService.exportTranslationPatch(any(ExportTranslationPatchRequest.class)))
+        .willReturn(Map.of(
+            "version", 1,
+            "languages", List.of("en"),
+            "entries", List.of()
+        ));
+
+    mockMvc.perform(post(BASE_PATH + PATCH_EXPORT_PATH)
+            .with(csrf())
+            .header("Authorization", "Bearer " + "jwt-token")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request))
+            .accept(MediaType.APPLICATION_JSON))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.version", is(1)));
+
+    verify(translationService).exportTranslationPatch(any(ExportTranslationPatchRequest.class));
   }
 }

--- a/server/src/test/java/org/tctalent/server/service/db/impl/TranslationPatchUtilsTest.java
+++ b/server/src/test/java/org/tctalent/server/service/db/impl/TranslationPatchUtilsTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2026 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.service.db.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class TranslationPatchUtilsTest {
+
+    @Test
+    void isValidPatchKey_acceptsExpectedFormat() {
+        assertTrue(TranslationPatchUtils.isValidPatchKey("SERVICES.VERIFY_PLUS.TAG"));
+        assertTrue(TranslationPatchUtils.isValidPatchKey("REGISTRATION.HEADER.TITLE.VERIFYPLUS"));
+        assertTrue(TranslationPatchUtils.isValidPatchKey("REGISTRATION.HEADER.TITLE.CONTACT/ADDITIONAL"));
+        assertFalse(TranslationPatchUtils.isValidPatchKey("services.verify_plus.tag"));
+        assertFalse(TranslationPatchUtils.isValidPatchKey("SERVICES"));
+        assertFalse(TranslationPatchUtils.isValidPatchKey("SERVICES..TAG"));
+    }
+
+    @Test
+    void deepMerge_mergesOnlyPatchPaths() {
+        Map<String, Object> source = new LinkedHashMap<>();
+        source.put("SERVICES", new LinkedHashMap<>(Map.of(
+            "VERIFY_PLUS", new LinkedHashMap<>(Map.of(
+                "TAG", "Verify+",
+                "TITLE", "UNHCR Verify+"
+            )),
+            "UNHCR", new LinkedHashMap<>(Map.of("TITLE", "UNHCR Help"))
+        )));
+
+        Map<String, Object> patch = new LinkedHashMap<>();
+        patch.put("SERVICES", new LinkedHashMap<>(Map.of(
+            "VERIFY_PLUS", new LinkedHashMap<>(Map.of("TITLE", "UNHCR Verify+ Updated"))
+        )));
+
+        Map<String, Object> merged = TranslationPatchUtils.deepMerge(new LinkedHashMap<>(source), patch);
+
+        assertEquals("Verify+",
+            TranslationPatchUtils.getFlattenedValue(merged, "SERVICES.VERIFY_PLUS.TAG"));
+        assertEquals("UNHCR Verify+ Updated",
+            TranslationPatchUtils.getFlattenedValue(merged, "SERVICES.VERIFY_PLUS.TITLE"));
+        assertEquals("UNHCR Help",
+            TranslationPatchUtils.getFlattenedValue(merged, "SERVICES.UNHCR.TITLE"));
+    }
+
+    @Test
+    void nestedMapFromFlatEntries_buildsNestedStructure() {
+        Map<String, String> flat = Map.of(
+            "SERVICES.VERIFY_PLUS.TAG", "Verify+",
+            "SERVICES.VERIFY_PLUS.TITLE", "UNHCR Verify+"
+        );
+
+        Map<String, Object> nested = TranslationPatchUtils.nestedMapFromFlatEntries(flat);
+
+        assertEquals("Verify+", TranslationPatchUtils.getFlattenedValue(nested,
+            "SERVICES.VERIFY_PLUS.TAG"));
+        assertEquals("UNHCR Verify+", TranslationPatchUtils.getFlattenedValue(nested,
+            "SERVICES.VERIFY_PLUS.TITLE"));
+    }
+
+    @Test
+    void collectFlattenedAtPrefix_collectsLeafStrings() {
+        Map<String, Object> nested = new LinkedHashMap<>();
+        TranslationPatchUtils.setNestedValue(nested, "SERVICES.VERIFY_PLUS.TAG", "Verify+");
+        TranslationPatchUtils.setNestedValue(nested, "SERVICES.VERIFY_PLUS.TITLE", "UNHCR Verify+");
+        TranslationPatchUtils.setNestedValue(nested, "SERVICES.UNHCR.TITLE", "UNHCR Help");
+
+        Map<String, String> flattened = new LinkedHashMap<>();
+        TranslationPatchUtils.collectFlattenedAtPrefix(nested, "SERVICES.VERIFY_PLUS", flattened);
+
+        assertEquals(2, flattened.size());
+        assertEquals("Verify+", flattened.get("SERVICES.VERIFY_PLUS.TAG"));
+        assertEquals("UNHCR Verify+", flattened.get("SERVICES.VERIFY_PLUS.TITLE"));
+    }
+
+    @Test
+    void getFlattenedValue_returnsNullForMissingPath() {
+        Map<String, Object> nested = new LinkedHashMap<>();
+        TranslationPatchUtils.setNestedValue(nested, "SERVICES.VERIFY_PLUS.TAG", "Verify+");
+
+        assertNull(TranslationPatchUtils.getFlattenedValue(nested,
+            "SERVICES.VERIFY_PLUS.MISSING"));
+    }
+}

--- a/server/src/test/java/org/tctalent/server/service/db/impl/TranslationPatchUtilsTest.java
+++ b/server/src/test/java/org/tctalent/server/service/db/impl/TranslationPatchUtilsTest.java
@@ -23,11 +23,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+@DisplayName("TranslationPatchUtils")
 class TranslationPatchUtilsTest {
 
     @Test
+    @DisplayName("isValidPatchKey accepts dotted uppercase keys")
     void isValidPatchKey_acceptsExpectedFormat() {
         assertTrue(TranslationPatchUtils.isValidPatchKey("SERVICES.VERIFY_PLUS.TAG"));
         assertTrue(TranslationPatchUtils.isValidPatchKey("REGISTRATION.HEADER.TITLE.VERIFYPLUS"));
@@ -38,6 +41,7 @@ class TranslationPatchUtilsTest {
     }
 
     @Test
+    @DisplayName("deepMerge overwrites patched leaves and leaves other keys")
     void deepMerge_mergesOnlyPatchPaths() {
         Map<String, Object> source = new LinkedHashMap<>();
         source.put("SERVICES", new LinkedHashMap<>(Map.of(
@@ -64,6 +68,7 @@ class TranslationPatchUtilsTest {
     }
 
     @Test
+    @DisplayName("nestedMapFromFlatEntries builds nested maps from dotted keys")
     void nestedMapFromFlatEntries_buildsNestedStructure() {
         Map<String, String> flat = Map.of(
             "SERVICES.VERIFY_PLUS.TAG", "Verify+",
@@ -79,6 +84,7 @@ class TranslationPatchUtilsTest {
     }
 
     @Test
+    @DisplayName("collectFlattenedAtPrefix collects only the requested subtree")
     void collectFlattenedAtPrefix_collectsLeafStrings() {
         Map<String, Object> nested = new LinkedHashMap<>();
         TranslationPatchUtils.setNestedValue(nested, "SERVICES.VERIFY_PLUS.TAG", "Verify+");
@@ -94,6 +100,7 @@ class TranslationPatchUtilsTest {
     }
 
     @Test
+    @DisplayName("getFlattenedValue returns null for a missing path")
     void getFlattenedValue_returnsNullForMissingPath() {
         Map<String, Object> nested = new LinkedHashMap<>();
         TranslationPatchUtils.setNestedValue(nested, "SERVICES.VERIFY_PLUS.TAG", "Verify+");

--- a/server/src/test/java/org/tctalent/server/service/db/impl/TranslationServiceImplPatchTest.java
+++ b/server/src/test/java/org/tctalent/server/service/db/impl/TranslationServiceImplPatchTest.java
@@ -30,6 +30,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -44,6 +45,7 @@ import org.tctalent.server.security.AuthService;
 import org.tctalent.server.storage.S3TranslationStorageService;
 
 @ExtendWith(MockitoExtension.class)
+@DisplayName("TranslationServiceImpl patch import and export")
 class TranslationServiceImplPatchTest {
 
     @Mock
@@ -64,6 +66,7 @@ class TranslationServiceImplPatchTest {
     }
 
     @Test
+    @DisplayName("import dry-run does not write to S3")
     void importPatch_dryRun_doesNotWriteToS3() {
         when(s3TranslationStorageService.getTranslationFile("en")).thenReturn(new LinkedHashMap<>(Map.of(
             "SERVICES", new LinkedHashMap<>(Map.of(
@@ -90,6 +93,7 @@ class TranslationServiceImplPatchTest {
     }
 
     @Test
+    @DisplayName("import apply writes the merged file to S3")
     void importPatch_apply_writesMergedFileToS3() {
         when(s3TranslationStorageService.getTranslationFile("en")).thenReturn(new LinkedHashMap<>(Map.of(
             "SERVICES", new LinkedHashMap<>(Map.of(
@@ -113,6 +117,7 @@ class TranslationServiceImplPatchTest {
     }
 
     @Test
+    @DisplayName("import strictLanguages rejects a missing language value")
     void importPatch_strictLanguages_rejectsMissingLanguageValue() {
         TranslationPatchRequest request = new TranslationPatchRequest();
         request.setVersion(1);
@@ -125,6 +130,7 @@ class TranslationServiceImplPatchTest {
     }
 
     @Test
+    @DisplayName("export returns only requested prefixes and keys")
     void exportPatch_returnsOnlyScopedKeys() {
         Map<String, Object> enFile = new LinkedHashMap<>();
         TranslationPatchUtils.setNestedValue(enFile, "SERVICES.VERIFY_PLUS.TAG", "Verify+");
@@ -157,6 +163,7 @@ class TranslationServiceImplPatchTest {
     }
 
     @Test
+    @DisplayName("export rejects an empty prefix and key scope")
     void exportPatch_rejectsEmptyScope() {
         ExportTranslationPatchRequest request = new ExportTranslationPatchRequest();
         request.setLanguages(List.of("en"));

--- a/server/src/test/java/org/tctalent/server/service/db/impl/TranslationServiceImplPatchTest.java
+++ b/server/src/test/java/org/tctalent/server/service/db/impl/TranslationServiceImplPatchTest.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2026 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.service.db.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.env.Environment;
+import org.tctalent.server.exception.InvalidRequestException;
+import org.tctalent.server.repository.db.TranslationRepository;
+import org.tctalent.server.request.translation.ExportTranslationPatchRequest;
+import org.tctalent.server.request.translation.TranslationPatchEntry;
+import org.tctalent.server.request.translation.TranslationPatchRequest;
+import org.tctalent.server.security.AuthService;
+import org.tctalent.server.storage.S3TranslationStorageService;
+
+@ExtendWith(MockitoExtension.class)
+class TranslationServiceImplPatchTest {
+
+    @Mock
+    TranslationRepository translationRepository;
+    @Mock
+    S3TranslationStorageService s3TranslationStorageService;
+    @Mock
+    Environment environment;
+    @Mock
+    AuthService authService;
+
+    TranslationServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new TranslationServiceImpl(
+            translationRepository, s3TranslationStorageService, environment, authService);
+    }
+
+    @Test
+    void importPatch_dryRun_doesNotWriteToS3() {
+        when(s3TranslationStorageService.getTranslationFile("en")).thenReturn(new LinkedHashMap<>(Map.of(
+            "SERVICES", new LinkedHashMap<>(Map.of(
+                "VERIFY_PLUS", new LinkedHashMap<>(Map.of("TITLE", "UNHCR Verify+"))
+            ))
+        )));
+        when(s3TranslationStorageService.getActiveTranslationsBucket()).thenReturn("translations.test");
+
+        TranslationPatchRequest request = new TranslationPatchRequest();
+        request.setVersion(1);
+        request.setLanguages(List.of("en"));
+        request.setEntries(List.of(entry(
+            "SERVICES.VERIFY_PLUS.TITLE", Map.of("en", "UNHCR Verify+ Updated"))));
+
+        Map<String, Object> result = service.importTranslationPatch(request, true, false);
+
+        assertEquals("success", result.get("status"));
+        assertEquals(true, result.get("dryRun"));
+        Map<?, ?> languageReport = (Map<?, ?>) ((Map<?, ?>) result.get("languages")).get("en");
+        assertEquals(1, languageReport.get("updatedKeys"));
+        assertEquals(0, languageReport.get("unchangedKeys"));
+        assertEquals(false, languageReport.get("wroteFile"));
+        verify(s3TranslationStorageService, never()).updateTranslationFile(any(), any());
+    }
+
+    @Test
+    void importPatch_apply_writesMergedFileToS3() {
+        when(s3TranslationStorageService.getTranslationFile("en")).thenReturn(new LinkedHashMap<>(Map.of(
+            "SERVICES", new LinkedHashMap<>(Map.of(
+                "VERIFY_PLUS", new LinkedHashMap<>(Map.of(
+                    "TITLE", "UNHCR Verify+",
+                    "TAG", "Verify+"
+                ))
+            ))
+        )));
+        when(s3TranslationStorageService.getActiveTranslationsBucket()).thenReturn("translations.test");
+
+        TranslationPatchRequest request = new TranslationPatchRequest();
+        request.setVersion(1);
+        request.setLanguages(List.of("en"));
+        request.setEntries(List.of(entry(
+            "SERVICES.VERIFY_PLUS.TITLE", Map.of("en", "UNHCR Verify+ Updated"))));
+
+        service.importTranslationPatch(request, false, false);
+
+        verify(s3TranslationStorageService).updateTranslationFile(eq("en"), any());
+    }
+
+    @Test
+    void importPatch_strictLanguages_rejectsMissingLanguageValue() {
+        TranslationPatchRequest request = new TranslationPatchRequest();
+        request.setVersion(1);
+        request.setLanguages(List.of("en", "ar"));
+        request.setEntries(List.of(entry(
+            "SERVICES.VERIFY_PLUS.TAG", Map.of("en", "Verify+"))));
+
+        assertThrows(InvalidRequestException.class,
+            () -> service.importTranslationPatch(request, true, true));
+    }
+
+    @Test
+    void exportPatch_returnsOnlyScopedKeys() {
+        Map<String, Object> enFile = new LinkedHashMap<>();
+        TranslationPatchUtils.setNestedValue(enFile, "SERVICES.VERIFY_PLUS.TAG", "Verify+");
+        TranslationPatchUtils.setNestedValue(enFile, "SERVICES.VERIFY_PLUS.TITLE", "UNHCR Verify+");
+        TranslationPatchUtils.setNestedValue(enFile, "SERVICES.UNHCR.TITLE", "UNHCR Help");
+
+        Map<String, Object> arFile = new LinkedHashMap<>();
+        TranslationPatchUtils.setNestedValue(arFile, "SERVICES.VERIFY_PLUS.TAG", "Verify+");
+        TranslationPatchUtils.setNestedValue(arFile, "SERVICES.VERIFY_PLUS.TITLE", "UNHCR Verify+");
+        TranslationPatchUtils.setNestedValue(arFile, "SERVICES.UNHCR.TITLE", "UNHCR مساعدة");
+
+        when(s3TranslationStorageService.getTranslationFile("en")).thenReturn(enFile);
+        when(s3TranslationStorageService.getTranslationFile("ar")).thenReturn(arFile);
+        when(s3TranslationStorageService.getActiveTranslationsBucket()).thenReturn("translations.test");
+
+        ExportTranslationPatchRequest request = new ExportTranslationPatchRequest();
+        request.setLanguages(List.of("en", "ar"));
+        request.setPrefixes(List.of("SERVICES.VERIFY_PLUS"));
+        request.setKeys(List.of("SERVICES.UNHCR.TITLE"));
+
+        Map<String, Object> exported = service.exportTranslationPatch(request);
+
+        assertEquals(1, exported.get("version"));
+        assertEquals(List.of("ar", "en"), exported.get("languages"));
+        assertNotNull(exported.get("entries"));
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> entries = (List<Map<String, Object>>) exported.get("entries");
+        assertFalse(entries.isEmpty());
+        verify(s3TranslationStorageService, never()).updateTranslationFile(any(), any());
+    }
+
+    @Test
+    void exportPatch_rejectsEmptyScope() {
+        ExportTranslationPatchRequest request = new ExportTranslationPatchRequest();
+        request.setLanguages(List.of("en"));
+
+        assertThrows(InvalidRequestException.class, () -> service.exportTranslationPatch(request));
+    }
+
+    private static TranslationPatchEntry entry(String key, Map<String, String> values) {
+        TranslationPatchEntry entry = new TranslationPatchEntry();
+        entry.setKey(key);
+        entry.setValues(values);
+        return entry;
+    }
+}

--- a/ui/admin-portal/src/app/components/settings/translations/general/general-translations.component.html
+++ b/ui/admin-portal/src/app/components/settings/translations/general/general-translations.component.html
@@ -22,11 +22,13 @@
         <tc-button id="save-translations" *ngIf="isAnAdmin() && !loggedInUser.readOnly"
                 (onClick)="save()" [disabled]="saving || error || saveError">Save</tc-button>
         <tc-button id="import-translation-patch" *ngIf="canManagePatch()"
+                   ariaLabel="Import scoped translation patch. Dry-run first, then confirm to apply."
                    [disabled]="patchBusy"
                    (onClick)="triggerImport(patchFileInput)">
           Import patch
         </tc-button>
         <tc-button id="toggle-export-translation-patch" *ngIf="canManagePatch()"
+                   ariaLabel="Export scoped translation patch by prefixes and exact keys."
                    [disabled]="patchBusy"
                    (onClick)="toggleExportForm()">
           {{showExportForm ? 'Close export' : 'Export patch'}}
@@ -35,6 +37,13 @@
                style="display: none" (change)="onPatchFileSelected($event)" />
       </div>
     </div>
+    <p *ngIf="canManagePatch()" class="text-muted small mb-3">
+      <strong>Import patch</strong> applies a scoped JSON patch to this instance using deep-merge
+      (keys outside the patch are unchanged). A dry-run summary is shown first, then
+      <strong>Confirm</strong> applies changes.
+      <strong>Export patch</strong> downloads only the prefixes and/or exact keys you specify
+      (not full language files), so release promotion can safely move just this feature's strings.
+    </p>
     <tc-alert *ngIf="patchError">
       Sorry, there was an error processing translation patch:
       <div>
@@ -129,16 +138,31 @@
                      [ngModel]="exportLanguages"
                      (ngModelChange)="exportLanguages = $event">
           </ng-select>
+          <p class="text-muted small mt-1 mb-0">
+            Choose which language files to include. Default is all system languages.
+          </p>
         </div>
         <div class="col-sm-4">
           <label>Prefixes (one per line)</label>
           <tc-textarea [(ngModel)]="exportPrefixesText"></tc-textarea>
+          <p class="text-muted small mt-1 mb-0">
+            Dotted uppercase subtree paths. Example: <code>SERVICES.VERIFY_PLUS</code>
+            includes all keys under that path.
+          </p>
         </div>
         <div class="col-sm-4">
           <label>Exact keys (one per line)</label>
           <tc-textarea [(ngModel)]="exportKeysText"></tc-textarea>
+          <p class="text-muted small mt-1 mb-0">
+            Full dotted leaf keys for values outside selected prefixes. Example:
+            <code>REGISTRATION.HEADER.TITLE.VERIFYPLUS</code>.
+          </p>
         </div>
       </div>
+      <p class="text-muted small mt-2 mb-0">
+        Provide at least one prefix or exact key. Keep export scoped to release fields only; do
+        not export full files.
+      </p>
       <div class="mt-2">
         <tc-button id="export-translation-patch"
                    [disabled]="patchBusy"

--- a/ui/admin-portal/src/app/components/settings/translations/general/general-translations.component.html
+++ b/ui/admin-portal/src/app/components/settings/translations/general/general-translations.component.html
@@ -18,9 +18,133 @@
 <div *ngIf="!loading" class="main container">
     <div class="header">
       <h4>General Translations</h4>
-      <div>
+      <div class="d-flex gap-2 header-actions">
         <tc-button id="save-translations" *ngIf="isAnAdmin() && !loggedInUser.readOnly"
                 (onClick)="save()" [disabled]="saving || error || saveError">Save</tc-button>
+        <tc-button id="import-translation-patch" *ngIf="canManagePatch()"
+                   [disabled]="patchBusy"
+                   (onClick)="triggerImport(patchFileInput)">
+          Import patch
+        </tc-button>
+        <tc-button id="toggle-export-translation-patch" *ngIf="canManagePatch()"
+                   [disabled]="patchBusy"
+                   (onClick)="toggleExportForm()">
+          {{showExportForm ? 'Close export' : 'Export patch'}}
+        </tc-button>
+        <input #patchFileInput type="file" accept=".json,application/json"
+               style="display: none" (change)="onPatchFileSelected($event)" />
+      </div>
+    </div>
+    <tc-alert *ngIf="patchError">
+      Sorry, there was an error processing translation patch:
+      <div>
+        {{patchError | json}}
+      </div>
+    </tc-alert>
+    <tc-alert *ngIf="patchAppliedSummary">
+      Translation patch applied.
+    </tc-alert>
+    <div *ngIf="canManagePatch() && patchAppliedSummary" class="border p-3 mb-3">
+      <h5>Applied summary</h5>
+      <p class="mb-2" *ngIf="patchAppliedSummary.description">{{ patchAppliedSummary.description }}</p>
+      <p class="mb-2" *ngIf="patchAppliedSummary.bucket">Bucket: {{ patchAppliedSummary.bucket }}</p>
+      <table class="table table-sm mb-2">
+        <thead>
+        <tr>
+          <th>Language</th>
+          <th>Total</th>
+          <th>Updated</th>
+          <th>Unchanged</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr *ngFor="let row of getPatchLanguageRows(patchAppliedSummary)">
+          <td>{{ row.language }}</td>
+          <td>{{ row.totalKeys }}</td>
+          <td>{{ row.updatedKeys }}</td>
+          <td>{{ row.unchangedKeys }}</td>
+        </tr>
+        </tbody>
+      </table>
+      <div *ngIf="hasPatchWarnings(patchAppliedSummary)">
+        <strong>Warnings</strong>
+        <ul class="mb-0">
+          <li *ngFor="let warning of patchAppliedSummary.warnings">{{ warning }}</li>
+        </ul>
+      </div>
+    </div>
+    <div *ngIf="canManagePatch() && patchReview" class="border p-3 mb-3">
+      <h5>Review translation patch (not applied yet)</h5>
+      <p class="mb-2" *ngIf="patchReview.description">{{ patchReview.description }}</p>
+      <p class="mb-2" *ngIf="patchReview.bucket">Bucket: {{ patchReview.bucket }}</p>
+      <table class="table table-sm mb-2">
+        <thead>
+        <tr>
+          <th>Language</th>
+          <th>Total</th>
+          <th>Updated</th>
+          <th>Unchanged</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr *ngFor="let row of getPatchLanguageRows(patchReview)">
+          <td>{{ row.language }}</td>
+          <td>{{ row.totalKeys }}</td>
+          <td>{{ row.updatedKeys }}</td>
+          <td>{{ row.unchangedKeys }}</td>
+        </tr>
+        </tbody>
+      </table>
+      <div *ngIf="hasPatchWarnings(patchReview)" class="mb-2">
+        <strong>Warnings</strong>
+        <ul class="mb-0">
+          <li *ngFor="let warning of patchReview.warnings">{{ warning }}</li>
+        </ul>
+      </div>
+      <p class="mb-2" *ngIf="!hasPatchWarnings(patchReview)">No warnings.</p>
+      <div class="d-flex justify-content-end gap-2">
+        <tc-button id="confirm-translation-patch"
+                   [disabled]="patchBusy"
+                   (onClick)="confirmPatchImport()">
+          Confirm
+        </tc-button>
+        <tc-button id="cancel-translation-patch"
+                   [disabled]="patchBusy"
+                   (onClick)="cancelPatchImport()">
+          Cancel
+        </tc-button>
+      </div>
+    </div>
+    <div *ngIf="canManagePatch() && showExportForm" class="border p-3 mb-3">
+      <h5>Export patch</h5>
+      <div class="row">
+        <div class="col-sm-4">
+          <label>Languages</label>
+          <ng-select class="tc-select"
+                     [items]="languages"
+                     bindLabel="label"
+                     bindValue="language"
+                     [multiple]="true"
+                     [closeOnSelect]="false"
+                     [ngModel]="exportLanguages"
+                     (ngModelChange)="exportLanguages = $event">
+          </ng-select>
+        </div>
+        <div class="col-sm-4">
+          <label>Prefixes (one per line)</label>
+          <tc-textarea [(ngModel)]="exportPrefixesText"></tc-textarea>
+        </div>
+        <div class="col-sm-4">
+          <label>Exact keys (one per line)</label>
+          <tc-textarea [(ngModel)]="exportKeysText"></tc-textarea>
+        </div>
+      </div>
+      <div class="mt-2">
+        <tc-button id="export-translation-patch"
+                   [disabled]="patchBusy"
+                   (onClick)="exportPatch()">
+          Download patch
+        </tc-button>
       </div>
     </div>
     <tc-alert *ngIf="saveError">

--- a/ui/admin-portal/src/app/components/settings/translations/general/general-translations.component.scss
+++ b/ui/admin-portal/src/app/components/settings/translations/general/general-translations.component.scss
@@ -21,6 +21,13 @@
 .header {
   display: flex;
   justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.header-actions {
+  margin-bottom: 0.5rem;
 }
 
 .filter {

--- a/ui/admin-portal/src/app/components/settings/translations/general/general-translations.component.spec.ts
+++ b/ui/admin-portal/src/app/components/settings/translations/general/general-translations.component.spec.ts
@@ -204,6 +204,37 @@ describe('GeneralTranslationsComponent', () => {
     });
   });
 
+  it('should trigger hidden import input click and clear applied summary', () => {
+    const fileInput = document.createElement('input');
+    const clickSpy = spyOn(fileInput, 'click');
+    component.patchAppliedSummary = {status: 'success'};
+
+    component.triggerImport(fileInput);
+
+    expect(clickSpy).toHaveBeenCalled();
+    expect(component.patchAppliedSummary).toBeNull();
+  });
+
+  it('should not trigger import input click when patch is busy', () => {
+    const fileInput = document.createElement('input');
+    const clickSpy = spyOn(fileInput, 'click');
+    component.patchBusy = true;
+
+    component.triggerImport(fileInput);
+
+    expect(clickSpy).not.toHaveBeenCalled();
+  });
+
+  it('should not trigger import input click for non-system admins', () => {
+    const fileInput = document.createElement('input');
+    const clickSpy = spyOn(fileInput, 'click');
+    authService.isSystemAdminOnly.and.returnValue(false);
+
+    component.triggerImport(fileInput);
+
+    expect(clickSpy).not.toHaveBeenCalled();
+  });
+
   it('should apply spacing class on header action buttons', () => {
     fixture.detectChanges();
     const headerActions = fixture.debugElement.query(By.css('.header > div.d-flex.gap-2'));
@@ -225,6 +256,14 @@ describe('GeneralTranslationsComponent', () => {
     expect(component.patchReview).toEqual(dryRunSummary);
     expect(component.pendingPatch).toEqual({version: 1, entries: []});
     expect(component.patchAppliedSummary).toBeFalsy();
+  });
+
+  it('should handle dry-run import error', () => {
+    translationService.importPatch.and.returnValue(throwError('dry-run error'));
+    component.startPatchDryRun({version: 1, entries: []});
+
+    expect(component.patchBusy).toBeFalse();
+    expect(component.patchError).toBe('dry-run error');
   });
 
   it('should run dry-run then apply import patch when confirmed', () => {
@@ -254,6 +293,26 @@ describe('GeneralTranslationsComponent', () => {
     expect(component.patchAppliedSummary).toEqual(applySummary);
   });
 
+  it('should not call apply import when no pending patch', () => {
+    component.pendingPatch = null;
+
+    component.confirmPatchImport();
+
+    expect(translationService.importPatch.calls.count()).toBe(0);
+  });
+
+  it('should handle apply import error', () => {
+    component.pendingPatch = {version: 1, entries: []};
+    component.patchReview = {languages: {}};
+    translationService.importPatch.and.returnValue(throwError('apply error'));
+
+    component.confirmPatchImport();
+
+    expect(component.patchBusy).toBeFalse();
+    expect(component.patchError).toBe('apply error');
+    expect(component.pendingPatch).toEqual({version: 1, entries: []});
+  });
+
   it('should clear review and not apply when canceling import', () => {
     const dryRunSummary = {
       languages: {
@@ -270,5 +329,123 @@ describe('GeneralTranslationsComponent', () => {
     expect(component.patchReview).toBeNull();
     expect(component.pendingPatch).toBeNull();
     expect(component.patchAppliedSummary).toBeFalsy();
+  });
+
+  it('should ignore file selection when no files are provided', () => {
+    const startDryRunSpy = spyOn(component, 'startPatchDryRun');
+    const event = {
+      target: { files: [] }
+    } as unknown as Event;
+
+    component.onPatchFileSelected(event);
+
+    expect(startDryRunSpy).not.toHaveBeenCalled();
+  });
+
+  it('should parse selected patch file and start dry-run', () => {
+    const startDryRunSpy = spyOn(component, 'startPatchDryRun');
+    const readerMock = {
+      result: '{"version":1,"entries":[]}',
+      onload: null as any,
+      onerror: null as any,
+      readAsText: function() {
+        this.onload();
+      }
+    };
+    spyOn(window as any, 'FileReader').and.returnValue(readerMock as unknown as FileReader);
+    const file = new File(['{"version":1}'], 'patch.json', {type: 'application/json'});
+    const input = document.createElement('input');
+    Object.defineProperty(input, 'files', { value: [file] });
+
+    component.onPatchFileSelected({ target: input } as unknown as Event);
+
+    expect(startDryRunSpy).toHaveBeenCalledWith({version: 1, entries: []});
+  });
+
+  it('should set patchError when selected patch file is invalid JSON', () => {
+    const readerMock = {
+      result: 'not-json',
+      onload: null as any,
+      onerror: null as any,
+      readAsText: function() {
+        this.onload();
+      }
+    };
+    spyOn(window as any, 'FileReader').and.returnValue(readerMock as unknown as FileReader);
+    const file = new File(['not-json'], 'patch.json', {type: 'application/json'});
+    const input = document.createElement('input');
+    Object.defineProperty(input, 'files', { value: [file] });
+
+    component.onPatchFileSelected({ target: input } as unknown as Event);
+
+    expect(component.patchError).toBeTruthy();
+  });
+
+  it('should toggle export form and initialize languages when empty', () => {
+    component.showExportForm = false;
+    component.exportLanguages = [];
+    component.languages = [{id:1, language: 'en', label: 'English', rtl:false} as SystemLanguage];
+
+    component.toggleExportForm();
+
+    expect(component.showExportForm).toBeTrue();
+    expect(component.exportLanguages).toEqual(['en']);
+  });
+
+  it('should set export error when no prefixes or keys are provided', () => {
+    component.exportPrefixesText = '';
+    component.exportKeysText = '';
+    component.exportLanguages = ['en'];
+
+    component.exportPatch();
+
+    expect(component.patchError).toBe('Specify at least one prefix or key before export.');
+    expect(translationService.exportPatch).not.toHaveBeenCalled();
+  });
+
+  it('should set export error when no languages are provided', () => {
+    component.exportPrefixesText = 'SERVICES.VERIFY_PLUS';
+    component.exportKeysText = '';
+    component.exportLanguages = [];
+
+    component.exportPatch();
+
+    expect(component.patchError).toBe('Select at least one language before export.');
+    expect(translationService.exportPatch).not.toHaveBeenCalled();
+  });
+
+  it('should handle export patch request errors', () => {
+    component.exportPrefixesText = 'SERVICES.VERIFY_PLUS';
+    component.exportLanguages = ['en'];
+    translationService.exportPatch.and.returnValue(throwError('export error'));
+
+    component.exportPatch();
+
+    expect(component.patchBusy).toBeFalse();
+    expect(component.patchError).toBe('export error');
+  });
+
+  it('should download exported patch file', () => {
+    component.exportPrefixesText = 'SERVICES.VERIFY_PLUS';
+    component.exportLanguages = ['en'];
+    translationService.exportPatch.and.returnValue(of({version: 1, entries: []}));
+    const createSpy = spyOn(window.URL, 'createObjectURL').and.returnValue('blob:test');
+    const revokeSpy = spyOn(window.URL, 'revokeObjectURL');
+    const clickSpy = jasmine.createSpy('click');
+    spyOn(document, 'createElement').and.returnValue({
+      click: clickSpy
+    } as unknown as HTMLAnchorElement);
+
+    component.exportPatch();
+
+    expect(createSpy).toHaveBeenCalled();
+    expect(clickSpy).toHaveBeenCalled();
+    expect(revokeSpy).toHaveBeenCalledWith('blob:test');
+  });
+
+  it('should return language rows and warning state helpers', () => {
+    expect(component.getPatchLanguageRows(null)).toEqual([]);
+    expect(component.hasPatchWarnings({warnings: []})).toBeFalse();
+    expect(component.hasPatchWarnings({warnings: ['warning']})).toBeTrue();
   });
 });

--- a/ui/admin-portal/src/app/components/settings/translations/general/general-translations.component.spec.ts
+++ b/ui/admin-portal/src/app/components/settings/translations/general/general-translations.component.spec.ts
@@ -35,9 +35,14 @@ describe('GeneralTranslationsComponent', () => {
   const systemLanguage: SystemLanguage = {id:1, language: 'fr', label: 'French',rtl:false };
 
   beforeEach(async () => {
-    const translationSpy = jasmine.createSpyObj('TranslationService', ['loadTranslationsFile', 'updateTranslationFile']);
+    const translationSpy = jasmine.createSpyObj('TranslationService', [
+      'loadTranslationsFile',
+      'updateTranslationFile',
+      'importPatch',
+      'exportPatch'
+    ]);
     const languageSpy = jasmine.createSpyObj('LanguageService', ['listSystemLanguages']);
-    const authSpy = jasmine.createSpyObj('AuthorizationService', ['isAnAdmin']);
+    const authSpy = jasmine.createSpyObj('AuthorizationService', ['isAnAdmin', 'isSystemAdminOnly']);
 
     await TestBed.configureTestingModule({
       imports: [FormsModule,ReactiveFormsModule,NgSelectModule,HttpClientTestingModule],
@@ -58,6 +63,7 @@ describe('GeneralTranslationsComponent', () => {
     languageService.listSystemLanguages.and.returnValue(of([systemLanguage]));
     translationService.loadTranslationsFile.and.returnValue(of({}));
     authService.isAnAdmin.and.returnValue(true);
+    authService.isSystemAdminOnly.and.returnValue(true);
     component.loggedInUser = new MockUser();
     fixture.detectChanges();
   });
@@ -138,6 +144,12 @@ describe('GeneralTranslationsComponent', () => {
     expect(saveButton).toBeTruthy();
   });
 
+  it('should display import and export controls for system admins', () => {
+    fixture.detectChanges();
+    expect(fixture.debugElement.query(By.css('tc-button#import-translation-patch'))).toBeTruthy();
+    expect(fixture.debugElement.query(By.css('tc-button#toggle-export-translation-patch'))).toBeTruthy();
+  });
+
   it('should disable save button if saving or errors exist', () => {
     let saveButton = fixture.debugElement.query(By.css('tc-button#save-translations'));
 
@@ -161,5 +173,102 @@ describe('GeneralTranslationsComponent', () => {
     fixture.detectChanges();
     const saveButton = fixture.debugElement.query(By.css('button.btn-success'));
     expect(saveButton).toBeFalsy();
+  });
+
+  it('should hide import and export controls for non-system admins', () => {
+    authService.isSystemAdminOnly.and.returnValue(false);
+    fixture.detectChanges();
+    expect(fixture.debugElement.query(By.css('tc-button#import-translation-patch'))).toBeFalsy();
+    expect(fixture.debugElement.query(By.css('tc-button#toggle-export-translation-patch'))).toBeFalsy();
+  });
+
+  it('should hide import and export controls for read-only users', () => {
+    component.loggedInUser.readOnly = true;
+    fixture.detectChanges();
+    expect(fixture.debugElement.query(By.css('tc-button#import-translation-patch'))).toBeFalsy();
+    expect(fixture.debugElement.query(By.css('tc-button#toggle-export-translation-patch'))).toBeFalsy();
+  });
+
+  it('should call export patch with parsed prefixes and keys', () => {
+    component.exportPrefixesText = 'SERVICES.VERIFY_PLUS\nSERVICES.UNHCR';
+    component.exportKeysText = 'REGISTRATION.HEADER.TITLE.VERIFYPLUS';
+    component.exportLanguages = ['en', 'ar'];
+    translationService.exportPatch.and.returnValue(of({version: 1, entries: []}));
+
+    component.exportPatch();
+
+    expect(translationService.exportPatch).toHaveBeenCalledWith({
+      prefixes: ['SERVICES.VERIFY_PLUS', 'SERVICES.UNHCR'],
+      keys: ['REGISTRATION.HEADER.TITLE.VERIFYPLUS'],
+      languages: ['en', 'ar']
+    });
+  });
+
+  it('should apply spacing class on header action buttons', () => {
+    fixture.detectChanges();
+    const headerActions = fixture.debugElement.query(By.css('.header > div.d-flex.gap-2'));
+    expect(headerActions).toBeTruthy();
+  });
+
+  it('should show dry-run review in tab after patch import selection', () => {
+    const dryRunSummary = {
+      languages: {
+        en: {totalKeys: 1, updatedKeys: 1, unchangedKeys: 0}
+      },
+      warnings: []
+    };
+    translationService.importPatch.and.returnValue(of(dryRunSummary));
+
+    component.startPatchDryRun({version: 1, entries: []});
+
+    expect(translationService.importPatch).toHaveBeenCalledWith({version: 1, entries: []}, true, false);
+    expect(component.patchReview).toEqual(dryRunSummary);
+    expect(component.pendingPatch).toEqual({version: 1, entries: []});
+    expect(component.patchAppliedSummary).toBeFalsy();
+  });
+
+  it('should run dry-run then apply import patch when confirmed', () => {
+    const dryRunSummary = {
+      languages: {
+        en: {totalKeys: 1, updatedKeys: 1, unchangedKeys: 0}
+      },
+      warnings: []
+    };
+    const applySummary = {
+      languages: {
+        en: {totalKeys: 1, updatedKeys: 1, unchangedKeys: 0}
+      },
+      warnings: []
+    };
+    translationService.importPatch.and.returnValues(of(dryRunSummary), of(applySummary));
+    const refreshSpy = spyOn(component, 'setLanguage').and.callThrough();
+
+    component.startPatchDryRun({version: 1, entries: []});
+    component.confirmPatchImport();
+
+    expect(translationService.importPatch).toHaveBeenCalledWith({version: 1, entries: []}, true, false);
+    expect(translationService.importPatch).toHaveBeenCalledWith({version: 1, entries: []}, false, false);
+    expect(refreshSpy).toHaveBeenCalledWith(systemLanguage);
+    expect(component.patchReview).toBeNull();
+    expect(component.pendingPatch).toBeNull();
+    expect(component.patchAppliedSummary).toEqual(applySummary);
+  });
+
+  it('should clear review and not apply when canceling import', () => {
+    const dryRunSummary = {
+      languages: {
+        en: {totalKeys: 1, updatedKeys: 0, unchangedKeys: 1}
+      },
+      warnings: ['Warning one']
+    };
+    translationService.importPatch.and.returnValue(of(dryRunSummary));
+    component.startPatchDryRun({version: 1, entries: []});
+
+    component.cancelPatchImport();
+
+    expect(translationService.importPatch.calls.count()).toBe(1);
+    expect(component.patchReview).toBeNull();
+    expect(component.pendingPatch).toBeNull();
+    expect(component.patchAppliedSummary).toBeFalsy();
   });
 });

--- a/ui/admin-portal/src/app/components/settings/translations/general/general-translations.component.ts
+++ b/ui/admin-portal/src/app/components/settings/translations/general/general-translations.component.ts
@@ -67,6 +67,16 @@ export class GeneralTranslationsComponent implements OnInit {
   saving: boolean;
   saveError: any;
   error: any;
+  patchBusy: boolean;
+  patchError: any;
+  patchReview: any;
+  patchAppliedSummary: any;
+  pendingPatch: any;
+  patchFileInput: HTMLInputElement;
+  exportPrefixesText: string;
+  exportKeysText: string;
+  exportLanguages: string[];
+  showExportForm: boolean;
 
   constructor(private translationService: TranslationService,
               private languageService: LanguageService,
@@ -86,6 +96,7 @@ export class GeneralTranslationsComponent implements OnInit {
     this.languageService.listSystemLanguages().subscribe(
       (result) => {
         this.languages = result;
+        this.exportLanguages = this.languages.map(language => language.language);
         this.loading = false;
         this.setLanguage(this.languages[0]);
       },
@@ -166,12 +177,184 @@ export class GeneralTranslationsComponent implements OnInit {
     return this.authService.isAnAdmin();
   }
 
+  canManagePatch(): boolean {
+    return this.authService.isSystemAdminOnly() && !this.loggedInUser?.readOnly;
+  }
+
   filterItems($event) {
     if ($event != null) {
       this.fieldsFiltered = this.fields.filter(f => f.path.split('.')[0] === $event.toLowerCase())
     } else {
       this.fieldsFiltered = this.fields;
     }
+  }
+
+  triggerImport(fileInput: HTMLInputElement) {
+    if (!this.canManagePatch() || this.patchBusy) {
+      return;
+    }
+    this.patchAppliedSummary = null;
+    fileInput.click();
+  }
+
+  onPatchFileSelected(event: Event) {
+    const input = event.target as HTMLInputElement;
+    if (!input.files || input.files.length === 0) {
+      return;
+    }
+
+    const file = input.files[0];
+    this.patchFileInput = input;
+    const reader = new FileReader();
+    reader.onload = () => {
+      try {
+        const patch = JSON.parse(String(reader.result));
+        this.startPatchDryRun(patch);
+      } catch (error) {
+        this.patchError = error;
+      }
+    };
+    reader.onerror = (error) => this.patchError = error;
+    reader.readAsText(file);
+  }
+
+  startPatchDryRun(patch) {
+    this.patchBusy = true;
+    this.patchError = null;
+    this.patchReview = null;
+    this.pendingPatch = null;
+    this.patchAppliedSummary = null;
+
+    this.translationService.importPatch(patch, true, false).subscribe(
+      (summary: any) => {
+        this.patchBusy = false;
+        this.pendingPatch = patch;
+        this.patchReview = summary;
+      },
+      (error) => {
+        this.patchBusy = false;
+        this.patchError = error;
+        this.clearPatchFileInput();
+      }
+    );
+  }
+
+  toggleExportForm() {
+    this.patchError = null;
+    this.patchAppliedSummary = null;
+    this.showExportForm = !this.showExportForm;
+    if (this.showExportForm && (!this.exportLanguages || this.exportLanguages.length === 0)) {
+      this.exportLanguages = this.languages.map(language => language.language);
+    }
+  }
+
+  exportPatch() {
+    this.patchAppliedSummary = null;
+    const prefixes = this.parseLines(this.exportPrefixesText);
+    const keys = this.parseLines(this.exportKeysText);
+
+    if (prefixes.length === 0 && keys.length === 0) {
+      this.patchError = 'Specify at least one prefix or key before export.';
+      return;
+    }
+
+    if (!this.exportLanguages || this.exportLanguages.length === 0) {
+      this.patchError = 'Select at least one language before export.';
+      return;
+    }
+
+    this.patchBusy = true;
+    this.patchError = null;
+    this.translationService.exportPatch({
+      prefixes,
+      keys,
+      languages: this.exportLanguages
+    }).subscribe(
+      (patch) => {
+        this.patchBusy = false;
+        this.downloadPatchFile(patch);
+      },
+      (error) => {
+        this.patchBusy = false;
+        this.patchError = error;
+      }
+    );
+  }
+
+  confirmPatchImport() {
+    if (!this.pendingPatch) {
+      return;
+    }
+    this.patchBusy = true;
+    this.patchError = null;
+    this.translationService.importPatch(this.pendingPatch, false, false).subscribe(
+      (appliedSummary: any) => {
+        this.patchAppliedSummary = appliedSummary;
+        this.patchReview = null;
+        this.pendingPatch = null;
+        this.patchBusy = false;
+        this.clearPatchFileInput();
+        if (this.systemLanguage) {
+          this.setLanguage(this.systemLanguage);
+        }
+      },
+      (error) => {
+        this.patchBusy = false;
+        this.patchError = error;
+      }
+    );
+  }
+
+  cancelPatchImport() {
+    this.patchReview = null;
+    this.pendingPatch = null;
+    this.patchBusy = false;
+    this.clearPatchFileInput();
+  }
+
+  getPatchLanguageRows(summary: any): any[] {
+    if (!summary?.languages) {
+      return [];
+    }
+    return Object.entries(summary.languages).map(([language, counts]: [string, any]) => ({
+      language,
+      totalKeys: counts?.totalKeys ?? 0,
+      updatedKeys: counts?.updatedKeys ?? 0,
+      unchangedKeys: counts?.unchangedKeys ?? 0,
+    }));
+  }
+
+  hasPatchWarnings(summary: any): boolean {
+    return !!summary?.warnings?.length;
+  }
+
+  private clearPatchFileInput() {
+    if (this.patchFileInput) {
+      this.patchFileInput.value = '';
+    }
+  }
+
+  private parseLines(input: string): string[] {
+    if (!input) {
+      return [];
+    }
+    return Array.from(new Set(
+      input
+        .split('\n')
+        .map(line => line.trim())
+        .filter(line => line.length > 0)
+    ));
+  }
+
+  private downloadPatchFile(patch) {
+    const output = JSON.stringify(patch, null, 2);
+    const blob = new Blob([output], {type: 'application/json'});
+    const downloadUrl = window.URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = downloadUrl;
+    link.download = `translation-patch-${new Date().toISOString()}.json`;
+    link.click();
+    window.URL.revokeObjectURL(downloadUrl);
   }
 }
 
@@ -383,6 +566,14 @@ const ALL_FIELDS = {
         "NEXT": null,
         "SUBMIT": null,
         "UPDATE": null
+      },
+      "VERIFY_PLUS": {
+        "TITLE": null,
+        "DESCRIPTION": null,
+        "SUCCESS_TITLE": null,
+        "SUCCESS_BODY": null,
+        "DUPLICATE_BODY": null,
+        "SKIP_HINT": null
       },
       "CONTACT": {
         "LABEL": {
@@ -814,6 +1005,59 @@ const ALL_FIELDS = {
         'REPORT_DESCRIPTION': null,
         'REPORT_COMMENT_PLACEHOLDER': null,
       }
+    },
+    'VERIFY_PLUS': {
+      'TAG': null,
+      'TITLE': null,
+      'DESCRIPTION': null,
+      'SCAN_INTRO': null,
+      'SCANNER_ERROR': null,
+      'REVIEW_TITLE': null,
+      'SUBMIT_ERROR_FALLBACK': null,
+      'SUBMIT_ERROR_HINT': null,
+      'RESCAN': null,
+      'CONFIRM': null,
+      'SUCCESS_TITLE': null,
+      'SUCCESS_BODY': null,
+      'DUPLICATE_TITLE': null,
+      'DUPLICATE_BODY': null,
+      'DUPLICATE_RESCAN_HINT': null,
+      'BACK': null,
+      'SCANNER': {
+        'ENABLE_CAMERA': null,
+        'SCAN_AGAIN': null,
+        'PERMISSION_DENIED': null,
+        'TRY_AGAIN': null,
+        'NO_CAMERA': null,
+        'NOT_DETECTED': null
+      }
+    },
+    'UNHCR': {
+      'TAG': null,
+      'TITLE': null,
+      'DESCRIPTION': null,
+      'DETAIL_TITLE': null,
+      'DETAIL_SUBTITLE': null,
+      'HELP_INTRO': null,
+      'BACK': null
+    },
+    'REFERENCE': {
+      'TAG': null,
+      'TITLE': null,
+      'DESCRIPTION': null,
+      'DETAIL_TITLE': null,
+      'DETAIL_DESCRIPTION': null,
+      'OPC_DPA_ALERT': null,
+      'ACKNOWLEDGE_OPC_DPA': null,
+      'TERMS_ALERT': null,
+      'ACCEPT_TERMS': null,
+      'ASSIGN_INTRO': null,
+      'ASSIGN_VOUCHER': null,
+      'VOUCHER_CODE': null,
+      'STATUS': null,
+      'MARK_REDEEMED': null,
+      'NOT_ELIGIBLE': null,
+      'BACK': null
     }
   },
   "TASKS": {

--- a/ui/admin-portal/src/app/components/settings/translations/general/general-translations.component.ts
+++ b/ui/admin-portal/src/app/components/settings/translations/general/general-translations.component.ts
@@ -212,9 +212,17 @@ export class GeneralTranslationsComponent implements OnInit {
         this.startPatchDryRun(patch);
       } catch (error) {
         this.patchError = error;
+        this.patchReview = null;
+        this.pendingPatch = null;
+        this.clearPatchFileInput();
       }
     };
-    reader.onerror = (error) => this.patchError = error;
+    reader.onerror = (error) => {
+      this.patchError = error;
+      this.patchReview = null;
+      this.pendingPatch = null;
+      this.clearPatchFileInput();
+    };
     reader.readAsText(file);
   }
 

--- a/ui/admin-portal/src/app/components/settings/translations/general/general-translations.component.ts
+++ b/ui/admin-portal/src/app/components/settings/translations/general/general-translations.component.ts
@@ -360,7 +360,8 @@ export class GeneralTranslationsComponent implements OnInit {
     const downloadUrl = window.URL.createObjectURL(blob);
     const link = document.createElement('a');
     link.href = downloadUrl;
-    link.download = `translation-patch-${new Date().toISOString()}.json`;
+    const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+    link.download = `translation-patch-${timestamp}.json`;
     link.click();
     window.URL.revokeObjectURL(downloadUrl);
   }

--- a/ui/admin-portal/src/app/services/translation.service.spec.ts
+++ b/ui/admin-portal/src/app/services/translation.service.spec.ts
@@ -130,4 +130,34 @@ describe('TranslationService', () => {
     req.flush(null);
   });
 
+  it('should import translation patch via POST', () => {
+    const patch = { version: 1, entries: [] };
+
+    service.importPatch(patch, true, false).subscribe((response) => {
+      expect(response).toEqual({ status: 'success' });
+    });
+
+    const req = httpMock.expectOne(`${apiUrl}/patch/import?dryRun=true&strictLanguages=false`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual(patch);
+    req.flush({ status: 'success' });
+  });
+
+  it('should export translation patch via POST', () => {
+    const request = {
+      prefixes: ['SERVICES.VERIFY_PLUS'],
+      keys: ['REGISTRATION.HEADER.TITLE.VERIFYPLUS'],
+      languages: ['en', 'ar']
+    };
+
+    service.exportPatch(request).subscribe((response) => {
+      expect(response).toEqual({ version: 1, entries: [] });
+    });
+
+    const req = httpMock.expectOne(`${apiUrl}/patch/export`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual(request);
+    req.flush({ version: 1, entries: [] });
+  });
+
 });

--- a/ui/admin-portal/src/app/services/translation.service.ts
+++ b/ui/admin-portal/src/app/services/translation.service.ts
@@ -55,4 +55,15 @@ export class TranslationService {
     return this.http.put(`${this.apiUrl}/file/${language}`, translations);
   }
 
+  importPatch(patch, dryRun: boolean = false, strictLanguages: boolean = false) {
+    return this.http.post(
+      `${this.apiUrl}/patch/import?dryRun=${dryRun}&strictLanguages=${strictLanguages}`,
+      patch
+    );
+  }
+
+  exportPatch(request) {
+    return this.http.post(`${this.apiUrl}/patch/export`, request);
+  }
+
 }

--- a/ui/candidate-portal/src/app/components/common/verify-plus-scanner/verify-plus-scanner.component.html
+++ b/ui/candidate-portal/src/app/components/common/verify-plus-scanner/verify-plus-scanner.component.html
@@ -17,21 +17,21 @@
 <div class="verify-plus-scanner">
   <div class="scanner-actions" *ngIf="!scanning && cameraPermission !== false && hasDevices !== false && !(hasScanned && hideScanAgain)">
     <tc-button [type]="'outline'" (onClick)="startScanning()">
-      {{ hasScanned ? 'Scan again' : 'Enable camera' }}
+      {{ hasScanned ? ('SERVICES.VERIFY_PLUS.SCANNER.SCAN_AGAIN' | translate) : ('SERVICES.VERIFY_PLUS.SCANNER.ENABLE_CAMERA' | translate) }}
     </tc-button>
   </div>
 
   <div class="scanner-actions" *ngIf="cameraPermission === false && hasDevices !== false">
     <p class="scanner-message scanner-message-error">
-    Camera access was denied. Please enable camera permission and try again.
+      {{ 'SERVICES.VERIFY_PLUS.SCANNER.PERMISSION_DENIED' | translate }}
     </p>
     <tc-button [type]="'outline'" (onClick)="startScanning()">
-      Try again
+      {{ 'SERVICES.VERIFY_PLUS.SCANNER.TRY_AGAIN' | translate }}
     </tc-button>
   </div>
 
   <p class="scanner-message scanner-message-error" *ngIf="hasDevices === false">
-    No camera was detected on this device.
+    {{ 'SERVICES.VERIFY_PLUS.SCANNER.NO_CAMERA' | translate }}
   </p>
 
   <div class="camera-preview" [hidden]="!(scanning && hasDevices !== false)">
@@ -40,6 +40,6 @@
   </div>
 
   <p class="scanner-message" *ngIf="scanning && invalidScan && cameraPermission !== false && hasDevices !== false">
-    A QR code has not been detected yet. Try moving closer and improving lighting.
+    {{ 'SERVICES.VERIFY_PLUS.SCANNER.NOT_DETECTED' | translate }}
   </p>
 </div>

--- a/ui/candidate-portal/src/app/components/common/verify-plus-scanner/verify-plus-scanner.component.spec.ts
+++ b/ui/candidate-portal/src/app/components/common/verify-plus-scanner/verify-plus-scanner.component.spec.ts
@@ -22,10 +22,17 @@ import {
   TestBed,
   tick
 } from '@angular/core/testing';
-import {NO_ERRORS_SCHEMA} from '@angular/core';
+import {NO_ERRORS_SCHEMA, Pipe, PipeTransform} from '@angular/core';
 
 import {VerifyPlusScannerComponent} from './verify-plus-scanner.component';
 import {VerifyPlusDecoderService} from '../../../services/verify-plus-decoder.service';
+
+@Pipe({name: 'translate'})
+class MockTranslatePipe implements PipeTransform {
+  transform(value: string): string {
+    return value;
+  }
+}
 
 describe('VerifyPlusScannerComponent', () => {
   let component: VerifyPlusScannerComponent;
@@ -58,7 +65,7 @@ describe('VerifyPlusScannerComponent', () => {
     });
 
     TestBed.configureTestingModule({
-      declarations: [VerifyPlusScannerComponent],
+      declarations: [VerifyPlusScannerComponent, MockTranslatePipe],
       providers: [
         {provide: VerifyPlusDecoderService, useValue: decoderService}
       ],

--- a/ui/candidate-portal/src/app/components/profile/view/tab/services/reference/reference.component.html
+++ b/ui/candidate-portal/src/app/components/profile/view/tab/services/reference/reference.component.html
@@ -4,8 +4,8 @@
 <div class="service-title">
   <div class="header">
     <div>
-      <h2>Reference Service</h2>
-      <p>Canonical CASI reference provider for voucher assignment.</p>
+      <h2>{{ 'SERVICES.REFERENCE.DETAIL_TITLE' | translate }}</h2>
+      <p>{{ 'SERVICES.REFERENCE.DETAIL_DESCRIPTION' | translate }}</p>
     </div>
     <img src="assets/images/services/opcLogo.svg" alt="Reference service (placeholder)"/>
   </div>
@@ -16,7 +16,7 @@
     <ng-container *ngIf="needsOpcDpa && opcDpaTermsInfo">
       <div *ngIf="!opcDpaTermsRead" class="d-flex justify-content-center text-center">
         <div class="alert alert-danger">
-          Please review and acknowledge the OPC Data Processing Agreement before using this service.
+          {{ 'SERVICES.REFERENCE.OPC_DPA_ALERT' | translate }}
         </div>
       </div>
 
@@ -28,14 +28,14 @@
       </app-show-terms>
 
       <tc-button color="success" [disabled]="!opcDpaTermsRead" (onClick)="acceptOpcDpa()">
-        Acknowledge OPC DPA
+        {{ 'SERVICES.REFERENCE.ACKNOWLEDGE_OPC_DPA' | translate }}
       </tc-button>
     </ng-container>
 
     <ng-container *ngIf="!needsOpcDpa && needsAgreement && termsInfo">
       <div *ngIf="!termsRead" class="d-flex justify-content-center text-center">
         <div class="alert alert-danger">
-          Please review and accept the latest terms before using this service.
+          {{ 'SERVICES.REFERENCE.TERMS_ALERT' | translate }}
         </div>
       </div>
 
@@ -47,23 +47,23 @@
       </app-show-terms>
 
       <tc-button color="success" [disabled]="!termsRead" (onClick)="acceptTerms()">
-        Accept Terms
+        {{ 'SERVICES.REFERENCE.ACCEPT_TERMS' | translate }}
       </tc-button>
     </ng-container>
 
     <ng-container *ngIf="!needsOpcDpa && !needsAgreement">
       <ng-container *ngIf="!assignment">
-        <p>Assign your reference voucher to start the flow.</p>
-        <tc-button [size]="'xl'" (onClick)="assign()">Assign Voucher</tc-button>
+        <p>{{ 'SERVICES.REFERENCE.ASSIGN_INTRO' | translate }}</p>
+        <tc-button [size]="'xl'" (onClick)="assign()">{{ 'SERVICES.REFERENCE.ASSIGN_VOUCHER' | translate }}</tc-button>
       </ng-container>
 
       <ng-container *ngIf="assignment">
         <p>
-          Voucher code:
+          {{ 'SERVICES.REFERENCE.VOUCHER_CODE' | translate }}
           <code>{{ assignment.resource.resourceCode }}</code>
         </p>
         <p>
-          Status:
+          {{ 'SERVICES.REFERENCE.STATUS' | translate }}
           <strong>{{ assignment.resource.status }}</strong>
         </p>
 
@@ -71,20 +71,20 @@
                    [size]="'xl'"
                    (onClick)="redeem()"
         >
-          Mark Redeemed
+          {{ 'SERVICES.REFERENCE.MARK_REDEEMED' | translate }}
         </tc-button>
       </ng-container>
     </ng-container>
   </ng-container>
 
   <ng-template #notEligible>
-    <p>You are not currently eligible for this service.</p>
+    <p>{{ 'SERVICES.REFERENCE.NOT_ELIGIBLE' | translate }}</p>
   </ng-template>
 
   <div class="mt-5">
     <tc-button [type]="'outline'" (onClick)="onBackButtonClicked()">
       <i class="me-1 fas fa-arrow-left"></i>
-      Back
+      {{ 'SERVICES.REFERENCE.BACK' | translate }}
     </tc-button>
   </div>
 </div>

--- a/ui/candidate-portal/src/app/components/profile/view/tab/services/reference/reference.component.spec.ts
+++ b/ui/candidate-portal/src/app/components/profile/view/tab/services/reference/reference.component.spec.ts
@@ -1,9 +1,16 @@
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {of, throwError} from 'rxjs';
-import {NO_ERRORS_SCHEMA} from "@angular/core";
+import {NO_ERRORS_SCHEMA, Pipe, PipeTransform} from "@angular/core";
 import {ReferenceComponent} from './reference.component';
 import {CasiPortalService} from "../../../../../../services/casi-portal.service";
 import {ResourceStatus} from "../../../../../../model/services";
+
+@Pipe({name: 'translate'})
+class MockTranslatePipe implements PipeTransform {
+  transform(value: string): string {
+    return value;
+  }
+}
 
 describe('ReferenceComponent', () => {
   let component: ReferenceComponent;
@@ -29,7 +36,7 @@ describe('ReferenceComponent', () => {
     mockPortalService.updateResourceStatus.and.returnValue(of(void 0));
 
     await TestBed.configureTestingModule({
-      declarations: [ReferenceComponent],
+      declarations: [ReferenceComponent, MockTranslatePipe],
       providers: [{provide: CasiPortalService, useValue: mockPortalService}],
       schemas: [NO_ERRORS_SCHEMA]
     }).compileComponents();

--- a/ui/candidate-portal/src/app/components/profile/view/tab/services/services.component.html
+++ b/ui/candidate-portal/src/app/components/profile/view/tab/services/services.component.html
@@ -96,13 +96,13 @@
     >
       <div>
         <span class="service-tag">
-          Reference
+          {{ 'SERVICES.REFERENCE.TAG' | translate }}
         </span>
         <h3>
-          Reference Service
+          {{ 'SERVICES.REFERENCE.TITLE' | translate }}
         </h3>
         <p>
-          Minimal CASI lifecycle test service.
+          {{ 'SERVICES.REFERENCE.DESCRIPTION' | translate }}
         </p>
       </div>
       <img src="assets/images/services/opcLogo.svg" alt="Reference Voucher (placeholder)"/>
@@ -115,13 +115,13 @@
     >
       <div>
         <span class="service-tag unhcr">
-          UNHCR
+          {{ 'SERVICES.UNHCR.TAG' | translate }}
         </span>
         <h3>
-          UNHCR Help
+          {{ 'SERVICES.UNHCR.TITLE' | translate }}
         </h3>
         <p>
-          Country-specific refugee support resources from UNHCR.
+          {{ 'SERVICES.UNHCR.DESCRIPTION' | translate }}
         </p>
       </div>
       <img src="assets/images/services/unhcr.png" alt="UNHCR Logo"/>
@@ -134,13 +134,13 @@
     >
       <div>
         <span class="service-tag unhcr">
-          Verify+
+          {{ 'SERVICES.VERIFY_PLUS.TAG' | translate }}
         </span>
         <h3>
-          UNHCR Verify+
+          {{ 'SERVICES.VERIFY_PLUS.TITLE' | translate }}
         </h3>
         <p>
-          Scan your UNHCR Verify+ QR code to capture data from your card.
+          {{ 'SERVICES.VERIFY_PLUS.DESCRIPTION' | translate }}
         </p>
       </div>
       <img src="assets/images/services/unhcr.png" alt="UNHCR Verify+ Logo"/>

--- a/ui/candidate-portal/src/app/components/profile/view/tab/services/services.component.spec.ts
+++ b/ui/candidate-portal/src/app/components/profile/view/tab/services/services.component.spec.ts
@@ -15,11 +15,18 @@
  */
 
 import {ComponentFixture, TestBed} from '@angular/core/testing';
-import {NO_ERRORS_SCHEMA} from "@angular/core";
+import {NO_ERRORS_SCHEMA, Pipe, PipeTransform} from "@angular/core";
 import {of} from "rxjs";
 
 import {ServicesComponent} from './services.component';
 import {ServiceProvider} from "../../../../../model/services";
+
+@Pipe({name: 'translate'})
+class MockTranslatePipe implements PipeTransform {
+  transform(value: string): string {
+    return value;
+  }
+}
 
 describe('ServicesComponent', () => {
   let component: ServicesComponent;
@@ -27,7 +34,7 @@ describe('ServicesComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [ServicesComponent],
+      declarations: [ServicesComponent, MockTranslatePipe],
       schemas: [NO_ERRORS_SCHEMA],
     });
     fixture = TestBed.createComponent(ServicesComponent);

--- a/ui/candidate-portal/src/app/components/profile/view/tab/services/unhcr/unhcr.component.html
+++ b/ui/candidate-portal/src/app/components/profile/view/tab/services/unhcr/unhcr.component.html
@@ -20,8 +20,8 @@
 <div class="service-title">
   <div class="header">
     <div>
-      <h2>UNHCR {{ countryName }}</h2>
-      <p>Official refugee help resources for {{ countryName }}.</p>
+      <h2>{{ 'SERVICES.UNHCR.DETAIL_TITLE' | translate:{ countryName: countryName } }}</h2>
+      <p>{{ 'SERVICES.UNHCR.DETAIL_SUBTITLE' | translate:{ countryName: countryName } }}</p>
     </div>
     <span class="flag-icon" aria-hidden="true">{{ countryFlag }}</span>
   </div>
@@ -29,7 +29,7 @@
 
 <div class="service-content" *ngIf="!loading">
   <p>
-    Visit UNHCR Help for up-to-date guidance and support information specific to {{ countryName }}.
+    {{ 'SERVICES.UNHCR.HELP_INTRO' | translate:{ countryName: countryName } }}
   </p>
 
   <p *ngIf="assignment?.resource?.resourceCode as helpUrl">
@@ -39,7 +39,7 @@
   <div class="mt-5">
     <tc-button [type]="'outline'" (onClick)="onBackButtonClicked()">
       <i class="me-1 fas fa-arrow-left"></i>
-      Back
+      {{ 'SERVICES.UNHCR.BACK' | translate }}
     </tc-button>
   </div>
 </div>

--- a/ui/candidate-portal/src/app/components/profile/view/tab/services/unhcr/unhcr.component.spec.ts
+++ b/ui/candidate-portal/src/app/components/profile/view/tab/services/unhcr/unhcr.component.spec.ts
@@ -15,10 +15,17 @@
  */
 
 import {ComponentFixture, TestBed} from '@angular/core/testing';
-import {NO_ERRORS_SCHEMA} from "@angular/core";
+import {NO_ERRORS_SCHEMA, Pipe, PipeTransform} from "@angular/core";
 import {of, throwError} from 'rxjs';
 import {UnhcrComponent} from './unhcr.component';
 import {CasiPortalService} from "../../../../../../services/casi-portal.service";
+
+@Pipe({name: 'translate'})
+class MockTranslatePipe implements PipeTransform {
+  transform(value: string): string {
+    return value;
+  }
+}
 
 describe('UnhcrComponent', () => {
   let component: UnhcrComponent;
@@ -33,7 +40,7 @@ describe('UnhcrComponent', () => {
     } as any));
 
     await TestBed.configureTestingModule({
-      declarations: [UnhcrComponent],
+      declarations: [UnhcrComponent, MockTranslatePipe],
       providers: [{provide: CasiPortalService, useValue: mockPortalService}],
       schemas: [NO_ERRORS_SCHEMA]
     }).compileComponents();

--- a/ui/candidate-portal/src/app/components/profile/view/tab/services/verify-plus/verify-plus.component.html
+++ b/ui/candidate-portal/src/app/components/profile/view/tab/services/verify-plus/verify-plus.component.html
@@ -17,8 +17,8 @@
 <div class="service-title">
   <div class="header">
     <div>
-      <h2>UNHCR Verify+</h2>
-      <p>Scan your UNHCR Verify+ card QR code to capture the encoded payload.</p>
+      <h2>{{ 'SERVICES.VERIFY_PLUS.TITLE' | translate }}</h2>
+      <p>{{ 'SERVICES.VERIFY_PLUS.SCAN_INTRO' | translate }}</p>
     </div>
   </div>
 </div>
@@ -31,44 +31,44 @@
   ></app-verify-plus-scanner>
 
   <p class="mt-3 text-danger" *ngIf="scannerError">
-    A camera or scanner error occurred. Please refresh and try again.
+    {{ 'SERVICES.VERIFY_PLUS.SCANNER_ERROR' | translate }}
   </p>
 
   <div class="scan-result mt-3" *ngIf="decodedPayload && !submitResult">
-    <h3>Review scanned payload</h3>
+    <h3>{{ 'SERVICES.VERIFY_PLUS.REVIEW_TITLE' | translate }}</h3>
     <pre>{{ formattedPayload }}</pre>
   </div>
 
   <p class="mt-3 text-danger" *ngIf="submitError">
-    {{ submitErrorMessage || "We couldn't submit this scan. Please check your connection and try again." }}
+    {{ submitErrorMessage || ('SERVICES.VERIFY_PLUS.SUBMIT_ERROR_FALLBACK' | translate) }}
     <br>
-    If this QR code is a valid UNHCR Verify+ code, please rescan.
+    {{ 'SERVICES.VERIFY_PLUS.SUBMIT_ERROR_HINT' | translate }}
   </p>
 
   <div class="mt-3 d-flex flex-wrap gap-2" *ngIf="decodedPayload && !submitResult">
     <tc-button [type]="'outline'" [disabled]="submitting" (onClick)="onRescan()">
-      Rescan
+      {{ 'SERVICES.VERIFY_PLUS.RESCAN' | translate }}
     </tc-button>
     <tc-button [loading]="submitting" [disabled]="submitting" (onClick)="onConfirm()">
-      Confirm
+      {{ 'SERVICES.VERIFY_PLUS.CONFIRM' | translate }}
     </tc-button>
   </div>
 
   <div class="scan-result mt-3" *ngIf="submitResult && !submitResult.duplicate">
-    <h3>Verification submitted</h3>
-    <p>Your UNHCR number was captured successfully: <strong>{{ submitResult.unhcrNumber }}</strong></p>
+    <h3>{{ 'SERVICES.VERIFY_PLUS.SUCCESS_TITLE' | translate }}</h3>
+    <p>{{ 'SERVICES.VERIFY_PLUS.SUCCESS_BODY' | translate }} <strong>{{ submitResult.unhcrNumber }}</strong></p>
   </div>
 
   <div class="scan-result mt-3" *ngIf="submitResult?.duplicate">
-    <h3>Duplicate UNHCR number found</h3>
-    <p>We submitted your scan, but this UNHCR number already exists on another active candidate: <strong>{{ submitResult.unhcrNumber }}</strong></p>
-    <p>You can rescan if needed.</p>
+    <h3>{{ 'SERVICES.VERIFY_PLUS.DUPLICATE_TITLE' | translate }}</h3>
+    <p>{{ 'SERVICES.VERIFY_PLUS.DUPLICATE_BODY' | translate }} <strong>{{ submitResult.unhcrNumber }}</strong></p>
+    <p>{{ 'SERVICES.VERIFY_PLUS.DUPLICATE_RESCAN_HINT' | translate }}</p>
   </div>
 
   <div class="mt-5">
     <tc-button [type]="'outline'" (onClick)="onBackButtonClicked()">
       <i class="me-1 fas fa-arrow-left"></i>
-      Back
+      {{ 'SERVICES.VERIFY_PLUS.BACK' | translate }}
     </tc-button>
   </div>
 </div>

--- a/ui/candidate-portal/src/app/components/profile/view/tab/services/verify-plus/verify-plus.component.spec.ts
+++ b/ui/candidate-portal/src/app/components/profile/view/tab/services/verify-plus/verify-plus.component.spec.ts
@@ -15,11 +15,18 @@
  */
 
 import {ComponentFixture, TestBed} from '@angular/core/testing';
-import {NO_ERRORS_SCHEMA} from '@angular/core';
+import {NO_ERRORS_SCHEMA, Pipe, PipeTransform} from '@angular/core';
 import {of, throwError} from 'rxjs';
 
 import {VerifyPlusComponent} from './verify-plus.component';
 import {VerifyPlusService} from '../../../../../../services/verify-plus.service';
+
+@Pipe({name: 'translate'})
+class MockTranslatePipe implements PipeTransform {
+  transform(value: string): string {
+    return value;
+  }
+}
 
 describe('VerifyPlusComponent', () => {
   let component: VerifyPlusComponent;
@@ -30,7 +37,7 @@ describe('VerifyPlusComponent', () => {
     verifyPlusService = jasmine.createSpyObj<VerifyPlusService>('VerifyPlusService', ['submitScan']);
 
     TestBed.configureTestingModule({
-      declarations: [VerifyPlusComponent],
+      declarations: [VerifyPlusComponent, MockTranslatePipe],
       providers: [
         {provide: VerifyPlusService, useValue: verifyPlusService}
       ],

--- a/ui/candidate-portal/src/app/components/register/verify-plus/registration-verify-plus.component.html
+++ b/ui/candidate-portal/src/app/components/register/verify-plus/registration-verify-plus.component.html
@@ -15,8 +15,8 @@
   -->
 
 <div class="container verify-plus-registration">
-  <h4>UNHCR Verify+ (optional)</h4>
-  <p>Scan your Verify+ card now to pre-fill your UNHCR registration number.</p>
+  <h4>{{ 'REGISTRATION.VERIFY_PLUS.TITLE' | translate }}</h4>
+  <p>{{ 'REGISTRATION.VERIFY_PLUS.DESCRIPTION' | translate }}</p>
 
   <app-verify-plus-scanner
     [hideScanAgain]="true"
@@ -25,45 +25,45 @@
   ></app-verify-plus-scanner>
 
   <p class="mt-3 text-danger" *ngIf="scannerError">
-    A camera or scanner error occurred. Please refresh and try again.
+    {{ 'SERVICES.VERIFY_PLUS.SCANNER_ERROR' | translate }}
   </p>
 
   <div class="scan-result mt-3" *ngIf="decodedPayload && !submitResult">
-    <h5>Review scanned payload</h5>
+    <h5>{{ 'SERVICES.VERIFY_PLUS.REVIEW_TITLE' | translate }}</h5>
     <pre>{{ formattedPayload }}</pre>
   </div>
 
   <p class="mt-3 text-danger" *ngIf="submitError">
-    {{ submitErrorMessage || "We couldn't submit this scan. Please check your connection and try again." }}
+    {{ submitErrorMessage || ('SERVICES.VERIFY_PLUS.SUBMIT_ERROR_FALLBACK' | translate) }}
   </p>
 
   <div class="mt-3 d-flex flex-wrap gap-2" *ngIf="decodedPayload && !submitResult">
     <tc-button [type]="'outline'" [disabled]="submitting" (onClick)="onRescan()">
-      Rescan
+      {{ 'SERVICES.VERIFY_PLUS.RESCAN' | translate }}
     </tc-button>
     <tc-button [loading]="submitting" [disabled]="submitting" (onClick)="onConfirm()">
-      Confirm
+      {{ 'SERVICES.VERIFY_PLUS.CONFIRM' | translate }}
     </tc-button>
   </div>
 
   <div class="scan-result mt-3" *ngIf="submitResult && !submitResult.duplicate">
-    <h5>UNHCR number captured</h5>
+    <h5>{{ 'REGISTRATION.VERIFY_PLUS.SUCCESS_TITLE' | translate }}</h5>
     <p>
-      Your scan was submitted successfully:
+      {{ 'REGISTRATION.VERIFY_PLUS.SUCCESS_BODY' | translate }}
       <strong>{{ submitResult.unhcrNumber }}</strong>
     </p>
   </div>
 
   <div class="scan-result mt-3" *ngIf="submitResult?.duplicate">
-    <h5>Duplicate UNHCR number found</h5>
+    <h5>{{ 'SERVICES.VERIFY_PLUS.DUPLICATE_TITLE' | translate }}</h5>
     <p>
-      We submitted your scan, but this UNHCR number already exists on another active candidate:
+      {{ 'REGISTRATION.VERIFY_PLUS.DUPLICATE_BODY' | translate }}
       <strong>{{ submitResult.unhcrNumber }}</strong>
     </p>
   </div>
 
   <p class="text-muted mt-3" *ngIf="!submitResult">
-    You can skip this step for now and continue registration.
+    {{ 'REGISTRATION.VERIFY_PLUS.SKIP_HINT' | translate }}
   </p>
 </div>
 

--- a/ui/candidate-portal/src/app/components/register/verify-plus/registration-verify-plus.component.spec.ts
+++ b/ui/candidate-portal/src/app/components/register/verify-plus/registration-verify-plus.component.spec.ts
@@ -15,13 +15,20 @@
  */
 
 import {ComponentFixture, TestBed} from '@angular/core/testing';
-import {NO_ERRORS_SCHEMA} from '@angular/core';
+import {NO_ERRORS_SCHEMA, Pipe, PipeTransform} from '@angular/core';
 import {of, throwError} from 'rxjs';
 
 import {RegistrationVerifyPlusComponent} from './registration-verify-plus.component';
 import {VerifyPlusService} from '../../../services/verify-plus.service';
 import {RegistrationService} from '../../../services/registration.service';
 import {AuthenticationService} from '../../../services/authentication.service';
+
+@Pipe({name: 'translate'})
+class MockTranslatePipe implements PipeTransform {
+  transform(value: string): string {
+    return value;
+  }
+}
 
 describe('RegistrationVerifyPlusComponent', () => {
   let component: RegistrationVerifyPlusComponent;
@@ -37,7 +44,7 @@ describe('RegistrationVerifyPlusComponent', () => {
     authenticationService.isGrnInstance.and.returnValue(true);
 
     TestBed.configureTestingModule({
-      declarations: [RegistrationVerifyPlusComponent],
+      declarations: [RegistrationVerifyPlusComponent, MockTranslatePipe],
       providers: [
         {provide: VerifyPlusService, useValue: verifyPlusService},
         {provide: RegistrationService, useValue: registrationService},

--- a/ui/candidate-portal/src/app/services/registration.service.ts
+++ b/ui/candidate-portal/src/app/services/registration.service.ts
@@ -39,7 +39,8 @@ export class RegistrationService {
     },
     {
       key: 'verifyplus',
-      title: 'Scan your UNHCR Verify+ card (optional)',
+      // Header title is sourced from REGISTRATION.HEADER.TITLE.VERIFYPLUS translations.
+      title: '',
       section: 2
     },
     {


### PR DESCRIPTION
## Pull request overview

Adds a translation/localization pass for candidate-portal service screens (Verify+, UNHCR, Reference) and introduces a scoped “translation patch” import/export workflow (Admin UI + Admin API + server-side merge/export utilities) to promote only selected translation subtrees/keys between environments.

**Changes:**
- Replaces hard-coded candidate-portal service strings with `translate` pipe keys and updates unit tests to mock the translate pipe.
- Adds Admin Portal controls to dry-run/import translation patches and export scoped patch JSON files.
- Implements server-side translation patch import/export (deep-merge + scoped export), with security restrictions and test coverage, plus an ops runbook and a Verify+ 1.4 patch artifact.

