### PR TITLE
AI Matching fails with SQL error when no skills are extracted and Keyword Search is populated

### DIFF
--- a/server/src/main/java/org/tctalent/server/repository/db/matching/CandidateBestNMatchingRepository.java
+++ b/server/src/main/java/org/tctalent/server/repository/db/matching/CandidateBestNMatchingRepository.java
@@ -124,6 +124,13 @@ public class CandidateBestNMatchingRepository {
 
         // A SQL bind parameter cannot represent an identifier.
         // The table name is inserted into the string using the String.formatted method call below.
+
+        // Note that there is deliberately no join or occupation predicate associated with
+        // computing the semantic pool.
+        // That could prevent PostgreSQL from making the best use of`the special HNSW index
+        // generated for vector embeddings.
+        // The semantic pool is computed first, and then the constraints are applied to the
+        // semantic candidates.
         return """
             WITH lexical_candidate_scores AS (
             """
@@ -146,8 +153,6 @@ public class CandidateBestNMatchingRepository {
                 LIMIT :candidateLimit
             ),
             semantic_pool AS (
-                -- Deliberately no join or occupation predicate here: this exact nearest-neighbour
-                -- ORDER BY/LIMIT shape gives PostgreSQL the best opportunity to use the HNSW index.
                 SELECT candidate_job_experience_id,
                        embedding <=> CAST(:queryEmbedding AS vector(%d)) AS distance
                 FROM %s

--- a/server/src/main/java/org/tctalent/server/service/db/impl/CandidateBestNMatchingServiceImpl.java
+++ b/server/src/main/java/org/tctalent/server/service/db/impl/CandidateBestNMatchingServiceImpl.java
@@ -149,18 +149,24 @@ public class CandidateBestNMatchingServiceImpl implements CandidateBestNMatching
 
     /**
      * Computes a filtered skills query by ANDing the skillsQueryString with the
-     * extraFilteringKeywords if it is not empty.
+     * extraFilteringKeywords if they are both not empty.
      * @param skillsQueryString The skills query string.
      * @param extraFilteringKeywords The extra filtering keywords.
      * @return The filtered skills query.
      */
     private String computeFilteredSkillsQuery(
         String skillsQueryString, String extraFilteringKeywords) {
-        if (StringUtils.hasText(extraFilteringKeywords)) {
-            return "(" + skillsQueryString + ") + (" + extraFilteringKeywords + ")";
+        String query;
+        if (StringUtils.hasText(skillsQueryString) && StringUtils.hasText(extraFilteringKeywords)) {
+            query = "(" + skillsQueryString.strip() + ") + (" + extraFilteringKeywords.strip() + ")";
+        } else if (StringUtils.hasText(skillsQueryString)) {
+            query = skillsQueryString.strip();
+        } else if (StringUtils.hasText(extraFilteringKeywords)) {
+            query = extraFilteringKeywords.strip();
         } else {
-            return skillsQueryString;
+            query = "";
         }
+        return query;
     }
 
     private List<IdAndScore> convertResults(List<CandidateBestNMatchingResult> results) {


### PR DESCRIPTION
Remove doc comments from inside SQL query.
Handle all edges cases in computeFilteredSkillsQuery related to combined text queries.