### PR TITLE
Ehsan/tc-1463-make-saved-search-checkbox-label-clickable

### DIFF
--- a/ui/admin-portal/src/app/shared/components/input/input.component.spec.ts
+++ b/ui/admin-portal/src/app/shared/components/input/input.component.spec.ts
@@ -24,7 +24,7 @@ describe('InputComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [InputComponent]
+      declarations: [InputComponent,HostComponent]
     });
     fixture = TestBed.createComponent(InputComponent);
     component = fixture.componentInstance;

--- a/ui/admin-portal/src/app/shared/components/input/input.component.spec.ts
+++ b/ui/admin-portal/src/app/shared/components/input/input.component.spec.ts
@@ -1,7 +1,23 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 
-import { InputComponent } from './input.component';
+import {InputComponent} from './input.component';
 
+import {Component} from '@angular/core';
+import {By} from '@angular/platform-browser';
+
+@Component({
+  template: `
+    <tc-input
+      id="reviewable"
+      type="checkbox">
+    </tc-input>
+
+    <label for="reviewable">
+      Should result of searches be reviewable?
+    </label>
+  `
+})
+class HostComponent {}
 describe('InputComponent', () => {
   let component: InputComponent;
   let fixture: ComponentFixture<InputComponent>;
@@ -30,5 +46,33 @@ describe('InputComponent', () => {
     expect(inputEl.min).toBe('0');
     expect(inputEl.max).toBe('1');
     expect(inputEl.step).toBe('0.1');
+  });
+
+  it('should allow an external label to toggle a checkbox', () => {
+    const hostFixture = TestBed.createComponent(HostComponent);
+    hostFixture.detectChanges();
+
+    const inputComponent =
+      hostFixture.debugElement.query(By.directive(InputComponent));
+
+    const componentHost =
+      inputComponent.nativeElement as HTMLElement;
+
+    const nativeInput =
+      inputComponent.query(By.css('input')).nativeElement as HTMLInputElement;
+
+    const label =
+      hostFixture.nativeElement.querySelector(
+        'label[for="reviewable"]'
+      ) as HTMLLabelElement;
+
+    expect(componentHost.hasAttribute('id')).toBeFalse();
+    expect(nativeInput.id).toBe('reviewable');
+    expect(nativeInput.checked).toBeFalse();
+
+    label.click();
+    hostFixture.detectChanges();
+
+    expect(nativeInput.checked).toBeTrue();
   });
 });

--- a/ui/admin-portal/src/app/shared/components/input/input.component.ts
+++ b/ui/admin-portal/src/app/shared/components/input/input.component.ts
@@ -3,6 +3,7 @@ import {
   ElementRef,
   EventEmitter,
   forwardRef,
+  HostBinding,
   Input,
   OnInit,
   Output,
@@ -86,6 +87,7 @@ import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
   ]
 })
 export class InputComponent implements ControlValueAccessor, OnInit {
+  @HostBinding('attr.id') hostId = null;
   @Input() id?: string;
   @Input() ariaLabel?: string;
   @Input() name?: string;

--- a/ui/admin-portal/src/test-global-custom-elements.ts
+++ b/ui/admin-portal/src/test-global-custom-elements.ts
@@ -414,6 +414,7 @@ const REAL_COMPONENTS = new Set([
   'TcTabComponent',
   'TcTabHeaderComponent',
   'TcTabContentComponent',
+  'InputComponent',
 ]);
 
 const originalConfigure = TestBed.configureTestingModule.bind(TestBed);

--- a/ui/candidate-portal/src/app/components/common/candidate-exam-form/candidate-exam-form.component.spec.ts
+++ b/ui/candidate-portal/src/app/components/common/candidate-exam-form/candidate-exam-form.component.spec.ts
@@ -245,7 +245,7 @@ describe('CandidateExamFormComponent', () => {
       component.form.patchValue({exam: 'Other'});
       fixture.detectChanges();
 
-      expect((fixture.nativeElement as HTMLElement).querySelector('tc-input[id="otherExam"]')).toBeTruthy();
+      expect((fixture.nativeElement as HTMLElement).querySelector('tc-input input[id="otherExam"]')).toBeTruthy();
     });
   });
 

--- a/ui/candidate-portal/src/app/components/common/candidate-exam-form/candidate-exam-form.component.spec.ts
+++ b/ui/candidate-portal/src/app/components/common/candidate-exam-form/candidate-exam-form.component.spec.ts
@@ -245,7 +245,7 @@ describe('CandidateExamFormComponent', () => {
       component.form.patchValue({exam: 'Other'});
       fixture.detectChanges();
 
-      expect((fixture.nativeElement as HTMLElement).querySelector('tc-input input[id="otherExam"]')).toBeTruthy();
+      expect((fixture.nativeElement as HTMLElement).querySelector('tc-input[id="otherExam"]')).toBeTruthy();
     });
   });
 

--- a/ui/candidate-portal/src/app/shared/components/input/input.component.spec.ts
+++ b/ui/candidate-portal/src/app/shared/components/input/input.component.spec.ts
@@ -1,14 +1,29 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 
-import { InputComponent } from './input.component';
+import {InputComponent} from './input.component';
+import {Component} from '@angular/core';
+import {By} from '@angular/platform-browser';
 
+@Component({
+  template: `
+    <tc-input
+      id="reviewable"
+      type="checkbox">
+    </tc-input>
+
+    <label for="reviewable">
+      Should result of searches be reviewable?
+    </label>
+  `
+})
+class HostComponent {}
 describe('InputComponent', () => {
   let component: InputComponent;
   let fixture: ComponentFixture<InputComponent>;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [InputComponent]
+      declarations: [InputComponent, HostComponent]
     });
     fixture = TestBed.createComponent(InputComponent);
     component = fixture.componentInstance;
@@ -17,5 +32,33 @@ describe('InputComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should allow an external label to toggle a checkbox', () => {
+    const hostFixture = TestBed.createComponent(HostComponent);
+    hostFixture.detectChanges();
+
+    const inputComponent =
+      hostFixture.debugElement.query(By.directive(InputComponent));
+
+    const componentHost =
+      inputComponent.nativeElement as HTMLElement;
+
+    const nativeInput =
+      inputComponent.query(By.css('input')).nativeElement as HTMLInputElement;
+
+    const label =
+      hostFixture.nativeElement.querySelector(
+        'label[for="reviewable"]'
+      ) as HTMLLabelElement;
+
+    expect(componentHost.hasAttribute('id')).toBeFalse();
+    expect(nativeInput.id).toBe('reviewable');
+    expect(nativeInput.checked).toBeFalse();
+
+    label.click();
+    hostFixture.detectChanges();
+
+    expect(nativeInput.checked).toBeTrue();
   });
 });

--- a/ui/candidate-portal/src/app/shared/components/input/input.component.ts
+++ b/ui/candidate-portal/src/app/shared/components/input/input.component.ts
@@ -3,6 +3,7 @@ import {
   ElementRef,
   EventEmitter,
   forwardRef,
+  HostBinding,
   Input,
   OnInit,
   Output,
@@ -84,6 +85,7 @@ import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
   ]
 })
 export class InputComponent implements ControlValueAccessor, OnInit {
+  @HostBinding('attr.id') hostId = null;
   @Input() id?: string;
   @Input() ariaLabel?: string;
   @Input() name?: string;


### PR DESCRIPTION
## Summary

Fixes label-to-input associations for the shared `tc-input` component in both the Admin Portal and Candidate Portal.

This resolves the Saved Search issue where clicking the label:

> Should result of searches be reviewable?

did not toggle the associated checkbox.

## Changes

- Remove the `id` attribute from the `tc-input` host element.
- Keep the `id` on the underlying native `<input>`.
- Apply the fix in both:
  - Admin Portal
  - Candidate Portal
- Add regression tests confirming that clicking a label toggles its associated checkbox.
- Update an affected Candidate Portal test to target the native input instead of the `tc-input` host.

## Why

Previously, the same `id` could appear on both the Angular `tc-input` host and its native `<input>`.

As a result, a `<label for="...">` could target the custom component instead of the actual input.

The change ensures the `id` belongs only to the native form control, allowing standard browser label behavior to work correctly.

This follows the existing `tc-radio` implementation done by @hiba-machfej  in both Admin and Candidate portals. It ensures the id belongs to the native form control rather than the Angular component host, allowing standard label for associations to work correctly.