### PR TITLE
Remove subtext from date picker in candidate portal

### DIFF
--- a/ui/candidate-portal/src/app/components/common/candidate-certification-form/candidate-certification-form.component.html
+++ b/ui/candidate-portal/src/app/components/common/candidate-certification-form/candidate-certification-form.component.html
@@ -30,7 +30,11 @@
 
   <div class="mb-3">
     <tc-label for="dateCompleted">{{ 'REGISTRATION.CERTIFICATIONS.LABEL.DATECOMPLETED' | translate }} <sup>*</sup></tc-label>
-    <tc-date-picker id="dateCompleted" [control]="form.controls.dateCompleted"></tc-date-picker>
+    <tc-date-picker
+      id="dateCompleted"
+      [control]="form.controls.dateCompleted"
+      [showHelpText]="false">
+    </tc-date-picker>
     <app-form-control-error [control]="form.controls.dateCompleted"></app-form-control-error>
     <p class="small mt-2 mb-0">
       {{ 'FORM.LABEL.APPROX' | translate }}

--- a/ui/candidate-portal/src/app/components/common/candidate-job-experience-form/candidate-job-experience-form.component.html
+++ b/ui/candidate-portal/src/app/components/common/candidate-job-experience-form/candidate-job-experience-form.component.html
@@ -67,7 +67,11 @@
       <tc-label for="startDate">
         {{ 'FORM.JOBEXPERIENCE.LABEL.STARTDATE' | translate }} <sup>*</sup>
       </tc-label>
-      <tc-date-picker id="startDate" [control]="form.controls.startDate"></tc-date-picker>
+      <tc-date-picker
+        id="startDate"
+        [control]="form.controls.startDate"
+        [showHelpText]="false">
+      </tc-date-picker>
       <app-form-control-error [control]="form.controls.startDate"></app-form-control-error>
       <p class="small mt-2 mb-0">
         {{ 'FORM.LABEL.APPROX' | translate }}
@@ -85,7 +89,11 @@
       <tc-label for="endDate">
         {{ 'FORM.JOBEXPERIENCE.LABEL.ENDDATE' | translate }}
       </tc-label>
-      <tc-date-picker id="endDate" [control]="form.controls.endDate"></tc-date-picker>
+      <tc-date-picker
+        id="endDate"
+        [control]="form.controls.endDate"
+        [showHelpText]="false">
+      </tc-date-picker>
       <app-form-control-error [control]="form.controls.endDate"></app-form-control-error>
       <p class="small mt-2 mb-0">
         {{ 'FORM.LABEL.APPROX' | translate }}

--- a/ui/candidate-portal/src/app/components/register/personal/registration-personal.component.html
+++ b/ui/candidate-portal/src/app/components/register/personal/registration-personal.component.html
@@ -58,7 +58,12 @@
     <div class="col-12 col-md-6">
       <div class="mb-3">
         <tc-label for="dob">{{ 'REGISTRATION.PERSONAL.LABEL.DOB' | translate }} <sup>*</sup></tc-label>
-        <tc-date-picker id="dob" [control]="form.controls.dob" [allowFuture]="false"></tc-date-picker>
+        <tc-date-picker
+          id="dob"
+          [control]="form.controls.dob"
+          [allowFuture]="false"
+          [showHelpText]="false">
+        </tc-date-picker>
         <app-form-control-error [control]="form.controls.dob"></app-form-control-error>
       </div>
     </div>


### PR DESCRIPTION
Just setting [showHelpText] input field to false to remove the plain english subtext from the date picker