### PR TITLE
Sadat/tc 1477 feature verify 71 hide verify UI on production until the

### DIFF
--- a/ui/candidate-portal/docs/verify-plus/README.md
+++ b/ui/candidate-portal/docs/verify-plus/README.md
@@ -9,7 +9,9 @@ No official UNHCR sample QR is available yet, so these fixtures are intentionall
 Verify+ candidate UI surfaces are intentionally visible only for GRN instances in local and staging environments.
 
 - Services card visibility: GRN and (`local` or `staging`)
-- Registration optional scan step visibility: GRN and (`local` or `staging`)
+- Registration optional scan: shown only to GRN in local/staging.
+  On local/staging the step stays in the wizard until login/register reveals instance type; 
+  TBB then omits it (no scan screen).
 - Production (`prod`) hides both surfaces until a later UNHCR-ready release
 
 The backend ingest endpoint remains unchanged in this slice.

--- a/ui/candidate-portal/docs/verify-plus/README.md
+++ b/ui/candidate-portal/docs/verify-plus/README.md
@@ -4,6 +4,16 @@ This folder is reserved for mock, non-production QR images used to manually test
 
 No official UNHCR sample QR is available yet, so these fixtures are intentionally synthetic.
 
+## Visibility Gate (7.1)
+
+Verify+ candidate UI surfaces are intentionally visible only for GRN instances in local and staging environments.
+
+- Services card visibility: GRN and (`local` or `staging`)
+- Registration optional scan step visibility: GRN and (`local` or `staging`)
+- Production (`prod`) hides both surfaces until a later UNHCR-ready release
+
+The backend ingest endpoint remains unchanged in this slice.
+
 ## Payload Contract
 
 The current backend mock parser accepts JSON payloads with this structure:

--- a/ui/candidate-portal/src/app/components/profile/view/view-candidate.component.spec.ts
+++ b/ui/candidate-portal/src/app/components/profile/view/view-candidate.component.spec.ts
@@ -29,6 +29,7 @@ import {LinkedinService} from '../../../services/linkedin.service';
 import {CasiPortalService} from '../../../services/casi-portal.service';
 import {LocalStorageService} from '../../../services/local-storage.service';
 import {AuthenticationService} from '../../../services/authentication.service';
+import {environment} from '../../../../environments/environment';
 
 @Pipe({name: 'translate'})
 class TranslatePipeStub implements PipeTransform {
@@ -49,6 +50,7 @@ describe('ViewCandidateComponent', () => {
   let localStorageService: jasmine.SpyObj<LocalStorageService>;
   let location: jasmine.SpyObj<Location>;
   let authenticationService: jasmine.SpyObj<AuthenticationService>;
+  let originalEnvironmentName: string;
 
   const candidate = {
     id: 1,
@@ -61,6 +63,7 @@ describe('ViewCandidateComponent', () => {
   };
 
   beforeEach(async () => {
+    originalEnvironmentName = environment.environmentName;
     authorizationService = jasmine.createSpyObj<AuthorizationService>(
       'AuthorizationService',
       ['canViewChats']
@@ -177,6 +180,10 @@ describe('ViewCandidateComponent', () => {
     fixture.detectChanges();
   });
 
+  afterEach(() => {
+    environment.environmentName = originalEnvironmentName;
+  });
+
   it('should create', () => {
     expect(component).toBeTruthy();
   });
@@ -234,6 +241,88 @@ describe('ViewCandidateComponent', () => {
         expect(showServicesTab).toBeTrue();
         done();
       });
+    });
+  });
+
+  it('should expose Verify+ eligibility for GRN local', (done) => {
+    environment.environmentName = 'local';
+    authenticationService.isGrnInstance.and.returnValue(true);
+    fixture = TestBed.createComponent(ViewCandidateComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+
+    component.verifyPlusEligible$.subscribe(verifyPlusEligible => {
+      expect(verifyPlusEligible).toBeTrue();
+      done();
+    });
+  });
+
+  it('should expose Verify+ eligibility for GRN staging', (done) => {
+    environment.environmentName = 'staging';
+    authenticationService.isGrnInstance.and.returnValue(true);
+    fixture = TestBed.createComponent(ViewCandidateComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+
+    component.verifyPlusEligible$.subscribe(verifyPlusEligible => {
+      expect(verifyPlusEligible).toBeTrue();
+      done();
+    });
+  });
+
+  it('should hide Verify+ eligibility for GRN prod', (done) => {
+    environment.environmentName = 'prod';
+    authenticationService.isGrnInstance.and.returnValue(true);
+    fixture = TestBed.createComponent(ViewCandidateComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+
+    component.verifyPlusEligible$.subscribe(verifyPlusEligible => {
+      expect(verifyPlusEligible).toBeFalse();
+      done();
+    });
+  });
+
+  it('should hide Verify+ eligibility for TBB local', (done) => {
+    environment.environmentName = 'local';
+    authenticationService.isGrnInstance.and.returnValue(false);
+    fixture = TestBed.createComponent(ViewCandidateComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+
+    component.verifyPlusEligible$.subscribe(verifyPlusEligible => {
+      expect(verifyPlusEligible).toBeFalse();
+      done();
+    });
+  });
+
+  it('should show the services tab when Verify+ is the only eligible service in staging GRN', (done) => {
+    environment.environmentName = 'staging';
+    authenticationService.isGrnInstance.and.returnValue(true);
+    linkedinService.isEligible.and.returnValue(of(false));
+    casiPortalService.checkEligibility.and.returnValue(of(false));
+    fixture = TestBed.createComponent(ViewCandidateComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+
+    component.showServicesTab$.subscribe(showServicesTab => {
+      expect(showServicesTab).toBeTrue();
+      done();
+    });
+  });
+
+  it('should hide the services tab when Verify+ is the only GRN service in prod', (done) => {
+    environment.environmentName = 'prod';
+    authenticationService.isGrnInstance.and.returnValue(true);
+    linkedinService.isEligible.and.returnValue(of(false));
+    casiPortalService.checkEligibility.and.returnValue(of(false));
+    fixture = TestBed.createComponent(ViewCandidateComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+
+    component.showServicesTab$.subscribe(showServicesTab => {
+      expect(showServicesTab).toBeFalse();
+      done();
     });
   });
 });

--- a/ui/candidate-portal/src/app/components/profile/view/view-candidate.component.ts
+++ b/ui/candidate-portal/src/app/components/profile/view/view-candidate.component.ts
@@ -36,6 +36,7 @@ import {AuthorizationService} from "../../../services/authorization.service";
 import {CasiPortalService} from "../../../services/casi-portal.service";
 import {environment} from "../../../../environments/environment";
 import {AuthenticationService} from "../../../services/authentication.service";
+import {isVerifyPlusUiEnabled} from "../../../util/verify-plus-ui";
 
 @Component({
   selector: 'app-view-candidate',
@@ -167,7 +168,9 @@ export class ViewCandidateComponent implements OnInit {
       pifi: this.casiPortalService.checkEligibility('PIFI', 'HELP_SITE_LINK'),
       // TODO - SM -when eligibility criteria is determined move this to the server as a
       //  checkEligibility test (for example by enrolled/approved country)
-      verifyPlus: of(this.authenticationService.isGrnInstance())
+      verifyPlus: of(
+        isVerifyPlusUiEnabled(this.authenticationService.isGrnInstance())
+      )
       // Additional async service eligibility calls here
     }).pipe(shareReplay(1)); // Avoid re-triggering on multiple subscriptions
 

--- a/ui/candidate-portal/src/app/components/register/register.component.html
+++ b/ui/candidate-portal/src/app/components/register/register.component.html
@@ -36,8 +36,8 @@
   </div>
 
   <div class="step-progress">
-    <div class="step-progress-bar" *ngFor="let section of registrationService?.sectionProgress; let i = index;"
-         [class.selected]="registrationService?.currentStep?.section === i + 1"></div>
+    <div class="step-progress-bar" *ngFor="let section of registrationService?.sectionProgress"
+         [class.selected]="registrationService?.currentStep?.section === section"></div>
   </div>
 
 

--- a/ui/candidate-portal/src/app/components/register/register.component.html
+++ b/ui/candidate-portal/src/app/components/register/register.component.html
@@ -36,7 +36,7 @@
   </div>
 
   <div class="step-progress">
-    <div class="step-progress-bar" *ngFor="let x of [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]; let i = index;"
+    <div class="step-progress-bar" *ngFor="let section of registrationService?.sectionProgress; let i = index;"
          [class.selected]="registrationService?.currentStep?.section === i + 1"></div>
   </div>
 

--- a/ui/candidate-portal/src/app/components/register/verify-plus/registration-verify-plus.component.spec.ts
+++ b/ui/candidate-portal/src/app/components/register/verify-plus/registration-verify-plus.component.spec.ts
@@ -22,6 +22,7 @@ import {RegistrationVerifyPlusComponent} from './registration-verify-plus.compon
 import {VerifyPlusService} from '../../../services/verify-plus.service';
 import {RegistrationService} from '../../../services/registration.service';
 import {AuthenticationService} from '../../../services/authentication.service';
+import {environment} from '../../../../environments/environment';
 
 @Pipe({name: 'translate'})
 class MockTranslatePipe implements PipeTransform {
@@ -36,8 +37,10 @@ describe('RegistrationVerifyPlusComponent', () => {
   let verifyPlusService: jasmine.SpyObj<VerifyPlusService>;
   let registrationService: jasmine.SpyObj<RegistrationService>;
   let authenticationService: jasmine.SpyObj<AuthenticationService>;
+  let originalEnvironmentName: string;
 
   beforeEach(() => {
+    originalEnvironmentName = environment.environmentName;
     verifyPlusService = jasmine.createSpyObj<VerifyPlusService>('VerifyPlusService', ['submitScan']);
     registrationService = jasmine.createSpyObj<RegistrationService>('RegistrationService', ['next', 'back']);
     authenticationService = jasmine.createSpyObj<AuthenticationService>('AuthenticationService', ['isGrnInstance']);
@@ -58,12 +61,27 @@ describe('RegistrationVerifyPlusComponent', () => {
     fixture.detectChanges();
   });
 
+  afterEach(() => {
+    environment.environmentName = originalEnvironmentName;
+  });
+
   it('should create', () => {
     expect(component).toBeTruthy();
   });
 
   it('should auto-skip step for non-GRN instances', () => {
+    environment.environmentName = 'local';
     authenticationService.isGrnInstance.and.returnValue(false);
+
+    const skippedFixture = TestBed.createComponent(RegistrationVerifyPlusComponent);
+    skippedFixture.detectChanges();
+
+    expect(registrationService.next).toHaveBeenCalled();
+  });
+
+  it('should auto-skip step for GRN prod instances', () => {
+    environment.environmentName = 'prod';
+    authenticationService.isGrnInstance.and.returnValue(true);
 
     const skippedFixture = TestBed.createComponent(RegistrationVerifyPlusComponent);
     skippedFixture.detectChanges();

--- a/ui/candidate-portal/src/app/components/register/verify-plus/registration-verify-plus.component.ts
+++ b/ui/candidate-portal/src/app/components/register/verify-plus/registration-verify-plus.component.ts
@@ -20,6 +20,7 @@ import {VerifyPlusScannerComponent} from '../../common/verify-plus-scanner/verif
 import {VerifyPlusScanResult, VerifyPlusService} from '../../../services/verify-plus.service';
 import {RegistrationService} from '../../../services/registration.service';
 import {AuthenticationService} from '../../../services/authentication.service';
+import {isVerifyPlusUiEnabled} from '../../../util/verify-plus-ui';
 
 /**
  * Component for the Verify Plus registration step.
@@ -48,7 +49,7 @@ export class RegistrationVerifyPlusComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    if (!this.authenticationService.isGrnInstance()) {
+    if (!isVerifyPlusUiEnabled(this.authenticationService.isGrnInstance())) {
       this.registrationService.next();
     }
   }

--- a/ui/candidate-portal/src/app/services/registration.service.spec.ts
+++ b/ui/candidate-portal/src/app/services/registration.service.spec.ts
@@ -15,19 +15,101 @@
  */
 
 import {TestBed} from '@angular/core/testing';
-import {HttpClientTestingModule} from '@angular/common/http/testing';
+import {ActivatedRoute, Router} from '@angular/router';
 import {RouterTestingModule} from '@angular/router/testing';
+import {of} from 'rxjs';
 
 import {RegistrationService} from './registration.service';
+import {AuthenticationService} from './authentication.service';
+import {environment} from '../../environments/environment';
 
 describe('RegistrationService', () => {
-  beforeEach(() => TestBed.configureTestingModule({
-    imports: [HttpClientTestingModule, RouterTestingModule],
-    providers: [RegistrationService]
-  }));
+  let service: RegistrationService;
+  let authenticationService: jasmine.SpyObj<AuthenticationService>;
+  let router: Router;
+  let isAuthenticated = false;
+  let isGrnInstance = false;
+  let originalEnvironmentName: string;
+
+  beforeEach(() => {
+    originalEnvironmentName = environment.environmentName;
+    isAuthenticated = false;
+    isGrnInstance = false;
+    authenticationService = jasmine.createSpyObj<AuthenticationService>(
+      'AuthenticationService',
+      ['isAuthenticated', 'isGrnInstance']
+    );
+    authenticationService.isAuthenticated.and.callFake(() => isAuthenticated);
+    authenticationService.isGrnInstance.and.callFake(() => isGrnInstance);
+
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule],
+      providers: [
+        RegistrationService,
+        {provide: AuthenticationService, useValue: authenticationService},
+        {provide: ActivatedRoute, useValue: {queryParams: of({})}}
+      ]
+    });
+
+    service = TestBed.inject(RegistrationService);
+    router = TestBed.inject(Router);
+    spyOn(router, 'navigate');
+  });
+
+  afterEach(() => {
+    environment.environmentName = originalEnvironmentName;
+  });
 
   it('should be created', () => {
-    const service: RegistrationService = TestBed.inject(RegistrationService);
     expect(service).toBeTruthy();
+  });
+
+  it('should include verifyplus step for unauthenticated local', () => {
+    environment.environmentName = 'local';
+    isAuthenticated = false;
+    isGrnInstance = false;
+    service.start();
+
+    expect(service.steps.some(step => step.key === 'verifyplus')).toBeTrue();
+  });
+
+  it('should include verifyplus step for authenticated GRN staging', () => {
+    environment.environmentName = 'staging';
+    isAuthenticated = true;
+    isGrnInstance = true;
+    service.start();
+
+    expect(service.steps.some(step => step.key === 'verifyplus')).toBeTrue();
+  });
+
+  it('should omit verifyplus step for authenticated TBB local', () => {
+    environment.environmentName = 'local';
+    isAuthenticated = true;
+    isGrnInstance = false;
+    service.start();
+
+    expect(service.steps.some(step => step.key === 'verifyplus')).toBeFalse();
+  });
+
+  it('should omit verifyplus step for authenticated GRN prod', () => {
+    environment.environmentName = 'prod';
+    isAuthenticated = true;
+    isGrnInstance = true;
+    service.start();
+
+    expect(service.steps.some(step => step.key === 'verifyplus')).toBeFalse();
+  });
+
+  it('should skip verifyplus when candidate becomes authenticated TBB during flow', () => {
+    environment.environmentName = 'local';
+    isAuthenticated = false;
+    isGrnInstance = false;
+    service.start();
+    service.openStep('contact');
+
+    isAuthenticated = true;
+    service.next();
+
+    expect(service.currentStepKey).toBe('personal');
   });
 });

--- a/ui/candidate-portal/src/app/services/registration.service.spec.ts
+++ b/ui/candidate-portal/src/app/services/registration.service.spec.ts
@@ -112,4 +112,41 @@ describe('RegistrationService', () => {
 
     expect(service.currentStepKey).toBe('personal');
   });
+
+  it('should keep contiguous section numbers when verifyplus is included', () => {
+    environment.environmentName = 'staging';
+    isAuthenticated = true;
+    isGrnInstance = true;
+    service.start();
+    service.openStep('contact');
+
+    expect(service.currentStep.section).toBe(1);
+    expect(service.totalSections).toBe(11);
+
+    service.openStep('verifyplus');
+    expect(service.currentStep.section).toBe(2);
+
+    service.openStep('personal');
+    expect(service.currentStep.section).toBe(3);
+  });
+
+  it('should compact section numbers when verifyplus is omitted', () => {
+    environment.environmentName = 'local';
+    isAuthenticated = true;
+    isGrnInstance = false;
+    service.start();
+    service.openStep('contact');
+
+    expect(service.currentStep.section).toBe(1);
+    expect(service.totalSections).toBe(10);
+    expect(service.sectionProgress.length).toBe(10);
+
+    service.openStep('personal');
+    expect(service.currentStep.section).toBe(2);
+    expect(service.totalSections).toBe(10);
+
+    const certifications = service.steps.find(step => step.key === 'certifications');
+    const destinations = service.steps.find(step => step.key === 'destinations');
+    expect(certifications?.section).toBe(destinations?.section);
+  });
 });

--- a/ui/candidate-portal/src/app/services/registration.service.ts
+++ b/ui/candidate-portal/src/app/services/registration.service.ts
@@ -106,6 +106,7 @@ export class RegistrationService {
   ];
   public steps: RegistrationStep[] = [];
   public totalSections: number = 0;
+  public sectionProgress: number[] = [];
   public currentStepKey: string;
   public currentStep: RegistrationStep;
   public currentStepIndex: number;
@@ -183,7 +184,11 @@ export class RegistrationService {
   private syncSteps() {
     const previousStepKey = this.currentStepKey;
     this.steps = this.buildSteps();
-    this.totalSections = Math.max(...this.steps.map(s => s.section));
+    this.totalSections = Math.max(0, ...this.steps.map(s => s.section));
+    this.sectionProgress = Array.from(
+      {length: this.totalSections},
+      (_, index) => index + 1
+    );
 
     if (previousStepKey == null) {
       return;
@@ -201,7 +206,7 @@ export class RegistrationService {
   }
 
   private buildSteps(): RegistrationStep[] {
-    return this.allSteps
+    const visibleSteps = this.allSteps
       .filter(step => {
         if (step.key !== RegistrationService.VERIFY_PLUS_STEP_KEY) {
           return true;
@@ -209,6 +214,32 @@ export class RegistrationService {
         return this.shouldIncludeVerifyPlusStep();
       })
       .map(step => ({...step}));
+
+    return this.compactSections(visibleSteps);
+  }
+
+  /**
+   * Renumbers remaining steps so section labels stay contiguous when a step is
+   * omitted. Steps that originally shared a section number keep sharing one.
+   */
+  private compactSections(steps: RegistrationStep[]): RegistrationStep[] {
+    let nextSection = 0;
+    let previousOriginalSection: number | null = null;
+
+    return steps.map(step => {
+      if (step.section === 0) {
+        previousOriginalSection = 0;
+        return {...step, section: 0};
+      }
+
+      if (previousOriginalSection === step.section) {
+        return {...step, section: nextSection};
+      }
+
+      previousOriginalSection = step.section;
+      nextSection += 1;
+      return {...step, section: nextSection};
+    });
   }
 
   private shouldIncludeVerifyPlusStep(): boolean {

--- a/ui/candidate-portal/src/app/services/registration.service.ts
+++ b/ui/candidate-portal/src/app/services/registration.service.ts
@@ -18,15 +18,19 @@ import {Injectable} from '@angular/core';
 import {RegistrationStep} from '../components/register/registration-step';
 import {ActivatedRoute, Router} from '@angular/router';
 import {Subscription} from 'rxjs';
+import {AuthenticationService} from './authentication.service';
+import {isLocalOrStaging, isVerifyPlusUiEnabled} from '../util/verify-plus-ui';
 
 @Injectable({
   providedIn: 'root'
 })
 export class RegistrationService {
 
+  private static readonly VERIFY_PLUS_STEP_KEY = 'verifyplus';
+
   private subscription: Subscription;
 
-  public steps: RegistrationStep[] = [
+  private readonly allSteps: RegistrationStep[] = [
     {
       key: 'account',
       title: 'Welcome to Talent Catalog!',
@@ -100,17 +104,22 @@ export class RegistrationService {
       section: 11
     }
   ];
-  public totalSections: number = Math.max(...this.steps.map(s => s.section));
+  public steps: RegistrationStep[] = [];
+  public totalSections: number = 0;
   public currentStepKey: string;
   public currentStep: RegistrationStep;
   public currentStepIndex: number;
   registering: boolean = false;
 
   constructor(private router: Router,
-              private route: ActivatedRoute) { }
+              private route: ActivatedRoute,
+              private authenticationService: AuthenticationService) {
+    this.syncSteps();
+  }
 
   // Observe the query params in the url to determine which step to display
   start() {
+    this.syncSteps();
     // Set step back to 0 before starting a new registration.
     this.currentStepIndex = 0;
     this.currentStep = this.steps[this.currentStepIndex];
@@ -138,6 +147,7 @@ export class RegistrationService {
   }
 
   openStep(stepKey: string) {
+    this.syncSteps();
     stepKey = stepKey || 'landing';
     this.currentStepIndex = this.steps.findIndex(step => step.key === stepKey);
     this.setStep();
@@ -145,12 +155,14 @@ export class RegistrationService {
 
   back() {
     if (!this.registering) {return;}
+    this.syncSteps();
     this.currentStepIndex--;
     this.setStep();
   }
 
   next() {
     if (!this.registering) {return;}
+    this.syncSteps();
     this.currentStepIndex++;
     this.setStep();
   }
@@ -166,5 +178,48 @@ export class RegistrationService {
 
   routeToStep(key: string) {
     this.router.navigate([], {queryParams: {step: key}, queryParamsHandling: "merge"});
+  }
+
+  private syncSteps() {
+    const previousStepKey = this.currentStepKey;
+    this.steps = this.buildSteps();
+    this.totalSections = Math.max(...this.steps.map(s => s.section));
+
+    if (previousStepKey == null) {
+      return;
+    }
+
+    const nextIndex = this.steps.findIndex(step => step.key === previousStepKey);
+    if (nextIndex >= 0) {
+      this.currentStepIndex = nextIndex;
+      return;
+    }
+
+    if (this.currentStepIndex != null && this.currentStepIndex >= this.steps.length) {
+      this.currentStepIndex = this.steps.length - 1;
+    }
+  }
+
+  private buildSteps(): RegistrationStep[] {
+    return this.allSteps
+      .filter(step => {
+        if (step.key !== RegistrationService.VERIFY_PLUS_STEP_KEY) {
+          return true;
+        }
+        return this.shouldIncludeVerifyPlusStep();
+      })
+      .map(step => ({...step}));
+  }
+
+  private shouldIncludeVerifyPlusStep(): boolean {
+    if (!isLocalOrStaging()) {
+      return false;
+    }
+
+    if (!this.authenticationService.isAuthenticated()) {
+      return true;
+    }
+
+    return isVerifyPlusUiEnabled(this.authenticationService.isGrnInstance());
   }
 }

--- a/ui/candidate-portal/src/app/util/verify-plus-ui.spec.ts
+++ b/ui/candidate-portal/src/app/util/verify-plus-ui.spec.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+import {environment} from '../../environments/environment';
+import {isLocalOrStaging, isVerifyPlusUiEnabled} from './verify-plus-ui';
+
+describe('verify-plus-ui', () => {
+  let originalEnvironmentName: string;
+
+  beforeEach(() => {
+    originalEnvironmentName = environment.environmentName;
+  });
+
+  afterEach(() => {
+    environment.environmentName = originalEnvironmentName;
+  });
+
+  it('should return true from isLocalOrStaging in local', () => {
+    environment.environmentName = 'local';
+    expect(isLocalOrStaging()).toBeTrue();
+  });
+
+  it('should return true from isLocalOrStaging in staging', () => {
+    environment.environmentName = 'staging';
+    expect(isLocalOrStaging()).toBeTrue();
+  });
+
+  it('should return false from isLocalOrStaging in prod', () => {
+    environment.environmentName = 'prod';
+    expect(isLocalOrStaging()).toBeFalse();
+  });
+
+  it('should enable Verify+ UI for GRN local', () => {
+    environment.environmentName = 'local';
+    expect(isVerifyPlusUiEnabled(true)).toBeTrue();
+  });
+
+  it('should enable Verify+ UI for GRN staging', () => {
+    environment.environmentName = 'staging';
+    expect(isVerifyPlusUiEnabled(true)).toBeTrue();
+  });
+
+  it('should disable Verify+ UI for GRN prod', () => {
+    environment.environmentName = 'prod';
+    expect(isVerifyPlusUiEnabled(true)).toBeFalse();
+  });
+
+  it('should disable Verify+ UI for TBB local', () => {
+    environment.environmentName = 'local';
+    expect(isVerifyPlusUiEnabled(false)).toBeFalse();
+  });
+
+  it('should disable Verify+ UI for TBB staging', () => {
+    environment.environmentName = 'staging';
+    expect(isVerifyPlusUiEnabled(false)).toBeFalse();
+  });
+});

--- a/ui/candidate-portal/src/app/util/verify-plus-ui.ts
+++ b/ui/candidate-portal/src/app/util/verify-plus-ui.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026 Talent Catalog.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+import {environment} from '../../environments/environment';
+
+/**
+ * Returns true when the candidate portal runs in a non-production environment
+ * where Verify+ UI should be visible.
+ */
+export function isLocalOrStaging(): boolean {
+  return ['local', 'staging'].includes(environment.environmentName);
+}
+
+/**
+ * Verify+ UI is enabled only for GRN instances in local or staging.
+ * Production and TBB instances should not show Verify+ surfaces.
+ */
+export function isVerifyPlusUiEnabled(isGrnInstance: boolean): boolean {
+  return isGrnInstance && isLocalOrStaging();
+}


### PR DESCRIPTION
This PR Introduces a centralised “Verify+ UI visibility gate” in the candidate portal so Verify+ surfaces are shown only for GRN instances in local/staging, and hidden in prod.

**Changes:**
- Added a shared isVerifyPlusUiEnabled() helper and unit tests for environment/instance gating.
- Updated registration flow, Verify+ registration step, and candidate profile Services eligibility to respect the gating (including compacting registration section numbering when the Verify+ step is omitted).
- Documented the intended Verify+ visibility rules in candidate-portal docs.
