### PR TITLE
Hiba/tc 1454 fix AI Candidate Matching input layout and animation visibility

### DIFF
--- a/ui/admin-portal/src/app/components/search/define-search/define-search.component.html
+++ b/ui/admin-portal/src/app/components/search/define-search/define-search.component.html
@@ -156,9 +156,9 @@
             </p>
           </div>
 
-          <div *ngIf="hasEmbeddingModels()" class="col-md-8 mt-3">
+          <div *ngIf="hasEmbeddingModels()" class="col-md-12 mt-3">
             <div>
-              <div class="ai-input" [class.ai-input--highlighted]="!hasEverHadRequirementsInput">
+              <div class="ai-input" [class.ai-input--highlighted]="!hasRequirements()">
                 <img class="ai-input-sparkle ai-input-sparkle-start"
                      src="assets/images/sparkle-primary.svg"
                      alt=""
@@ -190,17 +190,19 @@
             <div *ngIf="hasRequirements()" class="ai-matching-controls">
             <!-- Lexical vs Semantic importance -->
             <div class="ai-match-style-control">
-              <tc-label size="sm" class="form-label" for="lexicalWeight">How should AI match candidates?</tc-label>
-              <tc-button [type]="'plain'"
-                         class="tool-tip-button"
-                         ngbTooltip="Lexical vs Semantic matching. Enter a value between 0 and 1. The default is 0.5, which is Balanced and means that the lexical score is equally important as the semantic score. Exact requirements gives more weight to lexical matching. Related experience gives more weight to semantic matching."
-                         triggers="click"
-                         tooltipClass="search-tips"
-                         placement="bottom top"
-                         [stopNativeClickPropagation]="false"
-              >
-                <i class="fa-regular fa-circle-question fa-xs"></i>
-              </tc-button>
+              <div class="ai-control-label">
+                <tc-label size="sm" class="form-label" for="lexicalWeight">How should AI match candidates?</tc-label>
+                <tc-button [type]="'plain'"
+                           class="tool-tip-button"
+                           ngbTooltip="Lexical vs Semantic matching. Enter a value between 0 and 1. The default is 0.5, which is Balanced and means that the lexical score is equally important as the semantic score. Exact requirements gives more weight to lexical matching. Related experience gives more weight to semantic matching."
+                           triggers="click"
+                           tooltipClass="search-tips"
+                           placement="bottom top"
+                           [stopNativeClickPropagation]="false"
+                >
+                  <i class="fa-regular fa-circle-question fa-xs"></i>
+                </tc-button>
+              </div>
 
               <div class="ai-match-slider-row">
                 <span>Related experience</span>
@@ -221,16 +223,18 @@
 
             <!-- Number of matches requested -->
             <div class="ai-candidates-control">
-              <tc-label size="sm" class="form-label" for="nMatches">Number of matches</tc-label>
-              <tc-button type="plain"
-                         class="tool-tip-button"
-                         ngbTooltip="Best N candidates. Defaults to current page size."
-                         triggers="click"
-                         tooltipClass="search-tips keyword"
-                         [stopNativeClickPropagation]="false"
-              >
-                <i class="fa-regular fa-circle-question fa-xs"></i>
-              </tc-button>
+              <div class="ai-control-label">
+                <tc-label size="sm" class="form-label" for="nMatches">Number of matches</tc-label>
+                <tc-button type="plain"
+                           class="tool-tip-button"
+                           ngbTooltip="Best N candidates. Defaults to current page size."
+                           triggers="click"
+                           tooltipClass="search-tips keyword"
+                           [stopNativeClickPropagation]="false"
+                >
+                  <i class="fa-regular fa-circle-question fa-xs"></i>
+                </tc-button>
+              </div>
               <tc-input
                 id="nMatches"
                 type="number"
@@ -240,8 +244,7 @@
 
             <!-- Model selection and details -->
             <div class="ai-model-control">
-
-              <div>
+              <div class="ai-control-label">
                 <tc-label size="sm" class="form-label" for="modelKey">Model Key</tc-label>
                 <tc-button type="plain"
                            class="tool-tip-button"
@@ -252,18 +255,17 @@
                 >
                   <i class="fa-regular fa-circle-question fa-xs"></i>
                 </tc-button>
-                <ng-select
-                  class="tc-select"
-                  id="modelKey"
-                  bindLabel="modelKey"
-                  bindValue="modelKey"
-                  [items]="embeddingModels"
-                  [searchable]="false"
-                  placeholder="Select"
-                  formControlName="modelKey">
-                </ng-select>
               </div>
-
+              <ng-select
+                class="tc-select"
+                id="modelKey"
+                bindLabel="modelKey"
+                bindValue="modelKey"
+                [items]="embeddingModels"
+                [searchable]="false"
+                placeholder="Select"
+                formControlName="modelKey">
+              </ng-select>
             </div>
 
             <div *ngIf="hasEmbeddingModel()" class="ai-model-summary-row">

--- a/ui/admin-portal/src/app/components/search/define-search/define-search.component.scss
+++ b/ui/admin-portal/src/app/components/search/define-search/define-search.component.scss
@@ -287,9 +287,9 @@ $candidate-card-width: 375px;
 .ai-matching-controls {
   margin-top: 1rem;
   display: grid;
-  grid-template-columns: 2.2fr 0.8fr auto;
+  grid-template-columns: 2.2fr 0.5fr auto;
   align-items: start;
-  column-gap: 1.25rem;
+  column-gap: 2rem;
   row-gap: 0.125rem;
   padding: 1rem 1.25rem;
   border-radius: 0.75rem;
@@ -298,6 +298,11 @@ $candidate-card-width: 375px;
 
 .ai-match-style-control {
   min-width: 16rem;
+}
+
+.ai-control-label {
+  display: flex;
+  align-items: center;
 }
 
 .ai-match-slider-row {
@@ -309,8 +314,8 @@ $candidate-card-width: 375px;
   > span {
     @include paragraph-xs;
     @include text-color-secondary;
-    max-width: 5.5rem;
     white-space: normal;
+    flex-shrink: 1;
   }
 
 }
@@ -335,7 +340,6 @@ $candidate-card-width: 375px;
 }
 
 .ai-candidates-control {
-  min-width: 8rem;
 
   .form-label {
     white-space: nowrap;
@@ -347,7 +351,7 @@ $candidate-card-width: 375px;
 }
 
 .ai-model-control {
-  width: 12rem;
+  width: 18rem;
 }
 
 .ai-model-summary-row {

--- a/ui/admin-portal/src/app/components/search/define-search/define-search.component.spec.ts
+++ b/ui/admin-portal/src/app/components/search/define-search/define-search.component.spec.ts
@@ -326,16 +326,6 @@ describe('DefineSearchComponent', () => {
     expect(component.searchIsElastic).toBeFalse();
   });
 
-  it('should mark requirements as having received input once, even after clearing', () => {
-    expect(component.hasEverHadRequirementsInput).toBeFalse();
-
-    component.searchForm.get('requirements').patchValue('some job description');
-    expect(component.hasEverHadRequirementsInput).toBeTrue();
-
-    component.searchForm.get('requirements').patchValue('');
-    expect(component.hasEverHadRequirementsInput).toBeTrue();
-  });
-
   it('should initialize lookup data, models, user and form change output', fakeAsync(() => {
     spyOn(component.onFormChange, 'emit');
 

--- a/ui/admin-portal/src/app/components/search/define-search/define-search.component.ts
+++ b/ui/admin-portal/src/app/components/search/define-search/define-search.component.ts
@@ -134,9 +134,6 @@ export class DefineSearchComponent implements OnInit, OnChanges, AfterViewInit {
   loading: boolean;
   searchForm: UntypedFormGroup;
   showSearchRequest: boolean = false;
-  //Once the user has typed any requirements text, the AI input's highlight animation
-  //stops - even if they later clear the field back to empty.
-  hasEverHadRequirementsInput: boolean = false;
   results: SearchResults<Candidate>;
   savedSearchId;
 
@@ -269,14 +266,6 @@ export class DefineSearchComponent implements OnInit, OnChanges, AfterViewInit {
       //If nMatches is undefined, don't change pageSize
       this.pageSize = this.searchForm.controls.nMatches.value || this.pageSize;
     })
-
-    //Once requirements has held any text, stop treating the field as "empty" for
-    //highlighting purposes - even if the user clears it again afterwards.
-    this.searchForm.controls.requirements.valueChanges.pipe(
-      first(value => !!value?.trim())
-    ).subscribe(() => {
-      this.hasEverHadRequirementsInput = true;
-    });
   }
 
   ngOnInit() {


### PR DESCRIPTION
Quick summary:
- Expanded the AI matching input to the full available width.
- Horizontally aligned the matching controls and increased their spacing.
- Made the border animation run while requirements are empty and stop once text is entered.

<img width="1336" height="498" alt="Screenshot 2026-09-01 at 1 11 47 AM" src="https://github.com/user-attachments/assets/fed2fa19-aab2-48e3-b775-e9d519de7abe" />

