### PR TITLE
Sadat/tc 1466 feature verify 51 show verify scanned on the admin candidate

### DIFF
--- a/server/src/main/java/org/tctalent/server/api/dto/CandidateBuilderSelector.java
+++ b/server/src/main/java/org/tctalent/server/api/dto/CandidateBuilderSelector.java
@@ -183,6 +183,8 @@ public class CandidateBuilderSelector {
             .add("unhcrNumber")
             .add("unhcrStatus")
             .add("unhcrConsent")
+            .add("verifyPlusConsented")
+            .add("verifyPlusConsentedAt")
             .add("unrwaRegistered")
             .add("unrwaNumber")
             .add("mediaWillingness")

--- a/server/src/test/java/org/tctalent/server/api/dto/CandidateBuilderSelectorTest.java
+++ b/server/src/test/java/org/tctalent/server/api/dto/CandidateBuilderSelectorTest.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -306,7 +307,7 @@ class CandidateBuilderSelectorTest {
 
     var b = selector.selectBuilder(DtoType.API);
 
-    Map<String, Object> src = Map.of(
+    Map<String, Object> src = new HashMap<>(Map.of(
         "country", country("PK", "Pakistan"),
         "nationality", country("GB", "United Kingdom"),
         "candidateDestinations", List.of(
@@ -339,12 +340,16 @@ class CandidateBuilderSelectorTest {
         ),
         "relocatedCountry", country("SE", "Sweden"),
         "partnerOccupation", occupation(222L, "Architect")
-    );
+    ));
+    src.put("verifyPlusConsented", true);
+    src.put("verifyPlusConsentedAt", "2026-09-04T11:05:00Z");
 
     Map<String, Object> out = b.build(src);
 
     // spot-check a few extended/API structures
     assertMapEquals(country("PK", "Pakistan"), out.get("country"));
+    assertEquals(true, out.get("verifyPlusConsented"));
+    assertEquals("2026-09-04T11:05:00Z", out.get("verifyPlusConsentedAt"));
 
     var dests = listOfMaps(out.get("candidateDestinations"));
     assertMapEquals(country("DE", "Germany"), dests.get(0).get("country"));

--- a/ui/admin-portal/src/app/MockData/MockCandidate.ts
+++ b/ui/admin-portal/src/app/MockData/MockCandidate.ts
@@ -62,6 +62,8 @@ export class MockCandidate implements Candidate {
   unhcrRegistered: YesNoUnsure = YesNoUnsure.Yes;
   unhcrNumber: string = "UNHCR123";
   unhcrConsent: YesNo = YesNo.Yes;
+  verifyPlusConsented: boolean = false;
+  verifyPlusConsentedAt: string = null;
   unrwaRegistered: YesNoUnsure = YesNoUnsure.No;
   unrwaNumber: string = "123";
   user: any = mockUser;

--- a/ui/admin-portal/src/app/components/candidates/view/registration/view-candidate-registration.component.html
+++ b/ui/admin-portal/src/app/components/candidates/view/registration/view-candidate-registration.component.html
@@ -83,7 +83,7 @@
         ></span>
         <tc-badge *ngIf="candidate.verifyPlusConsented"
                   color="blue"
-                  [ngbTooltip]="'Verify+ card scanned on ' + (candidate.verifyPlusConsentedAt | date: 'customDateTime')"
+                  [ngbTooltip]="verifyPlusScanTooltip"
                   container="body"
         >
           Verify+ scan

--- a/ui/admin-portal/src/app/components/candidates/view/registration/view-candidate-registration.component.html
+++ b/ui/admin-portal/src/app/components/candidates/view/registration/view-candidate-registration.component.html
@@ -75,11 +75,20 @@
     <tc-description-item [label]="'UNHCR Registered'"
                          [icon]="'far fa-registered'"
     >
-      <span>{{candidate.unhcrRegistered}}</span>
-      <span *ngIf="candidate.unhcrNumber && candidate.unhcrRegistered === 'Yes'"
-            [innerHtml]="' - #' + candidate.unhcrNumber"
-            appHighlightSearch
-      ></span>
+      <div class="unhcr-registered-details">
+        <span>{{candidate.unhcrRegistered}}</span>
+        <span *ngIf="candidate.unhcrNumber && candidate.unhcrRegistered === 'Yes'"
+              [innerHtml]="' - #' + candidate.unhcrNumber"
+              appHighlightSearch
+        ></span>
+        <tc-badge *ngIf="candidate.verifyPlusConsented"
+                  color="blue"
+                  [ngbTooltip]="'Verify+ card scanned on ' + (candidate.verifyPlusConsentedAt | date: 'customDateTime')"
+                  container="body"
+        >
+          Verify+ scan
+        </tc-badge>
+      </div>
     </tc-description-item>
 
     <tc-description-item [label]="'UNRWA Registered'"

--- a/ui/admin-portal/src/app/components/candidates/view/registration/view-candidate-registration.component.scss
+++ b/ui/admin-portal/src/app/components/candidates/view/registration/view-candidate-registration.component.scss
@@ -14,3 +14,10 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
+.unhcr-registered-details {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+

--- a/ui/admin-portal/src/app/components/candidates/view/registration/view-candidate-registration.component.spec.ts
+++ b/ui/admin-portal/src/app/components/candidates/view/registration/view-candidate-registration.component.spec.ts
@@ -15,8 +15,9 @@
  */
 import {ViewCandidateRegistrationComponent} from "./view-candidate-registration.component";
 import {ComponentFixture, TestBed} from "@angular/core/testing";
+import {CUSTOM_ELEMENTS_SCHEMA} from "@angular/core";
 import {CandidateService} from "../../../../services/candidate.service";
-import {NgbModal} from "@ng-bootstrap/ng-bootstrap";
+import {NgbModal, NgbTooltipModule} from "@ng-bootstrap/ng-bootstrap";
 import {MockCandidate} from "../../../../MockData/MockCandidate";
 
 describe('ViewCandidateRegistrationComponent', () => {
@@ -30,11 +31,13 @@ describe('ViewCandidateRegistrationComponent', () => {
     const modalServiceSpy = jasmine.createSpyObj('NgbModal', ['open']);
 
     await TestBed.configureTestingModule({
+      imports: [NgbTooltipModule],
       declarations: [ViewCandidateRegistrationComponent],
       providers: [
         { provide: CandidateService, useValue: candidateServiceSpy },
         { provide: NgbModal, useValue: modalServiceSpy }
-      ]
+      ],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA]
     }).compileComponents();
 
     candidateService = TestBed.inject(CandidateService) as jasmine.SpyObj<CandidateService>;
@@ -50,5 +53,25 @@ describe('ViewCandidateRegistrationComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should show Verify+ scan badge when verify plus consent exists', () => {
+    component.candidate.verifyPlusConsented = true;
+    component.candidate.verifyPlusConsentedAt = '2026-09-04T11:05:00Z';
+    fixture.detectChanges();
+
+    const badgeEl: HTMLElement = fixture.nativeElement.querySelector('tc-badge');
+    expect(badgeEl).not.toBeNull();
+    expect(badgeEl.textContent).toContain('Verify+ scan');
+    expect(badgeEl.getAttribute('ng-reflect-ngb-tooltip')).toContain('Verify+ card scanned on');
+  });
+
+  it('should hide Verify+ scan badge when verify plus consent is false', () => {
+    component.candidate.verifyPlusConsented = false;
+    component.candidate.verifyPlusConsentedAt = null;
+    fixture.detectChanges();
+
+    const badgeEl: HTMLElement = fixture.nativeElement.querySelector('tc-badge');
+    expect(badgeEl).toBeNull();
   });
 });

--- a/ui/admin-portal/src/app/components/candidates/view/registration/view-candidate-registration.component.spec.ts
+++ b/ui/admin-portal/src/app/components/candidates/view/registration/view-candidate-registration.component.spec.ts
@@ -16,8 +16,10 @@
 import {ViewCandidateRegistrationComponent} from "./view-candidate-registration.component";
 import {ComponentFixture, TestBed} from "@angular/core/testing";
 import {CUSTOM_ELEMENTS_SCHEMA} from "@angular/core";
+import {DatePipe} from "@angular/common";
+import {By} from "@angular/platform-browser";
 import {CandidateService} from "../../../../services/candidate.service";
-import {NgbModal, NgbTooltipModule} from "@ng-bootstrap/ng-bootstrap";
+import {NgbModal, NgbTooltip, NgbTooltipModule} from "@ng-bootstrap/ng-bootstrap";
 import {MockCandidate} from "../../../../MockData/MockCandidate";
 
 describe('ViewCandidateRegistrationComponent', () => {
@@ -34,6 +36,7 @@ describe('ViewCandidateRegistrationComponent', () => {
       imports: [NgbTooltipModule],
       declarations: [ViewCandidateRegistrationComponent],
       providers: [
+        DatePipe,
         { provide: CandidateService, useValue: candidateServiceSpy },
         { provide: NgbModal, useValue: modalServiceSpy }
       ],
@@ -63,7 +66,25 @@ describe('ViewCandidateRegistrationComponent', () => {
     const badgeEl: HTMLElement = fixture.nativeElement.querySelector('tc-badge');
     expect(badgeEl).not.toBeNull();
     expect(badgeEl.textContent).toContain('Verify+ scan');
-    expect(badgeEl.getAttribute('ng-reflect-ngb-tooltip')).toContain('Verify+ card scanned on');
+
+    const tooltip = fixture.debugElement.query(By.directive(NgbTooltip))
+      .injector.get(NgbTooltip);
+    expect(tooltip.ngbTooltip).toBe(component.verifyPlusScanTooltip);
+    expect(tooltip.ngbTooltip).toContain('Verify+ card scanned on');
+  });
+
+  it('should show date-unavailable tooltip when scan timestamp is missing', () => {
+    component.candidate.verifyPlusConsented = true;
+    component.candidate.verifyPlusConsentedAt = null;
+    fixture.detectChanges();
+
+    const badgeEl: HTMLElement = fixture.nativeElement.querySelector('tc-badge');
+    expect(badgeEl).not.toBeNull();
+    expect(badgeEl.textContent).toContain('Verify+ scan');
+
+    const tooltip = fixture.debugElement.query(By.directive(NgbTooltip))
+      .injector.get(NgbTooltip);
+    expect(tooltip.ngbTooltip).toBe('Verify+ card scan date unavailable');
   });
 
   it('should hide Verify+ scan badge when verify plus consent is false', () => {

--- a/ui/admin-portal/src/app/components/candidates/view/registration/view-candidate-registration.component.ts
+++ b/ui/admin-portal/src/app/components/candidates/view/registration/view-candidate-registration.component.ts
@@ -15,6 +15,7 @@
  */
 
 import {Component, Input, OnInit} from '@angular/core';
+import {DatePipe} from "@angular/common";
 import {Candidate} from "../../../../model/candidate";
 import {NgbModal} from "@ng-bootstrap/ng-bootstrap";
 import {EditCandidateRegistrationComponent} from "./edit/edit-candidate-registration.component";
@@ -36,10 +37,22 @@ export class ViewCandidateRegistrationComponent implements OnInit {
   error;
 
   constructor(private modalService: NgbModal,
-              private candidateService: CandidateService) { }
+              private candidateService: CandidateService,
+              private datePipe: DatePipe) { }
 
   ngOnInit() {
 
+  }
+
+  get verifyPlusScanTooltip(): string {
+    const scannedAt = this.candidate?.verifyPlusConsentedAt;
+    if (!scannedAt) {
+      return 'Verify+ card scan date unavailable';
+    }
+    const formatted = this.datePipe.transform(scannedAt, 'yyyy-MM-dd, h:mm:ss a');
+    return formatted
+      ? `Verify+ card scanned on ${formatted}`
+      : 'Verify+ card scan date unavailable';
   }
 
   editRegistrationDetails() {

--- a/ui/admin-portal/src/app/components/candidates/view/tab/candidate-general-tab/candidate-general-tab.component.spec.ts
+++ b/ui/admin-portal/src/app/components/candidates/view/tab/candidate-general-tab/candidate-general-tab.component.spec.ts
@@ -26,6 +26,7 @@ import {FormsModule, ReactiveFormsModule} from "@angular/forms";
 import {NgSelectModule} from "@ng-select/ng-select";
 import {ViewCandidateAccountComponent} from "../../account/view-candidate-account.component";
 import {CUSTOM_ELEMENTS_SCHEMA} from "@angular/core";
+import {DatePipe} from "@angular/common";
 import {RouterTestingModule} from "@angular/router/testing";
 
 describe('CandidateGeneralTabComponent', () => {
@@ -36,6 +37,7 @@ describe('CandidateGeneralTabComponent', () => {
     await TestBed.configureTestingModule({
       imports: [HttpClientTestingModule,FormsModule,ReactiveFormsModule, NgSelectModule,RouterTestingModule],
       declarations: [ CandidateGeneralTabComponent,ViewCandidateLanguageComponent,ViewCandidateAccountComponent,ViewCandidateRegistrationComponent,ViewCandidateContactComponent ],
+      providers: [DatePipe],
       schemas: [CUSTOM_ELEMENTS_SCHEMA]
     })
     .compileComponents();

--- a/ui/admin-portal/src/app/model/candidate.ts
+++ b/ui/admin-portal/src/app/model/candidate.ts
@@ -70,6 +70,8 @@ export interface Candidate extends HasId {
   unhcrRegistered: YesNoUnsure;
   unhcrNumber: string;
   unhcrConsent: YesNo;
+  verifyPlusConsented?: boolean;
+  verifyPlusConsentedAt?: string;
   unrwaRegistered: YesNoUnsure;
   unrwaNumber: string;
   user: User;


### PR DESCRIPTION
Adds support for displaying a “Verify+ scan” indicator in the Admin Portal candidate registration view by plumbing new Verify+ consent fields through the server DTO layer and exposing them in the UI.

**Changes:**
- Added `verifyPlusConsented` and `verifyPlusConsentedAt` fields to the UI Candidate model and mock data.
- Extended server-side candidate DTO building (and tests) to include the new fields.
- Updated the candidate registration view to render a “Verify+ scan” badge with a tooltip and added accompanying UI unit tests and styling.