### PR TITLE
Ehsan/tc 1161 update GitHub actions to versions compatible with nodejs 24

### DIFF
--- a/.github/workflows/perf-nightly.yml
+++ b/.github/workflows/perf-nightly.yml
@@ -29,10 +29,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: nightly-shards
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Download all summaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: perf-summary-nightly-shard-*
           path: all-summaries
@@ -50,7 +50,7 @@ jobs:
 
       - name: Upload combined summaries
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: perf-summary-nightly-all
           path: all-summaries

--- a/.github/workflows/tc-admin-portal-test.yml
+++ b/.github/workflows/tc-admin-portal-test.yml
@@ -29,11 +29,11 @@ jobs:
     steps:
       # Step 1: Checkout the repository
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       # Step 2: Set up Node.js for Angular using version from .nvmrc
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
@@ -53,7 +53,7 @@ jobs:
 
       # Step 5: Upload the report to codecov
       - name: Upload Admin Portal coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./ui/admin-portal/coverage/lcov.info
@@ -65,7 +65,7 @@ jobs:
       # Step 6: Archive test results if tests fail
       - name: Archive test results
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: admin-portal-test-results
           path: |

--- a/.github/workflows/tc-build.yml
+++ b/.github/workflows/tc-build.yml
@@ -20,10 +20,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Java 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: 'zulu'
           java-version: '17'
@@ -32,7 +32,7 @@ jobs:
         run: chmod +x gradlew
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_TEST }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_TEST }}
@@ -51,7 +51,7 @@ jobs:
 
       - name: Upload test report on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-report
           path: server/build/reports/tests/test

--- a/.github/workflows/tc-candidate-portal-e2e.yml
+++ b/.github/workflows/tc-candidate-portal-e2e.yml
@@ -51,10 +51,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version-file: '.nvmrc'
           cache: npm
@@ -71,7 +71,7 @@ jobs:
 
       - name: Upload Playwright artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: candidate-portal-playwright-${{ github.run_id }}
           path: |

--- a/.github/workflows/tc-candidate-portal-test.yml
+++ b/.github/workflows/tc-candidate-portal-test.yml
@@ -34,10 +34,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version-file: '.nvmrc'
           cache: npm
@@ -52,7 +52,7 @@ jobs:
           CI: true
 
       - name: Upload Candidate Portal coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./ui/candidate-portal/coverage/lcov.info
@@ -63,7 +63,7 @@ jobs:
 
       - name: Archive test results
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: candidate-portal-test-results
           path: |

--- a/.github/workflows/tc-gatling-tests.yml
+++ b/.github/workflows/tc-gatling-tests.yml
@@ -43,14 +43,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Ensure Gradle cache dir exists
         run: |
           mkdir -p .gradle-cache/caches .gradle-cache/wrapper
 
       - name: Restore Gradle cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             .gradle-cache/caches
@@ -113,7 +113,7 @@ jobs:
             --strict-percentile p95
       - name: Upload Gatling HTML reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: gatling-reports-${{ inputs.tier }}-shard-${{ inputs.shard_index }}
           path: perf-reports
@@ -121,7 +121,7 @@ jobs:
 
       - name: Upload perf summaries (json/md)
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: perf-summary-${{ inputs.tier }}-shard-${{ inputs.shard_index }}
           path: perf-summary
@@ -129,7 +129,7 @@ jobs:
 
       - name: Upload raw simulation logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: perf-raw-${{ inputs.tier }}-shard-${{ inputs.shard_index }}
           path: perf-raw

--- a/.github/workflows/tc-prod-build-deploy.yml
+++ b/.github/workflows/tc-prod-build-deploy.yml
@@ -32,10 +32,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Java 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: 'zulu'
           java-version: '17'
@@ -49,7 +49,7 @@ jobs:
       # --- Build and Test ---
 
       - name: Configure AWS credentials for test resources
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -74,10 +74,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Java 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: 'zulu'
           java-version: '17'
@@ -89,7 +89,7 @@ jobs:
         run: chmod +x gradlew
 
       - name: Configure AWS credentials for TBB
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -99,7 +99,7 @@ jobs:
         run: ./gradlew jib -Ptbb-prod -x test
 
       - name: Configure AWS credentials for OPC
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
            aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_OPC_PROD }}
            aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_OPC_PROD }}
@@ -117,10 +117,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Java 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: 'zulu'
           java-version: '17'
@@ -132,7 +132,7 @@ jobs:
         run: chmod +x gradlew
 
       - name: Configure AWS credentials for GRN
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_OPC_PROD }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_OPC_PROD }}

--- a/.github/workflows/tc-public-portal-test.yml
+++ b/.github/workflows/tc-public-portal-test.yml
@@ -34,10 +34,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version-file: '.nvmrc'
           cache: npm
@@ -52,7 +52,7 @@ jobs:
           CI: true
 
       - name: Upload Public Portal coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./ui/public-portal/coverage/lcov.info
@@ -63,7 +63,7 @@ jobs:
 
       - name: Archive test results
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: public-portal-test-results
           path: |

--- a/.github/workflows/tc-test-build-deploy.yml
+++ b/.github/workflows/tc-test-build-deploy.yml
@@ -56,7 +56,7 @@ jobs:
         run: ./gradlew clean :server:test :server:jacocoTestReport --stacktrace --rerun-tasks
 
       - name: Upload server coverage to Codecov
-        uses: codecov/codecov-action@v7@
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./server/build/reports/jacoco/test/jacocoTestReport.xml

--- a/.github/workflows/tc-test-build-deploy.yml
+++ b/.github/workflows/tc-test-build-deploy.yml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Java 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: 'zulu'
           java-version: '17'
@@ -38,7 +38,7 @@ jobs:
       # --- Build and Test ---
 
       - name: Configure AWS credentials for test resources
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_TEST }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_TEST }}
@@ -56,7 +56,7 @@ jobs:
         run: ./gradlew clean :server:test :server:jacocoTestReport --stacktrace --rerun-tasks
 
       - name: Upload server coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7@
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./server/build/reports/jacoco/test/jacocoTestReport.xml
@@ -68,7 +68,7 @@ jobs:
       # --- Deploy to TBB Staging (us-east-1) ---
 
       - name: Configure AWS credentials for TBB
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_TEST }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_TEST }}
@@ -80,7 +80,7 @@ jobs:
       # --- Deploy to OPC Staging (eu-west-2) ---
 
       - name: Configure AWS credentials for OPC
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_OPC_STAGING }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_OPC_STAGING }}

--- a/.github/workflows/tc-ui-amplify-pr-preview.yaml
+++ b/.github/workflows/tc-ui-amplify-pr-preview.yaml
@@ -63,7 +63,7 @@ jobs:
           done
           echo "::set-output name=broken_ids::${broken_urls[@]}"
       - name: Delete or notify if any preview link is broken
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         if: steps.check-links.outputs.broken_ids != ''
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tc-ui-amplify-pr-preview.yaml
+++ b/.github/workflows/tc-ui-amplify-pr-preview.yaml
@@ -16,7 +16,7 @@ jobs:
           sleep 90
       - name: Get Amplify preview URLs from comments
         id: get-preview-urls
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/terraform-deploy.yml
+++ b/.github/workflows/terraform-deploy.yml
@@ -36,10 +36,10 @@ jobs:
 
 #      # Checkout the repository to the GitHub Actions runner
 #      - name: Checkout
-#        uses: actions/checkout@v3
+#        uses: actions/checkout@v7
 #
 #      - name: Setup AWS credentials
-#        uses: aws-actions/configure-aws-credentials@v2
+#        uses: aws-actions/configure-aws-credentials@v6
 #        with:
 #          aws-access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}
 #          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_DEV }}
@@ -48,7 +48,7 @@ jobs:
 #      # Install the latest version of Terraform CLI and configure the Terraform
 #      # CLI configuration file with a Terraform Cloud user API token
 #      - name: Setup Terraform
-#        uses: hashicorp/setup-terraform@v2
+#        uses: hashicorp/setup-terraform@v4
 #        with:
 #          terraform_version: ${{ env.TERRAFORM_VERSION }}
 #

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -30,10 +30,10 @@ jobs:
     steps:
       # Checkout the repository to the GitHub Actions runner
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_DEV }}
@@ -42,7 +42,7 @@ jobs:
       # Install the latest version of Terraform CLI and configure the Terraform
       # CLI configuration file with a Terraform Cloud user API token
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v2
+        uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
 
@@ -74,7 +74,7 @@ jobs:
         working-directory: ${{ env.INFRA_PATH }}
 
       - name: Update Pull Request
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         env:
           PLAN: "terraform\n${{ steps.plan.outputs.stdout }}"
         with:


### PR DESCRIPTION
## Summary

Updates GitHub Actions dependencies to versions compatible with Node.js 24 and removes reliance on deprecated Node.js 20-based action runtimes.

This is a CI/CD maintenance change only. No application code or application runtime configuration is changed.

## Changes

* Updated `actions/checkout` to `v7`
* Updated `actions/setup-node` to `v7`
* Updated `actions/setup-java` to `v6`
* Updated `actions/cache` to `v6`
* Updated `aws-actions/configure-aws-credentials` to `v6`
* Updated `actions/upload-artifact` to `v7`
* Updated `actions/download-artifact` to `v8`
* Updated `actions/github-script` to `v9`
* Updated `hashicorp/setup-terraform` to `v4`
* Updated `codecov/codecov-action` to `v7`
* Removed or cleaned up outdated action references where appropriate

## Why

GitHub Actions has migrated JavaScript actions to Node.js 24, and Node.js 20 support on hosted runners is being removed.

Updating these dependencies keeps our workflows supported and removes Node.js 20 deprecation warnings.

