### PR TITLE
3439 Add per-candidate task assignment email cooldown

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -93,6 +93,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'com.github.ben-manes.caffeine:caffeine'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation "org.springframework.data:spring-data-rest-webmvc"
     implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
@@ -289,4 +290,3 @@ bootJar {
         include ".ebextensions/**"
     }
 }
-

--- a/server/src/main/java/org/tctalent/server/configuration/properties/TaskAssignmentEmailProperties.java
+++ b/server/src/main/java/org/tctalent/server/configuration/properties/TaskAssignmentEmailProperties.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2026 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.server.configuration.properties;
+
+import java.time.Duration;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/** Configuration properties for task assignment email notifications. */
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "tc.task-assignment-email")
+public class TaskAssignmentEmailProperties {
+
+  /** Minimum time between task assignment emails sent to the same candidate. */
+  private Duration cooldown = Duration.ofMinutes(15);
+}

--- a/server/src/main/java/org/tctalent/server/service/db/task/TaskAssignedEmailListener.java
+++ b/server/src/main/java/org/tctalent/server/service/db/task/TaskAssignedEmailListener.java
@@ -2,25 +2,30 @@
  * Copyright (c) 2026 Talent Catalog.
  *
  * This program is free software: you can redistribute it and/or modify it under
- * the terms of the GNU Affero General Public License as published by the Free
+ * the terms of the GNU General Public License as published by the Free
  * Software Foundation, either version 3 of the License, or any later version.
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  * for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
 package org.tctalent.server.service.db.task;
 
-import lombok.RequiredArgsConstructor;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.Ticker;
+import java.time.Duration;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionalEventListener;
+import org.tctalent.server.configuration.properties.TaskAssignmentEmailProperties;
 import org.tctalent.server.logging.LogBuilder;
 import org.tctalent.server.model.db.Candidate;
 import org.tctalent.server.model.db.TaskAssignmentImpl;
@@ -31,51 +36,82 @@ import org.tctalent.server.service.db.email.EmailHelper;
 /**
  * Listens for task assignment events and sends notification emails to candidates.
  *
+ * <p>Successful notifications start a configurable, in-memory cooldown for the candidate so that
+ * bulk task assignments do not produce a burst of emails. Failed sends release the cooldown so a
+ * later assignment can retry.
+ *
  * @author sadatmalik
  */
 @Component
-@RequiredArgsConstructor
 @Slf4j
 public class TaskAssignedEmailListener {
 
-    private final EmailHelper emailHelper;
+  private final EmailHelper emailHelper;
+  private final Cache<Long, Object> notifiedCandidates;
 
-    @Async
-    @TransactionalEventListener
-    public void onAssigned(TaskAssignedEvent event) {
-        TaskAssignmentImpl taskAssignment = event.taskAssignment();
-        String action = "TaskAssignedEmailListener:onAssigned: " + taskAssignment.getTask().getName();
+  @Autowired
+  public TaskAssignedEmailListener(
+      EmailHelper emailHelper, TaskAssignmentEmailProperties properties) {
+    this(emailHelper, properties, Ticker.systemTicker());
+  }
 
-        if (!taskAssignment.getTask().isNotifyOnAssignment()) {
-            return;
-        }
-
-        Candidate candidate = taskAssignment.getCandidate();
-        if (candidate == null) {
-            LogBuilder.builder(log)
-                .action(action)
-                .message("Task assignment " + taskAssignment.getId() + " has no candidate")
-                .logWarn();
-            return;
-        }
-
-        User user = candidate.getUser();
-        if (user == null || user.getEmail() == null || user.getEmail().isBlank()) {
-            LogBuilder.builder(log)
-                .action(action)
-                .message("Candidate " + candidate.getId() + " has no associated user email")
-                .logWarn();
-            return;
-        }
-
-        try {
-            emailHelper.sendTaskAssignedEmail(user, taskAssignment.getTask().getDisplayName());
-        } catch (Exception ex) {
-            LogBuilder.builder(log)
-                .action(action)
-                .message("Failed sending task assignment email for task assignment " + taskAssignment.getId()
-                    + " to candidate " + candidate.getId())
-                .logWarn(ex);
-        }
+  TaskAssignedEmailListener(
+      EmailHelper emailHelper, TaskAssignmentEmailProperties properties, Ticker ticker) {
+    Duration cooldown = properties.getCooldown();
+    if (cooldown.isZero() || cooldown.isNegative()) {
+      throw new IllegalArgumentException("Task assignment email cooldown must be positive");
     }
+
+    this.emailHelper = emailHelper;
+    this.notifiedCandidates =
+        Caffeine.newBuilder().expireAfterWrite(cooldown).ticker(ticker).build();
+  }
+
+  @Async
+  @TransactionalEventListener
+  public void onAssigned(TaskAssignedEvent event) {
+    TaskAssignmentImpl taskAssignment = event.taskAssignment();
+    String action = "TaskAssignedEmailListener:onAssigned: " + taskAssignment.getTask().getName();
+
+    if (!taskAssignment.getTask().isNotifyOnAssignment()) {
+      return;
+    }
+
+    Candidate candidate = taskAssignment.getCandidate();
+    if (candidate == null) {
+      LogBuilder.builder(log)
+          .action(action)
+          .message("Task assignment " + taskAssignment.getId() + " has no candidate")
+          .logWarn();
+      return;
+    }
+
+    User user = candidate.getUser();
+    if (user == null || user.getEmail() == null || user.getEmail().isBlank()) {
+      LogBuilder.builder(log)
+          .action(action)
+          .message("Candidate " + candidate.getId() + " has no associated user email")
+          .logWarn();
+      return;
+    }
+
+    Object notificationMarker = new Object();
+    if (notifiedCandidates.asMap().putIfAbsent(candidate.getId(), notificationMarker) != null) {
+      return;
+    }
+
+    try {
+      emailHelper.sendTaskAssignedEmail(user, taskAssignment.getTask().getDisplayName());
+    } catch (Exception ex) {
+      notifiedCandidates.asMap().remove(candidate.getId(), notificationMarker);
+      LogBuilder.builder(log)
+          .action(action)
+          .message(
+              "Failed sending task assignment email for task assignment "
+                  + taskAssignment.getId()
+                  + " to candidate "
+                  + candidate.getId())
+          .logWarn(ex);
+    }
+  }
 }

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -4,6 +4,10 @@ tc:
       # Memory-hygiene TTL for the candidate JSON read cache. Set to 0 to disable expiry.
       ttl: ${TC_CANDIDATE_CACHE_TTL:7d}
 
+  task-assignment-email:
+    # Prevent multiple task assignment emails reaching one candidate in a short burst.
+    cooldown: ${TC_TASK_ASSIGNMENT_EMAIL_COOLDOWN:15m}
+
   cors:
     urls: ${TC_CORS_URLS:http://localhost:4200,http://127.0.0.1:4200,http://localhost:4201,http://localhost:4202}
 

--- a/server/src/test/java/org/tctalent/server/service/db/task/TaskAssignedEmailListenerTest.java
+++ b/server/src/test/java/org/tctalent/server/service/db/task/TaskAssignedEmailListenerTest.java
@@ -2,15 +2,15 @@
  * Copyright (c) 2026 Talent Catalog.
  *
  * This program is free software: you can redistribute it and/or modify it under
- * the terms of the GNU Affero General Public License as published by the Free
+ * the terms of the GNU General Public License as published by the Free
  * Software Foundation, either version 3 of the License, or any later version.
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  * for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
@@ -21,15 +21,18 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import com.github.benmanes.caffeine.cache.Ticker;
+import java.time.Duration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.tctalent.server.configuration.properties.TaskAssignmentEmailProperties;
 import org.tctalent.server.model.db.Candidate;
 import org.tctalent.server.model.db.TaskAssignmentImpl;
 import org.tctalent.server.model.db.TaskImpl;
@@ -40,86 +43,149 @@ import org.tctalent.server.service.db.email.EmailHelper;
 @ExtendWith(MockitoExtension.class)
 class TaskAssignedEmailListenerTest {
 
-    @Mock
-    private EmailHelper emailHelper;
+  @Mock private EmailHelper emailHelper;
 
-    @InjectMocks
-    private TaskAssignedEmailListener listener;
+  private TaskAssignedEmailListener listener;
+  private MutableTicker ticker;
 
-    private TaskAssignmentImpl taskAssignment;
-    private Candidate candidate;
-    private User user;
+  private TaskAssignmentImpl taskAssignment;
+  private Candidate candidate;
+  private User user;
 
-    @BeforeEach
-    void setUp() {
-        TaskImpl task = new TaskImpl();
-        task.setId(100L);
-        task.setName("testTask");
-        task.setDisplayName("Complete your profile");
-        task.setNotifyOnAssignment(true);
+  @BeforeEach
+  void setUp() {
+    TaskImpl task = new TaskImpl();
+    task.setId(100L);
+    task.setName("testTask");
+    task.setDisplayName("Complete your profile");
+    task.setNotifyOnAssignment(true);
 
-        user = new User();
-        user.setId(200L);
-        user.setEmail("candidate@example.com");
-        user.setFirstName("Test");
-        user.setLastName("Candidate");
+    user = new User();
+    user.setId(200L);
+    user.setEmail("candidate@example.com");
+    user.setFirstName("Test");
+    user.setLastName("Candidate");
 
-        candidate = new Candidate();
-        candidate.setId(300L);
-        candidate.setUser(user);
+    candidate = new Candidate();
+    candidate.setId(300L);
+    candidate.setUser(user);
 
-        taskAssignment = new TaskAssignmentImpl();
-        taskAssignment.setId(400L);
-        taskAssignment.setTask(task);
-        taskAssignment.setCandidate(candidate);
+    taskAssignment = new TaskAssignmentImpl();
+    taskAssignment.setId(400L);
+    taskAssignment.setTask(task);
+    taskAssignment.setCandidate(candidate);
+
+    TaskAssignmentEmailProperties properties = new TaskAssignmentEmailProperties();
+    properties.setCooldown(Duration.ofMinutes(15));
+    ticker = new MutableTicker();
+    listener = new TaskAssignedEmailListener(emailHelper, properties, ticker);
+  }
+
+  @Test
+  @DisplayName("onAssigned sends email when candidate user and email exist")
+  void onAssignedSendsEmailWhenCandidateDetailsExist() {
+    listener.onAssigned(new TaskAssignedEvent(taskAssignment));
+
+    verify(emailHelper).sendTaskAssignedEmail(user, "Complete your profile");
+  }
+
+  @Test
+  @DisplayName("onAssigned suppresses a second email within the candidate cooldown")
+  void onAssignedSuppressesSecondEmailWithinCooldown() {
+    listener.onAssigned(new TaskAssignedEvent(taskAssignment));
+    listener.onAssigned(new TaskAssignedEvent(taskAssignment));
+
+    verify(emailHelper).sendTaskAssignedEmail(user, "Complete your profile");
+  }
+
+  @Test
+  @DisplayName("onAssigned sends another email after the candidate cooldown expires")
+  void onAssignedSendsAgainAfterCooldown() {
+    listener.onAssigned(new TaskAssignedEvent(taskAssignment));
+    ticker.advance(Duration.ofMinutes(15));
+    listener.onAssigned(new TaskAssignedEvent(taskAssignment));
+
+    verify(emailHelper, times(2)).sendTaskAssignedEmail(user, "Complete your profile");
+  }
+
+  @Test
+  @DisplayName("onAssigned applies cooldowns independently per candidate")
+  void onAssignedAppliesCooldownPerCandidate() {
+    User otherUser = new User();
+    otherUser.setId(201L);
+    otherUser.setEmail("other@example.com");
+
+    Candidate otherCandidate = new Candidate();
+    otherCandidate.setId(301L);
+    otherCandidate.setUser(otherUser);
+
+    TaskAssignmentImpl otherAssignment = new TaskAssignmentImpl();
+    otherAssignment.setId(401L);
+    otherAssignment.setTask(taskAssignment.getTask());
+    otherAssignment.setCandidate(otherCandidate);
+
+    listener.onAssigned(new TaskAssignedEvent(taskAssignment));
+    listener.onAssigned(new TaskAssignedEvent(otherAssignment));
+
+    verify(emailHelper).sendTaskAssignedEmail(user, "Complete your profile");
+    verify(emailHelper).sendTaskAssignedEmail(otherUser, "Complete your profile");
+  }
+
+  @Test
+  @DisplayName("onAssigned skips email when candidate is missing")
+  void onAssignedSkipsEmailWhenCandidateMissing() {
+    taskAssignment.setCandidate(null);
+
+    listener.onAssigned(new TaskAssignedEvent(taskAssignment));
+
+    verify(emailHelper, never()).sendTaskAssignedEmail(any(User.class), anyString());
+  }
+
+  @Test
+  @DisplayName("onAssigned skips email when candidate user is missing")
+  void onAssignedSkipsEmailWhenUserMissing() {
+    candidate.setUser(null);
+
+    listener.onAssigned(new TaskAssignedEvent(taskAssignment));
+
+    verify(emailHelper, never()).sendTaskAssignedEmail(any(User.class), anyString());
+  }
+
+  @Test
+  @DisplayName("onAssigned skips email when candidate email is missing")
+  void onAssignedSkipsEmailWhenEmailMissing() {
+    user.setEmail(null);
+
+    listener.onAssigned(new TaskAssignedEvent(taskAssignment));
+
+    verify(emailHelper, never()).sendTaskAssignedEmail(any(User.class), anyString());
+  }
+
+  @Test
+  @DisplayName("onAssigned releases the cooldown when email sending fails")
+  void onAssignedReleasesCooldownAfterEmailSendFailure() {
+    doThrow(new RuntimeException("smtp down"))
+        .doNothing()
+        .when(emailHelper)
+        .sendTaskAssignedEmail(any(User.class), anyString());
+
+    assertDoesNotThrow(() -> listener.onAssigned(new TaskAssignedEvent(taskAssignment)));
+    listener.onAssigned(new TaskAssignedEvent(taskAssignment));
+
+    verify(emailHelper, times(2)).sendTaskAssignedEmail(user, "Complete your profile");
+  }
+
+  private static final class MutableTicker implements Ticker {
+
+    private long elapsedNanos;
+
+    @Override
+    public long read() {
+      return elapsedNanos;
     }
 
-    @Test
-    @DisplayName("onAssigned sends email when candidate user and email exist")
-    void onAssignedSendsEmailWhenCandidateDetailsExist() {
-        listener.onAssigned(new TaskAssignedEvent(taskAssignment));
-
-        verify(emailHelper).sendTaskAssignedEmail(user, "Complete your profile");
+    void advance(Duration duration) {
+      elapsedNanos += duration.toNanos();
     }
-
-    @Test
-    @DisplayName("onAssigned skips email when candidate is missing")
-    void onAssignedSkipsEmailWhenCandidateMissing() {
-        taskAssignment.setCandidate(null);
-
-        listener.onAssigned(new TaskAssignedEvent(taskAssignment));
-
-        verify(emailHelper, never()).sendTaskAssignedEmail(any(User.class), anyString());
-    }
-
-    @Test
-    @DisplayName("onAssigned skips email when candidate user is missing")
-    void onAssignedSkipsEmailWhenUserMissing() {
-        candidate.setUser(null);
-
-        listener.onAssigned(new TaskAssignedEvent(taskAssignment));
-
-        verify(emailHelper, never()).sendTaskAssignedEmail(any(User.class), anyString());
-    }
-
-    @Test
-    @DisplayName("onAssigned skips email when candidate email is missing")
-    void onAssignedSkipsEmailWhenEmailMissing() {
-        user.setEmail(null);
-
-        listener.onAssigned(new TaskAssignedEvent(taskAssignment));
-
-        verify(emailHelper, never()).sendTaskAssignedEmail(any(User.class), anyString());
-    }
-
-    @Test
-    @DisplayName("onAssigned catches email send failures")
-    void onAssignedHandlesEmailSendFailure() {
-        doThrow(new RuntimeException("smtp down"))
-            .when(emailHelper).sendTaskAssignedEmail(any(User.class), anyString());
-
-        assertDoesNotThrow(() -> listener.onAssigned(new TaskAssignedEvent(taskAssignment)));
-
-        verify(emailHelper).sendTaskAssignedEmail(user, "Complete your profile");
-    }
+  }
 }


### PR DESCRIPTION
## Summary

Closes #3439.

Adds a configurable per-candidate cooldown to task assignment notifications so bulk task assignments do not send several emails to the same candidate in a short burst.

## What changed

- Added a Caffeine cache keyed by candidate ID to reserve the notification window atomically.
- Defaulted the cooldown to 15 minutes and made it configurable with `TC_TASK_ASSIGNMENT_EMAIL_COOLDOWN`.
- Applied the cooldown only after the existing task, candidate, user, and email guards.
- Released the reservation when email delivery throws so a later assignment can retry.
- Added focused unit coverage for the initial send, suppression within the window, sending after expiry, independent candidates, and delivery-failure retry.
- Updated the touched Java files to the repository's current GPL header and Google Java formatting standard.

## Why

When several tasks with `notifyOnAssignment` enabled are assigned to one candidate in quick succession, the listener currently sends one email for every task. The cooldown reduces duplicate notification noise while preserving a fresh notification after the configured window.

The cache is intentionally in-memory, as proposed in the issue. It covers burst assignments handled by one application instance without adding a schema migration. It resets on restart and is not shared between server instances.

## Validation

- `JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home PATH=/opt/homebrew/opt/openjdk@17/bin:$PATH ./gradlew -Denv=dev server:test --tests org.tctalent.server.service.db.task.TaskAssignedEmailListenerTest`
  - Passed: 8 tests, 0 failures.
- Full dependency path through the monorepo UI builds and the same focused backend test also passed.
- Caffeine resolves to the Spring Boot managed version `3.2.3`.
- `git diff --cached --check`
  - Passed.

## Contribution guideline alignment

- Branched from current upstream `staging`.
- Uses the fork-and-pull workflow and an issue-linked descriptive branch.
- Keeps the change scoped to issue #3439.
- Uses constructor injection and documents the new configuration.
- Adds no database or Flyway changes.