### PR TITLE
Sadat/tc 1459 document talent catalogs origin partners and current

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,9 +2,11 @@
 
 First of all, thank you for considering contributing to the Talent Catalog. 
 
-Talent Catalog was created by Talent Beyond Boundaries (TBB) and is now shared, open-source
-software used by TBB and other labour mobility partners, including the Global Refugee Network
-(GRN). This GitHub repository is currently maintained by Open Pathway Collective (OPC) — see
+Talent Catalog was created by Talent Beyond Boundaries (TBB), with the original engineering
+team's work made possible by philanthropic funding from the Cameron Foundation, a continuing
+primary funder. TC is now shared, open-source software used by TBB and other labour mobility
+partners, including the Global Refugee Network (GRN). This GitHub repository is currently
+maintained by Open Pathway Collective (OPC) — see
 [Origin and Maintainers](README.md#origin-and-maintainers) in the README for more.
 
 [Please read and abide by our Code of Conduct](CODE_OF_CONDUCT.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,11 @@
 
 First of all, thank you for considering contributing to the Talent Catalog. 
 
+Talent Catalog was created by Talent Beyond Boundaries (TBB) and is now shared, open-source
+software used by TBB and other labour mobility partners, including the Global Refugee Network
+(GRN). This GitHub repository is currently maintained by Open Pathway Collective (OPC) — see
+[Origin and Maintainers](README.md#origin-and-maintainers) in the README for more.
+
 [Please read and abide by our Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## Code Style ##

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,8 @@ First of all, thank you for considering contributing to the Talent Catalog.
 Talent Catalog was created by Talent Beyond Boundaries (TBB), with the original engineering
 team's work made possible by philanthropic funding from the Cameron Foundation, a continuing
 primary funder. TC is now shared, open-source software used by TBB and other labour mobility
-partners, including the Global Refugee Network (GRN). This GitHub repository is currently
+partners, as well as by the Global Refugee Network (GRN), a broader global network serving
+refugees more generally. This GitHub repository is currently
 maintained by Open Pathway Collective (OPC) — see
 [Origin and Maintainers](README.md#origin-and-maintainers) in the README for more.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@
 ## Origin and Maintainers ##
 
 Talent Catalog was created by [Talent Beyond Boundaries](https://talentbeyondboundaries.org)
-(TBB), which remains a core partner and operator of the platform.
+(TBB), which remains a core partner and operator of the platform. The original software
+engineering team was made possible by the philanthropic support of the Cameron Foundation,
+which remains an active, primary funder of the project.
 
 Talent Catalog is now shared, open-source software, used by TBB and by other labour mobility
 partners, including the Global Refugee Network (GRN).

--- a/README.md
+++ b/README.md
@@ -2,6 +2,22 @@
 
 [![codecov](https://codecov.io/gh/Talent-Catalog/talentcatalog/graph/badge.svg?token=7VD4PDE12R)](https://codecov.io/gh/Talent-Catalog/talentcatalog)
 
+## Origin and Maintainers ##
+
+Talent Catalog was created by [Talent Beyond Boundaries](https://talentbeyondboundaries.org)
+(TBB), which remains a core partner and operator of the platform.
+
+Talent Catalog is now shared, open-source software, used by TBB and by other labour mobility
+partners, including the Global Refugee Network (GRN).
+
+This GitHub repository is currently maintained by
+[Open Pathway Collective](https://openpathwaycollective.org/) (OPC), which is the primary
+active contributor to the codebase.
+
+For questions about this repository, contact OPC at
+[support@talentcatalog.net](mailto:support@talentcatalog.net) or via
+[openpathwaycollective.org](https://openpathwaycollective.org/).
+
 ## Overview ##
 
 This is the repository for the Talent Catalog (TC), which manages data

--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@
 
 Talent Catalog was created by [Talent Beyond Boundaries](https://talentbeyondboundaries.org)
 (TBB), which remains a core partner and operator of the platform. The original software
-engineering team was made possible by the philanthropic support of the Cameron Foundation,
-which remains an active, primary funder of the project.
+engineering team was made possible by the philanthropic support of the
+[Cameron Foundation](https://cameronfoundation.org/), which remains an active, primary funder
+of the project.
 
 Talent Catalog is now shared, open-source software, used by TBB and by other labour mobility
 partners, including the Global Refugee Network (GRN).

--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ engineering team was made possible by the philanthropic support of the
 [Cameron Foundation](https://cameronfoundation.org/), which remains an active, primary funder
 of the project.
 
-Talent Catalog is now shared, open-source software, used by TBB and by other labour mobility
-partners, including the Global Refugee Network (GRN).
+Talent Catalog is now shared, open-source software, used by TBB and other labour mobility
+partners, as well as by the Global Refugee Network (GRN), a broader global network serving
+refugees more generally.
 
 This GitHub repository is currently maintained by
 [Open Pathway Collective](https://openpathwaycollective.org/) (OPC), which is the primary


### PR DESCRIPTION
This PR -

- Updates the project documentation to provide more context about the origin, funding, and current maintainers of the Talent Catalog.
- These changes aim to clarify the history of the project and identify the organizations involved in its ongoing development and support.